### PR TITLE
fix(c++): Fix debug building warning

### DIFF
--- a/cpp/benchmarks/arrow_chunk_reader_benchmark.cc
+++ b/cpp/benchmarks/arrow_chunk_reader_benchmark.cc
@@ -87,9 +87,9 @@ BENCHMARK_DEFINE_F(BenchmarkFixture, VertexPropertyArrowChunkReaderReadChunk)
   }
   auto reader = maybe_reader.value();
   for (auto _ : state) {
-    reader->seek(0);
-    reader->GetChunk();
-    reader->next_chunk();
+    assert(reader->seek(0).ok());
+    assert(reader->GetChunk().status().ok());
+    assert(reader->next_chunk().ok());
   }
 }
 
@@ -103,9 +103,9 @@ BENCHMARK_DEFINE_F(BenchmarkFixture, AdjListArrowChunkReaderReadChunk)
   }
   auto reader = maybe_reader.value();
   for (auto _ : state) {
-    reader->seek(0);
-    reader->GetChunk();
-    reader->next_chunk();
+    assert(reader->seek(0).ok());
+    assert(reader->GetChunk().status().ok());
+    assert(reader->next_chunk().ok());
   }
 }
 
@@ -119,9 +119,9 @@ BENCHMARK_DEFINE_F(BenchmarkFixture, AdjListOffsetArrowChunkReaderReadChunk)
   }
   auto reader = maybe_reader.value();
   for (auto _ : state) {
-    reader->seek(0);
-    reader->GetChunk();
-    reader->next_chunk();
+    assert(reader->seek(0).ok());
+    assert(reader->GetChunk().status().ok());
+    assert(reader->next_chunk().ok());
   }
 }
 
@@ -136,9 +136,9 @@ BENCHMARK_DEFINE_F(BenchmarkFixture, AdjListPropertyArrowChunkReaderReadChunk)
   }
   auto reader = maybe_reader.value();
   for (auto _ : state) {
-    reader->seek(0);
-    reader->GetChunk();
-    reader->next_chunk();
+    assert(reader->seek(0).ok());
+    assert(reader->GetChunk().status().ok());
+    assert(reader->next_chunk().ok());
   }
 }
 

--- a/cpp/examples/high_level_reader_example.cc
+++ b/cpp/examples/high_level_reader_example.cc
@@ -35,7 +35,7 @@ void vertices_collection(
   auto vertices = maybe_vertices_collection.value();
 
   // use vertices collection
-  auto count = 0;
+  size_t count = 0;
   // iterate through vertices collection
   for (auto it = vertices->begin(); it != vertices->end(); ++it) {
     count++;


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
as title

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Fix the warning of debug buidling

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes
### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
no
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
