### PR TITLE
[POC]feat(format): Add format  protocol definitions files with google protocol buffers

### DIFF
--- a/format/adjacent_list.proto
+++ b/format/adjacent_list.proto
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 syntax = "proto3";
 
 package graphar;

--- a/format/adjacent_list.proto
+++ b/format/adjacent_list.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package graphar;
+option java_package = "org.apache.graphar.info";
+
+import "types.proto";
+
+message AdjacentList {
+    AdjListType type = 1;
+    FileType file_type = 2;
+    string prefix = 3;
+
+    message Statistics {
+        int64 num_vertices = 1; 
+        int64 num_vertex_chunks = 2;
+        repeated int64 edge_nums_of_vertex_chunks = 3;
+    }
+    optional Statistics statistics = 4;
+};

--- a/format/edge_info.proto
+++ b/format/edge_info.proto
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 syntax = "proto3";
 
 package graphar;

--- a/format/edge_info.proto
+++ b/format/edge_info.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package graphar;
+option java_package = "org.apache.graphar.info";
+
+import "property_group.proto";
+import "adjacent_list.proto";
+
+message EdgeInfo {
+    string type = 1;
+    string source_vertex_type = 2;
+    string destination_vertex_type = 3;
+    int64 chunk_size = 4;
+    int64 source_vertex_chunk_size = 5;
+    int64 destination_vertex_chunk_size = 6;
+    repeated AdjacentList adjacent_list = 7;
+    repeated PropertyGroup properties = 8;
+    bool is_directed = 9;
+    string prefix = 10;
+
+    message Statistics {
+        int64 num_edges = 1;
+        int64 num_source_vertices = 2;
+        int64 num_destination_vertices = 3;
+    }
+    optional Statistics statistics = 11;
+};

--- a/format/graph_info.proto
+++ b/format/graph_info.proto
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 syntax = "proto3";
 
 package graphar;

--- a/format/graph_info.proto
+++ b/format/graph_info.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package graphar;
+option java_package = "org.apache.graphar.info";
+
+import "vertex_info.proto";
+import "edge_info.proto";
+
+message GraphInfo {
+    string name = 1;
+    repeated VertexInfo vertices = 2;
+    repeated EdgeInfo edges = 3;
+    string prefix = 4;
+
+    message Statistics {
+        int64 num_vertices = 1;
+        int64 num_edges = 2;
+    }
+    optional Statistics statistics = 5;
+
+    message KeyValue {
+        string key = 1;
+        string value = 2;
+    } 
+    map<string, string> metadata = 6;
+};

--- a/format/property_group.proto
+++ b/format/property_group.proto
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 syntax = "proto3";
 
 package graphar;

--- a/format/property_group.proto
+++ b/format/property_group.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package graphar;
+option java_package = "org.apache.graphar.info";
+
+import "types.proto";
+
+message Property {
+    string name = 1;
+    DataType type = 2;
+    bool is_primary_key = 3;
+    bool nullable = 4;
+    string prefix = 5;
+};
+
+message PropertyGroup {
+    repeated Property properties = 1;
+    FileType file_type = 2;
+    string prefix = 3;
+};

--- a/format/test_vertex_info.cc
+++ b/format/test_vertex_info.cc
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 #include <google/protobuf/util/json_util.h>
 #include <iostream>
 #include "vertex_info.pb.h"

--- a/format/test_vertex_info.cc
+++ b/format/test_vertex_info.cc
@@ -1,0 +1,38 @@
+#include <google/protobuf/util/json_util.h>
+#include <iostream>
+#include "vertex_info.pb.h"
+
+using google::protobuf::util::JsonStringToMessage;
+
+bool proto_to_json(const google::protobuf::Message& message, std::string& json) {
+    google::protobuf::util::JsonPrintOptions options;
+    options.add_whitespace = true;
+    options.always_print_primitive_fields = true;
+    options.preserve_proto_field_names = true;
+    return MessageToJsonString(message, &json, options).ok();
+}
+
+bool json_to_proto(const std::string& json, google::protobuf::Message& message) {
+    return JsonStringToMessage(json, &message).ok();
+}
+
+int main() {
+    graphar::VertexInfo vertex;
+    vertex.set_type("person");
+    vertex.set_chunk_size(100);
+    vertex.set_prefix("./person");
+
+    std::string json_string;
+   /* protobuf to json。 */
+    if (!proto_to_json(vertex, json_string)) {
+        std::cout << "protobuf convert json failed!" << std::endl;
+        return 1;
+    }
+    std::cout << "protobuf convert json done!" << std::endl
+              << json_string << std::endl;
+
+    vertex.Clear();
+    std::cout << "-----" << std::endl;
+
+    return 0;
+}

--- a/format/types.proto
+++ b/format/types.proto
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 syntax = "proto3";
 
 package graphar;

--- a/format/types.proto
+++ b/format/types.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+package graphar;
+option java_package = "org.apache.graphar.info";
+
+enum DataType {
+    BOOL = 0;
+    INT32 = 1;
+    INT64 = 2;
+    FLOAT = 3;
+    DOUBLE = 4;
+    STRING = 5;
+    LIST = 6;
+    DATE = 7;
+    TIMESTAMP = 8;
+    TIME = 9;
+};
+
+enum FileType {
+    CSV = 0;
+    PARQUET = 1;
+    ORC = 2;
+    JSON = 3;
+    AVRO = 4;
+    HDF5 = 5;
+};
+
+enum AdjListType {
+    UNORDERED_BY_SOURCE = 0;
+    UNORDERED_BY_TARGET = 1;
+    ORDERED_BY_SOURCE = 2;
+    ORDERED_BY_TARGET = 3;
+};

--- a/format/vertex_info.proto
+++ b/format/vertex_info.proto
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 syntax = "proto3";
 
 package graphar;

--- a/format/vertex_info.proto
+++ b/format/vertex_info.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package graphar;
+option java_package = "org.apache.graphar.info";
+
+import "property_group.proto";
+
+message VertexInfo {
+    string type = 1;
+    int64 chunk_size = 2;
+    repeated PropertyGroup properties = 3;
+    string prefix = 4;
+
+    message Statistics {
+        int64 num_vertices = 5;
+        int64 num_chunks = 6; 
+    }
+    optional Statistics statistics = 7;
+};


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
as issue #73 describes, currently the C++ library, Java, and scala library implement the format independently and they may have some miss-match between the implementation. It's better to standardize the format with protobuf and the libraries rely on the definition.

The standardized format definition would bring much benefits:
- More clear definition to the C++/Java code
- Make the format cross-language compatibility
- It would  not only carry the schema of graph, but also contain the optional metadata like vertex num/edge num, the chunk statistics. ( which we serialize to files directly)
- It can be evolve without change the library code immediately
- [arrow](https://github.com/apache/arrow/blob/main/format/Schema.fbs) and [parquet](https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift) are define their format with IDL too.

But the changes may break the breaking changes to current public APIs if we adapt the implementation to the format protocol.

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

-  Add format  protocol definitions files with google protocol buffers
- README about the format  protocol definitions

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
not yet

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->
not yet

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
