### PR TITLE
feat(c++): get testing data dir with filesystem relative path in unit tests

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -59,7 +59,6 @@ Release build:
 Debug build with unit tests:
 
 ```bash
-    $ export GAR_TEST_DATA=$PWD/../testing/
     $ mkdir build-debug
     $ cd build-debug
     $ cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON ..

--- a/cpp/test/test_arrow_chunk_reader.cc
+++ b/cpp/test/test_arrow_chunk_reader.cc
@@ -35,11 +35,9 @@
 namespace graphar {
 
 TEST_CASE("ArrowChunkReader") {
-  std::string root;
-  REQUIRE(GetTestResourceRoot(&root).ok());
-
   // read file and construct graph info
-  std::string path = root + "/ldbc_sample/parquet/ldbc_sample.graph.yml";
+  std::string path =
+      TEST_DATA_DIR + "/ldbc_sample/parquet/ldbc_sample.graph.yml";
   std::string src_label = "person", edge_label = "knows", dst_label = "person";
   std::string vertex_property_name = "id";
   std::string edge_property_name = "creationDate";
@@ -99,7 +97,7 @@ TEST_CASE("ArrowChunkReader") {
     }
 
     SECTION("CastDataType") {
-      std::string prefix = root + "/modern_graph/";
+      std::string prefix = TEST_DATA_DIR + "/modern_graph/";
       std::string vertex_info_path = prefix + "person.vertex.yml";
       std::cout << "Vertex info path: " << vertex_info_path << std::endl;
       auto fs = FileSystemFromUriOrPath(prefix).value();

--- a/cpp/test/test_arrow_chunk_writer.cc
+++ b/cpp/test/test_arrow_chunk_writer.cc
@@ -45,11 +45,7 @@
 namespace graphar {
 
 TEST_CASE("test_vertex_property_writer_from_file") {
-  std::string root;
-  REQUIRE(GetTestResourceRoot(&root).ok());
-
-  REQUIRE(!root.empty());
-  std::string path = root + "/ldbc_sample/person_0_0.csv";
+  std::string path = TEST_DATA_DIR + "/ldbc_sample/person_0_0.csv";
   arrow::io::IOContext io_context = arrow::io::default_io_context();
 
   auto fs = arrow::fs::FileSystemFromUriOrPath(path).ValueOrDie();
@@ -75,7 +71,7 @@ TEST_CASE("test_vertex_property_writer_from_file") {
 
   // Construct the writer
   std::string vertex_meta_file =
-      root + "/ldbc_sample/parquet/" + "person.vertex.yml";
+      TEST_DATA_DIR + "/ldbc_sample/parquet/" + "person.vertex.yml";
   auto vertex_meta = Yaml::LoadFile(vertex_meta_file).value();
   auto vertex_info = VertexInfo::Load(vertex_meta).value();
   auto maybe_writer = VertexPropertyWriter::Make(vertex_info, "/tmp/");
@@ -123,14 +119,11 @@ TEST_CASE("test_vertex_property_writer_from_file") {
 }
 
 TEST_CASE("test_orc_and_parquet_reader") {
-  std::string root;
-  REQUIRE(GetTestResourceRoot(&root).ok());
-
   arrow::Status st;
   arrow::MemoryPool* pool = arrow::default_memory_pool();
-  std::string path1 = root + "/ldbc_sample/orc" +
+  std::string path1 = TEST_DATA_DIR + "/ldbc_sample/orc" +
                       "/vertex/person/firstName_lastName_gender/chunk1";
-  std::string path2 = root + "/ldbc_sample/parquet" +
+  std::string path2 = TEST_DATA_DIR + "/ldbc_sample/parquet" +
                       "/vertex/person/firstName_lastName_gender/chunk1";
   arrow::io::IOContext io_context = arrow::io::default_io_context();
 
@@ -165,12 +158,9 @@ TEST_CASE("test_orc_and_parquet_reader") {
 }
 
 TEST_CASE("test_edge_chunk_writer") {
-  std::string root;
-  REQUIRE(GetTestResourceRoot(&root).ok());
-
   arrow::Status st;
   arrow::MemoryPool* pool = arrow::default_memory_pool();
-  std::string path = root +
+  std::string path = TEST_DATA_DIR +
                      "/ldbc_sample/parquet/edge/person_knows_person/"
                      "unordered_by_source/adj_list/part0/chunk0";
   auto fs = arrow::fs::FileSystemFromUriOrPath(path).ValueOrDie();
@@ -193,7 +183,7 @@ TEST_CASE("test_edge_chunk_writer") {
 
   // Construct the writer
   std::string edge_meta_file =
-      root + "/ldbc_sample/csv/" + "person_knows_person.edge.yml";
+      TEST_DATA_DIR + "/ldbc_sample/csv/" + "person_knows_person.edge.yml";
   auto edge_meta = Yaml::LoadFile(edge_meta_file).value();
   auto edge_info = EdgeInfo::Load(edge_meta).value();
   auto adj_list_type = AdjListType::ordered_by_source;

--- a/cpp/test/test_builder.cc
+++ b/cpp/test/test_builder.cc
@@ -45,12 +45,10 @@
 namespace graphar {
 TEST_CASE("test_vertices_builder") {
   std::cout << "Test vertex builder" << std::endl;
-  std::string root;
-  REQUIRE(GetTestResourceRoot(&root).ok());
 
   // construct vertex builder
   std::string vertex_meta_file =
-      root + "/ldbc_sample/parquet/" + "person.vertex.yml";
+      TEST_DATA_DIR + "/ldbc_sample/parquet/" + "person.vertex.yml";
   auto vertex_meta = Yaml::LoadFile(vertex_meta_file).value();
   auto vertex_info = VertexInfo::Load(vertex_meta).value();
   IdType start_index = 0;
@@ -82,7 +80,7 @@ TEST_CASE("test_vertices_builder") {
   REQUIRE(builder->GetNum() == 0);
 
   // add vertices
-  std::ifstream fp(root + "/ldbc_sample/person_0_0.csv");
+  std::ifstream fp(TEST_DATA_DIR + "/ldbc_sample/person_0_0.csv");
   std::string line;
   getline(fp, line);
   int m = 4;
@@ -124,7 +122,7 @@ TEST_CASE("test_vertices_builder") {
   REQUIRE(builder->AddVertex(v).IsInvalid());
 
   // check the number of vertices dumped
-  auto fs = arrow::fs::FileSystemFromUriOrPath(root).ValueOrDie();
+  auto fs = arrow::fs::FileSystemFromUriOrPath(TEST_DATA_DIR).ValueOrDie();
   auto input =
       fs->OpenInputStream("/tmp/vertex/person/vertex_count").ValueOrDie();
   auto num = input->Read(sizeof(IdType)).ValueOrDie();
@@ -134,12 +132,9 @@ TEST_CASE("test_vertices_builder") {
 
 TEST_CASE("test_edges_builder") {
   std::cout << "Test edge builder" << std::endl;
-  std::string root;
-  REQUIRE(GetTestResourceRoot(&root).ok());
-
   // construct edge builder
   std::string edge_meta_file =
-      root + "/ldbc_sample/parquet/" + "person_knows_person.edge.yml";
+      TEST_DATA_DIR + "/ldbc_sample/parquet/" + "person_knows_person.edge.yml";
   auto edge_meta = Yaml::LoadFile(edge_meta_file).value();
   auto edge_info = EdgeInfo::Load(edge_meta).value();
   auto vertices_num = 903;
@@ -167,7 +162,7 @@ TEST_CASE("test_edges_builder") {
   REQUIRE(builder->GetNum() == 0);
 
   // add edges
-  std::ifstream fp(root + "/ldbc_sample/person_knows_person_0_0.csv");
+  std::ifstream fp(TEST_DATA_DIR + "/ldbc_sample/person_knows_person_0_0.csv");
   std::string line;
   getline(fp, line);
   std::vector<std::string> names;
@@ -208,7 +203,7 @@ TEST_CASE("test_edges_builder") {
   REQUIRE(builder->AddEdge(e).IsInvalid());
 
   // check the number of vertices dumped
-  auto fs = arrow::fs::FileSystemFromUriOrPath(root).ValueOrDie();
+  auto fs = arrow::fs::FileSystemFromUriOrPath(TEST_DATA_DIR).ValueOrDie();
   auto input =
       fs->OpenInputStream(
             "/tmp/edge/person_knows_person/ordered_by_dest/vertex_count")

--- a/cpp/test/test_chunk_info_reader.cc
+++ b/cpp/test/test_chunk_info_reader.cc
@@ -30,11 +30,9 @@
 namespace graphar {
 
 TEST_CASE("ChunkInfoReader") {
-  std::string root;
-  REQUIRE(GetTestResourceRoot(&root).ok());
-
   // read file and construct graph info
-  std::string path = root + "/ldbc_sample/parquet/ldbc_sample.graph.yml";
+  std::string path =
+      TEST_DATA_DIR + "/ldbc_sample/parquet/ldbc_sample.graph.yml";
   std::string src_label = "person", edge_label = "knows", dst_label = "person";
   std::string vertex_property_name = "id";
   std::string edge_property_name = "creationDate";
@@ -64,24 +62,24 @@ TEST_CASE("ChunkInfoReader") {
       REQUIRE(maybe_chunk_path.status().ok());
       std::string chunk_path = maybe_chunk_path.value();
       REQUIRE(chunk_path ==
-              root + "/ldbc_sample/parquet/vertex/person/id/chunk0");
+              TEST_DATA_DIR + "/ldbc_sample/parquet/vertex/person/id/chunk0");
       REQUIRE(reader->seek(520).ok());
       maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       chunk_path = maybe_chunk_path.value();
       REQUIRE(chunk_path ==
-              root + "/ldbc_sample/parquet/vertex/person/id/chunk5");
+              TEST_DATA_DIR + "/ldbc_sample/parquet/vertex/person/id/chunk5");
       REQUIRE(reader->next_chunk().ok());
       maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       chunk_path = maybe_chunk_path.value();
       REQUIRE(chunk_path ==
-              root + "/ldbc_sample/parquet/vertex/person/id/chunk6");
+              TEST_DATA_DIR + "/ldbc_sample/parquet/vertex/person/id/chunk6");
       REQUIRE(reader->seek(900).ok());
       maybe_chunk_path = reader->GetChunk();
       chunk_path = maybe_chunk_path.value();
       REQUIRE(chunk_path ==
-              root + "/ldbc_sample/parquet/vertex/person/id/chunk9");
+              TEST_DATA_DIR + "/ldbc_sample/parquet/vertex/person/id/chunk9");
       // now is end of the chunks
       REQUIRE(reader->next_chunk().IsIndexError());
       // test seek the id not in the chunks
@@ -117,21 +115,21 @@ TEST_CASE("ChunkInfoReader") {
       auto maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       auto chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_source/adj_list/part0/chunk0");
       REQUIRE(reader->seek(100).ok());
       maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_source/adj_list/part0/chunk0");
       REQUIRE(reader->next_chunk().ok());
       maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_source/adj_list/part1/chunk0");
 
@@ -140,14 +138,14 @@ TEST_CASE("ChunkInfoReader") {
       maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_source/adj_list/part1/chunk0");
       REQUIRE(reader->seek_src(900).ok());
       maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_source/adj_list/part9/chunk0");
       REQUIRE(reader->next_chunk().IsIndexError());
@@ -167,7 +165,7 @@ TEST_CASE("ChunkInfoReader") {
       auto maybe_chunk_path = dst_reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       auto chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_dest/adj_list/part1/chunk0");
       // seek an invalid dst id
@@ -188,27 +186,27 @@ TEST_CASE("ChunkInfoReader") {
       auto maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       std::string chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_source/offset/chunk0");
       REQUIRE(reader->seek(520).ok());
       maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_source/offset/chunk5");
       REQUIRE(reader->next_chunk().ok());
       maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_source/offset/chunk6");
       REQUIRE(reader->seek(900).ok());
       maybe_chunk_path = reader->GetChunk();
       chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_source/offset/chunk9");
       // now is end of the chunks
@@ -237,21 +235,21 @@ TEST_CASE("ChunkInfoReader") {
       auto maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       auto chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_source/creationDate/part0/chunk0");
       REQUIRE(reader->seek(100).ok());
       maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_source/creationDate/part0/chunk0");
       REQUIRE(reader->next_chunk().ok());
       maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_source/creationDate/part1/chunk0");
 
@@ -260,14 +258,14 @@ TEST_CASE("ChunkInfoReader") {
       maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_source/creationDate/part1/chunk0");
       REQUIRE(reader->seek_src(900).ok());
       maybe_chunk_path = reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_source/creationDate/part9/chunk0");
       REQUIRE(reader->next_chunk().IsIndexError());
@@ -288,7 +286,7 @@ TEST_CASE("ChunkInfoReader") {
       auto maybe_chunk_path = dst_reader->GetChunk();
       REQUIRE(maybe_chunk_path.status().ok());
       auto chunk_path = maybe_chunk_path.value();
-      REQUIRE(chunk_path == root +
+      REQUIRE(chunk_path == TEST_DATA_DIR +
                                 "/ldbc_sample/parquet/edge/person_knows_person/"
                                 "ordered_by_dest/creationDate/part1/chunk0");
 

--- a/cpp/test/test_graph.cc
+++ b/cpp/test/test_graph.cc
@@ -28,11 +28,9 @@
 
 namespace graphar {
 TEST_CASE("Graph") {
-  std::string root;
-  REQUIRE(GetTestResourceRoot(&root).ok());
-
   // read file and construct graph info
-  std::string path = root + "/ldbc_sample/parquet/ldbc_sample.graph.yml";
+  std::string path =
+      TEST_DATA_DIR + "/ldbc_sample/parquet/ldbc_sample.graph.yml";
   auto maybe_graph_info = GraphInfo::Load(path);
   REQUIRE(maybe_graph_info.status().ok());
   auto graph_info = maybe_graph_info.value();
@@ -87,7 +85,8 @@ TEST_CASE("Graph") {
   SECTION("ListProperty") {
     // read file and construct graph info
     std::string path =
-        root + "/ldbc_sample/parquet/ldbc_sample_with_feature.graph.yml";
+        TEST_DATA_DIR +
+        "/ldbc_sample/parquet/ldbc_sample_with_feature.graph.yml";
     auto maybe_graph_info = GraphInfo::Load(path);
     REQUIRE(maybe_graph_info.status().ok());
     auto graph_info = maybe_graph_info.value();
@@ -200,7 +199,7 @@ TEST_CASE("Graph") {
 
   SECTION("ValidateProperty") {
     // read file and construct graph info
-    std::string path = root + "/neo4j/MovieGraph.graph.yml";
+    std::string path = TEST_DATA_DIR + "/neo4j/MovieGraph.graph.yml";
     auto maybe_graph_info = GraphInfo::Load(path);
     REQUIRE(maybe_graph_info.status().ok());
     auto graph_info = maybe_graph_info.value();

--- a/cpp/test/util.h
+++ b/cpp/test/util.h
@@ -20,22 +20,20 @@
 #pragma once
 
 #include <filesystem>
+#include <iostream>
 #include <string>
 
 #include "graphar/util/status.h"
 
 namespace graphar {
 
-// Return the value of the GAR_TEST_DATA environment variable or return error
-// Status
-Status GetTestResourceRoot(std::string* out) {
-  const char* c_root = std::getenv("GAR_TEST_DATA");
-  if (!c_root) {
-    return Status::IOError(
-        "Test resources not found, set GAR_TEST_DATA to <repo root>/testing");
-  }
-  *out = std::string(c_root);
-  return Status::OK();
-}
+static const std::string TEST_DATA_DIR =  // NOLINT
+    std::filesystem::path(__FILE__)
+        .parent_path()
+        .parent_path()
+        .parent_path()
+        .parent_path()
+        .string() +
+    "/testing";
 
 }  // namespace graphar


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
Update the method to get testing dir with filesystem for convenient to build and test

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Update the method to get testing dir:
use filesystem, deprecated environment variable GAR_TEST_DATA

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
already test with current unit tests

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->
no
<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
