### PR TITLE
fix(ci): deprecate centos ci in cpp action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,49 +153,6 @@ jobs:
         ./graph_info_benchmark
         ./arrow_chunk_reader_benchmark
     
-  centos:
-    name: CentOS 7 C++
-    runs-on: ubuntu-latest
-    container:
-      image: centos:7
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up devtoolset-8 
-      run: |
-        # install gcc and g++ 8
-        yum install -y centos-release-scl
-        yum install -y devtoolset-8
-
-    - name: Install dependencies
-      shell: scl enable devtoolset-8 -- bash --noprofile --norc -eo pipefail {0}
-      run: |
-        # install cmake
-        yum install -y wget
-        wget https://cmake.org/files/v3.12/cmake-3.12.3.tar.gz -P /tmp/ && \
-            tar -zxf /tmp/cmake-3.12.3.tar.gz -C /tmp/ && \
-            pushd /tmp/cmake-3.12.3 && \
-            ./bootstrap --prefix=/usr/local && \
-            make -j$(nproc) && \
-            make install && \
-            popd
-        echo "cmake version: $(cmake --version)"
-
-        #install arrow
-        yum install -y epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1).noarch.rpm
-        yum install -y https://apache.jfrog.io/artifactory/arrow/centos/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm
-        yum install -y --enablerepo=epel arrow-devel arrow-dataset-devel arrow-acero-devel parquet-devel
-
-    - name: Build GraphAr
-      shell: scl enable devtoolset-8 -- bash --noprofile --norc -eo pipefail {0}
-      working-directory: "cpp"
-      run: |
-        mkdir build
-        pushd build
-        cmake ..
-        make -j$(nproc)
-        popd
-  
   macos:
     name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} C++
     runs-on: macos-${{ matrix.macos-version }}


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->

Deprecate the centos CI since the centos:7 image is too old and the `actions/checkout@v3` can not work on it:
```bash
/usr/bin/docker exec  7c554302d7825ddb6842d137e48460adb118f64955dbfb6e1557261385995898 sh -c "cat /etc/*release | grep ^ID"
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node[20](https://github.com/apache/incubator-graphar/actions/runs/9802355588/job/27066942963?pr=533#step:3:21)/bin/node: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)
```


### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Remove the centos ci

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes
### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->
no
<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
