### PR TITLE
feat(java): Set parent pom to apache

### DIFF
--- a/maven-projects/pom.xml
+++ b/maven-projects/pom.xml
@@ -22,20 +22,58 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache</groupId>
+        <artifactId>apache</artifactId>
+        <version>31</version>
+    </parent>
+    <groupId>org.apache.graphar</groupId>
+    <artifactId>graphar-root</artifactId>
+    <version>${graphar.version}</version>
+    <packaging>pom</packaging>
 
-  <groupId>org.apache.graphar</groupId>
-  <artifactId>graphar-root</artifactId>
-  <version>${graphar.version}</version>
-  <packaging>pom</packaging>
+    <name>Apache GraphAr Root POM</name>
+    <description>Apache GraphAr(Incubating) is an open source, standard data file format for graph data storage and retrieval.</description>
+    <url>https://graphar.apache.org/</url>
 
-  <name>Apache GraphAr Root POM</name>
-  <modules>
-    <module>java</module>
-    <module>spark</module>
-    <module>info</module>
-  </modules>
-
-  <properties>
-    <graphar.version>0.1.0-SNAPSHOT</graphar.version>
-  </properties>
+    <mailingLists>
+        <mailingList>
+            <name>Developer List</name>
+            <subscribe>dev-subscribe@graphar.apache.org</subscribe>
+            <unsubscribe>dev-unsubscribe@graphar.apache.org</unsubscribe>
+            <post>dev@graphar.apache.org</post>
+            <archive>https://lists.apache.org/list.html?dev@graphar.apache.org</archive>
+        </mailingList>
+        <mailingList>
+            <name>Commits List</name>
+            <subscribe>commits-subscribe@graphar.apache.org</subscribe>
+            <unsubscribe>commits-unsubscribe@graphar.apache.org</unsubscribe>
+            <post>commits@graphar.apache.org</post>
+            <archive>https://lists.apache.org/list.html?commits@graphar.apache.org</archive>
+        </mailingList>
+    </mailingLists>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+<!--    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/apache/graphar/issues</url>
+    </issueManagement>
+    <scm>
+        <connection>scm:git:https://github.com/apache/graphar.git</connection>
+        <developerConnection>scm:git:https://github.com/apache/graphar.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/apache/graphar</url>
+    </scm>-->
+    <properties>
+        <graphar.version>0.1.0-SNAPSHOT</graphar.version>
+    </properties>
+    <modules>
+        <module>java</module>
+        <module>spark</module>
+        <module>info</module>
+    </modules>
 </project>


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR

https://maven.apache.org/pom/asf/
Apache Software Foundation Parent POM
contains settings that are likely to be useful to any Apache project that is building and releasing code with Maven. By using this project as a parent, a project gets these settings.
**If we have specific version requirements for certain plugins, we need to explicitly declare the corresponding versions in the project. Otherwise, it will default to the version specified in the parent POM.**
### What changes are included in this PR?
- Add mailing list and License etc


