### PR TITLE
fix(c++): Fix cmake warning

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -15,10 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
-if(POLICY CMP0026)
-  cmake_policy(SET CMP0026 OLD)
+# Avoid mixing plain and keyword signature of target_link_libraries
+if (POLICY CMP0023)
+  cmake_policy(SET CMP0023 NEW)
 endif()
 
 if(POLICY CMP0048)
@@ -183,11 +184,7 @@ endmacro()
 # ------------------------------------------------------------------------------
 find_package(Threads REQUIRED)
 find_package(OpenSSL QUIET)
-if (APPLE)
-    find_package(curl REQUIRED)
-else()
-    find_package(CURL REQUIRED)
-endif()
+find_package(CURL REQUIRED)
 if(OPENSSL_FOUND)
     if(OPENSSL_VERSION LESS "1.1.0")
         message(ERROR "The OpenSSL must be greater than or equal to 1.1.0, current version is  ${OPENSSL_VERSION}")
@@ -392,7 +389,7 @@ if (BUILD_TESTS)
                     "${GAR_PARQUET_STATIC_LIB}"
                     "${GAR_ARROW_BUNDLED_DEPS_STATIC_LIB}")
             else()
-                target_link_libraries(${target} Arrow::arrow_shared
+                target_link_libraries(${target} PRIVATE Arrow::arrow_shared
                     Parquet::parquet_shared)
             endif()
         else()


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
Fix the cmake warning of building process


### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
