### PR TITLE
[FEAT][C++] Use `#pragma once` to replace `#ifndef` as  include guards

### DIFF
--- a/cpp/benchmarks/benchmark_util.h
+++ b/cpp/benchmarks/benchmark_util.h
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#pragma once
+
 #include <filesystem>
 #include <memory>
 #include <string>
@@ -25,9 +27,6 @@
 
 #include "gar/graph_info.h"
 #include "gar/util/status.h"
-
-#ifndef CPP_BENCHMARKS_BENCHMARK_UTIL_H_
-#define CPP_BENCHMARKS_BENCHMARK_UTIL_H_
 
 namespace graphar {
 
@@ -61,5 +60,3 @@ class BenchmarkFixture : public ::benchmark::Fixture {
   std::shared_ptr<GraphInfo> graph_info_;
 };
 }  // namespace graphar
-
-#endif  // CPP_BENCHMARKS_BENCHMARK_UTIL_H_

--- a/cpp/examples/config.h
+++ b/cpp/examples/config.h
@@ -17,11 +17,10 @@
  * under the License.
  */
 
+#pragma once
+
 #include <filesystem>
 #include <string>
-
-#ifndef CPP_EXAMPLES_CONFIG_H_
-#define CPP_EXAMPLES_CONFIG_H_
 
 // Define a new macro that is just like the standard C assert macro,
 // except that it works even in optimized builds (where NDEBUG is
@@ -65,5 +64,3 @@ static const std::string TEST_DATA_DIR =  // NOLINT
         .parent_path()
         .string() +
     "/testing";
-
-#endif  // CPP_EXAMPLES_CONFIG_H_

--- a/cpp/include/gar/api.h
+++ b/cpp/include/gar/api.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_API_H_
-#define GAR_API_H_
+#pragma once
 
 #include "gar/graph_info.h"
 #include "gar/util/adj_list_type.h"
@@ -32,5 +31,3 @@
 #include "gar/util/util.h"
 #include "gar/util/version_parser.h"
 #include "gar/util/yaml.h"
-
-#endif  // GAR_API_H_

--- a/cpp/include/gar/fwd.h
+++ b/cpp/include/gar/fwd.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_FWD_H_
-#define GAR_FWD_H_
+#pragma once
 
 #include <memory>
 #include <optional>
@@ -211,5 +210,3 @@ using ColumnNames =
 }  // namespace util
 
 }  // namespace graphar
-
-#endif  // GAR_FWD_H_

--- a/cpp/include/gar/graph.h
+++ b/cpp/include/gar/graph.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_GRAPH_H_
-#define GAR_GRAPH_H_
+#pragma once
 
 #include <any>
 #include <limits>
@@ -1094,5 +1093,3 @@ class UBDEdgesCollection : public EdgesCollection {
   }
 };
 }  // namespace graphar
-
-#endif  // GAR_GRAPH_H_

--- a/cpp/include/gar/graph_info.h
+++ b/cpp/include/gar/graph_info.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_GRAPH_INFO_H_
-#define GAR_GRAPH_INFO_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -875,4 +874,3 @@ class GraphInfo {
 };
 
 }  // namespace graphar
-#endif  // GAR_GRAPH_INFO_H_

--- a/cpp/include/gar/reader/arrow_chunk_reader.h
+++ b/cpp/include/gar/reader/arrow_chunk_reader.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_READER_ARROW_CHUNK_READER_H_
-#define GAR_READER_ARROW_CHUNK_READER_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -508,4 +507,3 @@ class AdjListPropertyArrowChunkReader {
   std::shared_ptr<FileSystem> fs_;
 };
 }  // namespace graphar
-#endif  // GAR_READER_ARROW_CHUNK_READER_H_

--- a/cpp/include/gar/reader/chunk_info_reader.h
+++ b/cpp/include/gar/reader/chunk_info_reader.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_READER_CHUNK_INFO_READER_H_
-#define GAR_READER_CHUNK_INFO_READER_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -387,4 +386,3 @@ class AdjListPropertyChunkInfoReader {
   std::shared_ptr<FileSystem> fs_;
 };
 }  // namespace graphar
-#endif  // GAR_READER_CHUNK_INFO_READER_H_

--- a/cpp/include/gar/util/adj_list_type.h
+++ b/cpp/include/gar/util/adj_list_type.h
@@ -17,14 +17,13 @@
  * under the License.
  */
 
+#pragma once
+
 #include <map>
 #include <string>
 #include <utility>
 
 #include "gar/util/macros.h"
-
-#ifndef GAR_UTIL_ADJ_LIST_TYPE_H_
-#define GAR_UTIL_ADJ_LIST_TYPE_H_
 
 namespace graphar {
 
@@ -90,4 +89,3 @@ static inline std::pair<bool, std::string> AdjListTypeToOrderedAligned(
 }
 
 }  // namespace graphar
-#endif  // GAR_UTIL_ADJ_LIST_TYPE_H_

--- a/cpp/include/gar/util/convert_to_arrow_type.h
+++ b/cpp/include/gar/util/convert_to_arrow_type.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_UTIL_CONVERT_TO_ARROW_TYPE_H_
-#define GAR_UTIL_CONVERT_TO_ARROW_TYPE_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -79,5 +78,3 @@ CONVERT_TO_ARROW_TYPE(Type::DATE, Date, arrow::Date32Type, arrow::Date32Array,
                       arrow::Date32Builder, arrow::date32(), "date")
 
 }  // namespace graphar
-
-#endif  // GAR_UTIL_CONVERT_TO_ARROW_TYPE_H_

--- a/cpp/include/gar/util/data_type.h
+++ b/cpp/include/gar/util/data_type.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_UTIL_DATA_TYPE_H_
-#define GAR_UTIL_DATA_TYPE_H_
+#pragma once
 
 #include <map>
 #include <memory>
@@ -160,5 +159,3 @@ class Date {
 };
 
 }  // namespace graphar
-
-#endif  // GAR_UTIL_DATA_TYPE_H_

--- a/cpp/include/gar/util/expression.h
+++ b/cpp/include/gar/util/expression.h
@@ -17,15 +17,14 @@
  * under the License.
  */
 
+#pragma once
+
 #include <memory>
 #include <string>
 
 #include "arrow/compute/api.h"
 
 #include "gar/graph_info.h"
-
-#ifndef GAR_UTIL_EXPRESSION_H_
-#define GAR_UTIL_EXPRESSION_H_
 
 namespace graphar {
 
@@ -357,4 +356,3 @@ template <typename T,
   return std::make_shared<ExpressionOr>(lhs, rhs);
 }
 }  // namespace graphar
-#endif  // GAR_UTIL_EXPRESSION_H_

--- a/cpp/include/gar/util/file_type.h
+++ b/cpp/include/gar/util/file_type.h
@@ -17,15 +17,14 @@
  * under the License.
  */
 
+#pragma once
+
 #include <map>
 #include <stdexcept>
 #include <string>
 
 #include "gar/fwd.h"
 #include "gar/util/macros.h"
-
-#ifndef GAR_UTIL_FILE_TYPE_H_
-#define GAR_UTIL_FILE_TYPE_H_
 
 namespace graphar {
 
@@ -50,4 +49,3 @@ static inline const char* FileTypeToString(FileType file_type) {
 }
 
 }  // namespace graphar
-#endif  // GAR_UTIL_FILE_TYPE_H_

--- a/cpp/include/gar/util/filesystem.h
+++ b/cpp/include/gar/util/filesystem.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_UTIL_FILESYSTEM_H_
-#define GAR_UTIL_FILESYSTEM_H_
+#pragma once
 
 #include <memory>
 #include <optional>
@@ -152,4 +151,3 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriOrPath(
     const std::string& uri, std::string* out_path = nullptr);
 
 }  // namespace graphar
-#endif  // GAR_UTIL_FILESYSTEM_H_

--- a/cpp/include/gar/util/general_params.h
+++ b/cpp/include/gar/util/general_params.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_UTIL_GENERAL_PARAMS_H_
-#define GAR_UTIL_GENERAL_PARAMS_H_
+#pragma once
 
 namespace graphar {
 
@@ -31,5 +30,3 @@ struct GeneralParams {
 };
 
 }  // namespace graphar
-
-#endif  // GAR_UTIL_GENERAL_PARAMS_H_

--- a/cpp/include/gar/util/macros.h
+++ b/cpp/include/gar/util/macros.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_UTIL_MACROS_H_
-#define GAR_UTIL_MACROS_H_
+#pragma once
 
 #include <cstdint>
 
@@ -44,5 +43,3 @@
 #define GAR_PREDICT_FALSE(x) (x)
 #define GAR_PREDICT_TRUE(x) (x)
 #endif
-
-#endif  // GAR_UTIL_MACROS_H_

--- a/cpp/include/gar/util/reader_util.h
+++ b/cpp/include/gar/util/reader_util.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_UTIL_READER_UTIL_H_
-#define GAR_UTIL_READER_UTIL_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -77,4 +76,3 @@ Result<IdType> GetEdgeNum(const std::string& prefix,
 
 }  // namespace util
 }  // namespace graphar
-#endif  // GAR_UTIL_READER_UTIL_H_

--- a/cpp/include/gar/util/result.h
+++ b/cpp/include/gar/util/result.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_UTIL_RESULT_H_
-#define GAR_UTIL_RESULT_H_
+#pragma once
 
 #include <utility>
 
@@ -121,4 +120,3 @@ inline Status GenericToStatus(Result<T>&& res) {
 }  // namespace internal
 
 }  // namespace graphar
-#endif  // GAR_UTIL_RESULT_H_

--- a/cpp/include/gar/util/status.h
+++ b/cpp/include/gar/util/status.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_UTIL_STATUS_H_
-#define GAR_UTIL_STATUS_H_
+#pragma once
 
 #include <sstream>
 #include <string>
@@ -280,5 +279,3 @@ inline Status GenericToStatus(Status&& st) { return std::move(st); }
 }  // namespace internal
 
 }  // namespace graphar
-
-#endif  // GAR_UTIL_STATUS_H_

--- a/cpp/include/gar/util/util.h
+++ b/cpp/include/gar/util/util.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_UTIL_UTIL_H_
-#define GAR_UTIL_UTIL_H_
+#pragma once
 
 #include <memory>
 #include <numeric>
@@ -252,4 +251,3 @@ using DoubleArray = Array<double>;
 using StringArray = Array<std::string_view>;
 
 }  // namespace graphar
-#endif  // GAR_UTIL_UTIL_H_

--- a/cpp/include/gar/util/version_parser.h
+++ b/cpp/include/gar/util/version_parser.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_UTIL_VERSION_PARSER_H_
-#define GAR_UTIL_VERSION_PARSER_H_
+#pragma once
 
 #include <map>
 #include <memory>
@@ -111,4 +110,3 @@ class InfoVersion {
 };
 
 }  // namespace graphar
-#endif  // GAR_UTIL_VERSION_PARSER_H_

--- a/cpp/include/gar/util/writer_util.h
+++ b/cpp/include/gar/util/writer_util.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_UTIL_WRITER_UTIL_H_
-#define GAR_UTIL_WRITER_UTIL_H_
+#pragma once
 
 #include "gar/util/macros.h"
 
@@ -42,4 +41,3 @@ enum class ValidateLevel : char {
 };
 
 }  // namespace graphar
-#endif  // GAR_UTIL_WRITER_UTIL_H_

--- a/cpp/include/gar/util/yaml.h
+++ b/cpp/include/gar/util/yaml.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_UTIL_YAML_H_
-#define GAR_UTIL_YAML_H_
+#pragma once
 
 #include <iosfwd>
 #include <memory>
@@ -69,4 +68,3 @@ class Yaml {
 };
 
 }  // namespace graphar
-#endif  // GAR_UTIL_YAML_H_

--- a/cpp/include/gar/writer/arrow_chunk_writer.h
+++ b/cpp/include/gar/writer/arrow_chunk_writer.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_WRITER_ARROW_CHUNK_WRITER_H_
-#define GAR_WRITER_ARROW_CHUNK_WRITER_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -733,4 +732,3 @@ class EdgeChunkWriter {
 };
 
 }  // namespace graphar
-#endif  // GAR_WRITER_ARROW_CHUNK_WRITER_H_

--- a/cpp/include/gar/writer/edges_builder.h
+++ b/cpp/include/gar/writer/edges_builder.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_WRITER_EDGES_BUILDER_H_
-#define GAR_WRITER_EDGES_BUILDER_H_
+#pragma once
 
 #include <algorithm>
 #include <any>
@@ -429,4 +428,3 @@ class EdgesBuilder {
 
 }  // namespace builder
 }  // namespace graphar
-#endif  // GAR_WRITER_EDGES_BUILDER_H_

--- a/cpp/include/gar/writer/vertices_builder.h
+++ b/cpp/include/gar/writer/vertices_builder.h
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-#ifndef GAR_WRITER_VERTICES_BUILDER_H_
-#define GAR_WRITER_VERTICES_BUILDER_H_
+#pragma once
 
 #include <any>
 #include <memory>
@@ -350,4 +349,3 @@ class VerticesBuilder {
 
 }  // namespace builder
 }  // namespace graphar
-#endif  // GAR_WRITER_VERTICES_BUILDER_H_

--- a/cpp/test/util.h
+++ b/cpp/test/util.h
@@ -17,13 +17,12 @@
  * under the License.
  */
 
+#pragma once
+
 #include <filesystem>
 #include <string>
 
 #include "gar/util/status.h"
-
-#ifndef CPP_TEST_UTIL_H_
-#define CPP_TEST_UTIL_H_
 
 namespace graphar {
 
@@ -40,5 +39,3 @@ Status GetTestResourceRoot(std::string* out) {
 }
 
 }  // namespace graphar
-
-#endif  // CPP_TEST_UTIL_H_


### PR DESCRIPTION
## Proposed changes
This change use `#pragma once` to replace `#ifndef` as  include guards

## Further comments
Fixs #454 
