### PR TITLE
fix(c++): Raise error if cmake found arrow built without ORC support.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -180,7 +180,7 @@ endmacro()
 # building or find third party library
 # ------------------------------------------------------------------------------
 # check if arrow is installed
-find_package(Arrow QUIET)
+find_package(Arrow)
 if (NOT ${Arrow_FOUND})
     message(FATAL_ERROR "apache-arrow is required, please install it and retry")
 endif()
@@ -195,6 +195,11 @@ if (${Arrow_VERSION} VERSION_GREATER_EQUAL "12.0.0")
         message(FATAL_ERROR "apache-arrow-acero is required, please install it and retry")
     endif()
 endif()
+# Check if ORC is enabled.
+if (NOT ${ARROW_ORC})
+    message(FATAL_ERROR "apache-arrow ORC extension is required.")
+endif()
+
 find_package(Parquet QUIET)
 if (NOT ${Parquet_FOUND})
     message(FATAL_ERROR "parquet is required, please install it and retry")


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)
Fix issues #547 and #545 

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->

Since brew installed arrow does not include orc extension. This PR add a fix to raise fatal message to terminate the build process if it does not find the orc extension.

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

a testing item added in CMakeList.

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes. but the test case is not included in PR, since it only affects a building failed codepath.


### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
