### PR TITLE
fix(spark): Fix the LdbcSample2GraphAr result and use csv as output

### DIFF
--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/example/LdbcSample2GraphAr.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/example/LdbcSample2GraphAr.scala
@@ -92,19 +92,10 @@ object LdbcSample2GraphAr {
     writer.PutVertexData("Person", person_df)
 
     // read edges with type "Person"->"Knows"->"Person" from given path as a DataFrame
-    // FIXME(@acezen): the schema should be inferred from the data, but graphar spark
-    // library does not support timestamp type yet
-    val schema = StructType(
-      Array(
-        StructField("src", IntegerType, true),
-        StructField("dst", IntegerType, true),
-        StructField("creationDate", StringType, true)
-      )
-    )
     val produced_edge_df = spark.read
       .option("delimiter", "|")
       .option("header", "true")
-      .schema(schema)
+      .option("inferSchema", "true")
       .format("csv")
       .load(personKnowsPersonInputPath)
     // put into writer, source vertex label is "Person", edge label is "Knows"

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/example/LdbcSample2GraphAr.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/example/LdbcSample2GraphAr.scala
@@ -92,7 +92,7 @@ object LdbcSample2GraphAr {
     writer.PutVertexData("Person", person_df)
 
     // read edges with type "Person"->"Knows"->"Person" from given path as a DataFrame
-    val produced_edge_df = spark.read
+    val knows_edge_df = spark.read
       .option("delimiter", "|")
       .option("header", "true")
       .option("inferSchema", "true")
@@ -100,6 +100,6 @@ object LdbcSample2GraphAr {
       .load(personKnowsPersonInputPath)
     // put into writer, source vertex label is "Person", edge label is "Knows"
     // target vertex label is "Person"
-    writer.PutEdgeData(("Person", "Knows", "Person"), produced_edge_df)
+    writer.PutEdgeData(("Person", "Knows", "Person"), knows_edge_df)
   }
 }

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/util/Utils.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/util/Utils.scala
@@ -56,11 +56,11 @@ object Utils {
   def sparkDataType2GraphArTypeName(dataType: DataType): String = {
     val typeName = dataType.typeName
     val grapharTypeName = typeName match {
-      case "string"  => "string"
-      case "integer" => "int"
-      case "long"    => "int64"
-      case "double"  => "double"
-      case "boolean" => "bool"
+      case "string"    => "string"
+      case "integer"   => "int"
+      case "long"      => "int64"
+      case "double"    => "double"
+      case "boolean"   => "bool"
       case "timestamp" => "timestamp"
       case _ =>
         throw new IllegalArgumentException(

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/util/Utils.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/util/Utils.scala
@@ -61,6 +61,7 @@ object Utils {
       case "long"    => "int64"
       case "double"  => "double"
       case "boolean" => "bool"
+      case "timestamp" => "timestamp"
       case _ =>
         throw new IllegalArgumentException(
           "Expected string, integral, double or boolean type, got " + typeName + " type"

--- a/maven-projects/spark/scripts/run-ldbc-sample2graphar.sh
+++ b/maven-projects/spark/scripts/run-ldbc-sample2graphar.sh
@@ -28,6 +28,6 @@ output_dir="/tmp/graphar/ldbc_sample"
 
 vertex_chunk_size=100
 edge_chunk_size=1024
-file_type="parquet"
+file_type="csv"
 spark-submit --class org.apache.graphar.example.LdbcSample2GraphAr ${jar_file} \
     ${person_input_file} ${person_knows_person_input_file} ${output_dir} ${vertex_chunk_size} ${edge_chunk_size} ${file_type}


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->


### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
#527 describe

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- The specified schema make the `knows_edge_df` got many wrong null value, use `inferSchema` to make the read operation to get a correct dataframe.
- Since this is example, use `csv` as payload file output make more sense.

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes 

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
no
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
