### PR TITLE
fix(c++): return nullptr at GetChunk if there is no edge in chunk

### DIFF
--- a/cpp/src/graphar/arrow/chunk_reader.cc
+++ b/cpp/src/graphar/arrow/chunk_reader.cc
@@ -368,6 +368,13 @@ Status AdjListArrowChunkReader::seek(IdType offset) {
 
 Result<std::shared_ptr<arrow::Table>> AdjListArrowChunkReader::GetChunk() {
   if (chunk_table_ == nullptr) {
+    // check if the edge num of the current vertex chunk is 0
+    GAR_ASSIGN_OR_RAISE(auto edge_num,
+                        util::GetEdgeNum(prefix_, edge_info_,
+                                         adj_list_type_, vertex_chunk_index_));
+    if (edge_num == 0) {
+      return nullptr;
+    }
     GAR_ASSIGN_OR_RAISE(auto chunk_file_path,
                         edge_info_->GetAdjListFilePath(
                             vertex_chunk_index_, chunk_index_, adj_list_type_));
@@ -691,6 +698,13 @@ Result<std::shared_ptr<arrow::Table>>
 AdjListPropertyArrowChunkReader::GetChunk() {
   GAR_RETURN_NOT_OK(util::CheckFilterOptions(filter_options_, property_group_));
   if (chunk_table_ == nullptr) {
+    // check if the edge num of the current vertex chunk is 0
+    GAR_ASSIGN_OR_RAISE(auto edge_num,
+                        util::GetEdgeNum(prefix_, edge_info_,
+                                         adj_list_type_, vertex_chunk_index_));
+    if (edge_num == 0) {
+      return nullptr;
+    }
     GAR_ASSIGN_OR_RAISE(
         auto chunk_file_path,
         edge_info_->GetPropertyFilePath(property_group_, adj_list_type_,

--- a/cpp/src/graphar/arrow/chunk_reader.cc
+++ b/cpp/src/graphar/arrow/chunk_reader.cc
@@ -370,8 +370,8 @@ Result<std::shared_ptr<arrow::Table>> AdjListArrowChunkReader::GetChunk() {
   if (chunk_table_ == nullptr) {
     // check if the edge num of the current vertex chunk is 0
     GAR_ASSIGN_OR_RAISE(auto edge_num,
-                        util::GetEdgeNum(prefix_, edge_info_,
-                                         adj_list_type_, vertex_chunk_index_));
+                        util::GetEdgeNum(prefix_, edge_info_, adj_list_type_,
+                                         vertex_chunk_index_));
     if (edge_num == 0) {
       return nullptr;
     }
@@ -700,8 +700,8 @@ AdjListPropertyArrowChunkReader::GetChunk() {
   if (chunk_table_ == nullptr) {
     // check if the edge num of the current vertex chunk is 0
     GAR_ASSIGN_OR_RAISE(auto edge_num,
-                        util::GetEdgeNum(prefix_, edge_info_,
-                                         adj_list_type_, vertex_chunk_index_));
+                        util::GetEdgeNum(prefix_, edge_info_, adj_list_type_,
+                                         vertex_chunk_index_));
     if (edge_num == 0) {
       return nullptr;
     }

--- a/cpp/src/graphar/arrow/chunk_reader.h
+++ b/cpp/src/graphar/arrow/chunk_reader.h
@@ -198,7 +198,7 @@ class AdjListArrowChunkReader {
 
   /**
    * @brief Return the current chunk of chunk position indicator as
-   * arrow::Table
+   * arrow::Table, if the chunk is empty, return nullptr.
    */
   Result<std::shared_ptr<arrow::Table>> GetChunk();
 
@@ -400,7 +400,7 @@ class AdjListPropertyArrowChunkReader {
 
   /**
    * @brief Return the current chunk of chunk position indicator as
-   * arrow::Table
+   * arrow::Table, if the chunk is empty, return nullptr.
    */
   Result<std::shared_ptr<arrow::Table>> GetChunk();
 

--- a/cpp/test/test_arrow_chunk_reader.cc
+++ b/cpp/test/test_arrow_chunk_reader.cc
@@ -458,6 +458,41 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
   }
 }
 
+TEST_CASE_METHOD(GlobalFixture, "EmptyChunkTest") {
+  // read file and construct graph info
+  std::string path = test_data_dir + "/neo4j/MovieGraph.graph.yml";
+  std::string src_label = "Person", edge_label = "REVIEWED",
+              dst_label = "Movie";
+  std::string edge_property_name = "rating";
+  auto maybe_graph_info = GraphInfo::Load(path);
+  REQUIRE(maybe_graph_info.status().ok());
+  auto graph_info = maybe_graph_info.value();
+
+  SECTION("AdjListArrowChunkReader") {
+    auto maybe_reader = AdjListArrowChunkReader::Make(
+        graph_info, src_label, edge_label, dst_label,
+        AdjListType::ordered_by_source);
+    REQUIRE(maybe_reader.status().ok());
+    auto reader = maybe_reader.value();
+    auto result = reader->GetChunk();
+    REQUIRE(!result.has_error());
+    // the edge chunk is empty, should return nullptr
+    REQUIRE(result.value() == nullptr);
+  }
+
+  SECTION("AdjListPropertyArrowChunkReader") {
+    auto maybe_reader = AdjListPropertyArrowChunkReader::Make(
+        graph_info, src_label, edge_label, dst_label, edge_property_name,
+        AdjListType::ordered_by_source);
+    REQUIRE(maybe_reader.status().ok());
+    auto reader = maybe_reader.value();
+    auto result = reader->GetChunk();
+    REQUIRE(!result.has_error());
+    // the edge chunk is empty, should return nullptr
+    REQUIRE(result.value() == nullptr);
+  }
+}
+
 TEST_CASE_METHOD(GlobalFixture, "JSON_TEST") {
   // read file and construct graph info
   std::string path = test_data_dir + "/ldbc_sample/json/LdbcSample.graph.yml";


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->

as #549 describe, when there are no edge of a vertex chunk, the directory could be empty, and the GetChunk would return `IOError`. 

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Instead of return IOError, change to return a nullptr since the GetChunk operation should be OK and just the return chunk is empty.

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
the test case will be added.

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->

No