### PR TITLE
[BugFix][C++] Cast to correct schema when get chunk with property reader

### DIFF
--- a/cpp/include/gar/reader/arrow_chunk_reader.h
+++ b/cpp/include/gar/reader/arrow_chunk_reader.h
@@ -31,6 +31,7 @@
 // forward declaration
 namespace arrow {
 class Array;
+class Schema;
 class Table;
 }  // namespace arrow
 
@@ -146,6 +147,7 @@ class VertexPropertyArrowChunkReader {
   IdType seek_id_;
   IdType chunk_num_;
   IdType vertex_num_;
+  std::shared_ptr<arrow::Schema> schema_;
   std::shared_ptr<arrow::Table> chunk_table_;
   util::FilterOptions filter_options_;
   std::shared_ptr<FileSystem> fs_;
@@ -501,6 +503,7 @@ class AdjListPropertyArrowChunkReader {
   std::string prefix_;
   IdType vertex_chunk_index_, chunk_index_;
   IdType seek_offset_;
+  std::shared_ptr<arrow::Schema> schema_;
   std::shared_ptr<arrow::Table> chunk_table_;
   util::FilterOptions filter_options_;
   IdType vertex_chunk_num_, chunk_num_;

--- a/cpp/src/filesystem.cc
+++ b/cpp/src/filesystem.cc
@@ -283,7 +283,9 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriOrPath(
         auto arrow_fs,
         arrow::fs::FileSystemFromUriOrPath(uri_string, out_path));
     // arrow would delete the last slash, so use uri string
-    *out_path = uri_string;
+    if (out_path != nullptr) {
+      *out_path = uri_string;
+    }
     return std::make_shared<FileSystem>(arrow_fs);
   }
 

--- a/cpp/test/test_arrow_chunk_reader.cc
+++ b/cpp/test/test_arrow_chunk_reader.cc
@@ -18,13 +18,16 @@
  */
 
 #include <cstdlib>
+#include <iostream>
 
 #include "arrow/api.h"
 
 #include "./util.h"
 #include "gar/reader/arrow_chunk_reader.h"
 #include "gar/util/adj_list_type.h"
+#include "gar/util/data_type.h"
 #include "gar/util/expression.h"
+#include "gar/util/filesystem.h"
 #include "gar/util/general_params.h"
 
 #define CATCH_CONFIG_MAIN
@@ -94,6 +97,40 @@ TEST_CASE("ArrowChunkReader") {
       REQUIRE(reader->next_chunk().IsIndexError());
 
       REQUIRE(reader->seek(1024).IsIndexError());
+    }
+
+    SECTION("CastDataType") {
+      std::string prefix = root + "/modern_graph/";
+      std::string vertex_info_path = prefix + "person.vertex.yml";
+      std::cout << "Vertex info path: " << vertex_info_path << std::endl;
+      auto fs = FileSystemFromUriOrPath(prefix).value();
+      auto yaml_content =
+          fs->ReadFileToValue<std::string>(vertex_info_path).value();
+      std::cout << yaml_content << std::endl;
+      auto maybe_vertex_info = VertexInfo::Load(yaml_content);
+      REQUIRE(maybe_vertex_info.status().ok());
+      auto vertex_info = maybe_vertex_info.value();
+      std::cout << vertex_info->Dump().value() << std::endl;
+      auto pg = vertex_info->GetPropertyGroup("id");
+      REQUIRE(pg != nullptr);
+      REQUIRE(pg->GetProperties().size() == 1);
+      auto origin_property = pg->GetProperties()[0];
+      REQUIRE(origin_property.type->Equals(int64()));
+
+      // change to int32_t
+      Property new_property("id", int32(), origin_property.is_primary,
+                            origin_property.is_nullable);
+      auto new_pg = CreatePropertyGroup({new_property}, pg->GetFileType(),
+                                        pg->GetPrefix());
+      auto maybe_reader =
+          VertexPropertyArrowChunkReader::Make(vertex_info, new_pg, prefix);
+      REQUIRE(maybe_reader.status().ok());
+      auto reader = maybe_reader.value();
+      auto result = reader->GetChunk();
+      REQUIRE(!result.has_error());
+      auto table = result.value();
+      REQUIRE(table->schema()->GetFieldByName("id")->type()->id() ==
+              arrow::Type::INT32);
     }
 
     SECTION("PropertyPushDown") {

--- a/cpp/test/test_arrow_chunk_reader.cc
+++ b/cpp/test/test_arrow_chunk_reader.cc
@@ -18,7 +18,6 @@
  */
 
 #include <cstdlib>
-#include <iostream>
 
 #include "arrow/api.h"
 


### PR DESCRIPTION
## Proposed changes
as issue #219 describe, the chunk table get from arrow chunk reader may not has the same type with schema.
This change help to fix the problem by cast the chunk table to what they should be(schema), if cast failed, raise error.


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/apache/incubator-graphar/blob/main/CONTRIBUTING.rst) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
fixes #219 
