### PR TITLE
docs: change images in docs from relative url to absolute url.

### DIFF
--- a/docs/overview/overview.md
+++ b/docs/overview/overview.md
@@ -4,7 +4,7 @@ title: Overview
 sidebar_position: 1
 ---
 
-<img src="../images/overview.png" alt="overview" width="700"/>
+<img src="/docs/images/overview.png" alt="overview" width="700"/>
 
 GraphAr is a project to standardize the graph data format and provide a set of libraries to generate, access and transform such formatted files.
 

--- a/docs/specification/format.md
+++ b/docs/specification/format.md
@@ -27,7 +27,7 @@ Each edge contains a unique identifier and:
 
 The following is an example property graph containing two types of vertices ("person" and "comment") and three types of edges.
 
-<img src="../images/property_graph.png" alt="property graph" width="700" align="center"/>
+<img src="/docs/images/property_graph.png" alt="property graph" width="700" align="center"/>
 
 ## Property Data Types
 
@@ -94,7 +94,7 @@ Each type of vertices (with the same label) constructs a logical vertex table, w
 
 Given an internal vertex id and the vertex label, a vertex is uniquely identifiable and its respective properties can be accessed from this table. The internal vertex id is further used to identify the source and destination vertices when maintaining the topology of the graph.
 
-<img src="../images/vertex_logical_table.png" alt="vertex logical table" width="700" align="center"/>
+<img src="/docs/images/vertex_logical_table.png" alt="vertex logical table" width="700" align="center"/>
 
 :::note
 
@@ -108,7 +108,7 @@ The logical vertex table will be partitioned into multiple continuous vertex chu
 
 Take the "person" vertex table as an example, if the chunk size is set to be 500, the logical table will be separated into sub-logical-tables of 500 rows with the exception of the last one, which may have less than 500 rows. The columns for maintaining properties will also be divided into distinct groups (e.g., 2 for our example). As a result, a total of 4 physical vertex tables are created for storing the example logical table, which can be seen from the following figure.
 
-<img src="../images/vertex_physical_table.png" alt="vertex physical table" width="700" align="center"/>
+<img src="/docs/images/vertex_physical_table.png" alt="vertex physical table" width="700" align="center"/>
 
 :::note
 
@@ -124,7 +124,7 @@ For maintaining a type of edges (that with the same triplet of the source label,
 
 Take the logical table for "person likes person" edges as an example, the logical edge table looks like:
 
-<img src="../images/edge_logical_table.png" alt="edge logical table" width="700" align="center"/>
+<img src="/docs/images/edge_logical_table.png" alt="edge logical table" width="700" align="center"/>
 
 ### Physical table of edges
 
@@ -139,9 +139,9 @@ Additionally, there would be an offset table for **ordered_by_source** or **orde
 
 Take the "person knows person" edges to illustrate. Suppose the vertex chunk size is set to 500 and the edge chunk size is 1024, and the edges are **ordered_by_source**, then the edges could be saved in the following physical tables:
 
-<img src="../images/edge_physical_table1.png" alt="edge physical table1" width="700" align="center"/>
+<img src="/docs/images/edge_physical_table1.png" alt="edge physical table1" width="700" align="center"/>
 
-<img src="../images/edge_physical_table2.png" alt="edge physical table2" width="700" align="center"/>
+<img src="/docs/images/edge_physical_table2.png" alt="edge physical table2" width="700" align="center"/>
 
 > **Tip:** When the edge type is **ordered_by_source**, the sorted adjList table together with the offset table can be used as CSR, supporting the fast access of the outgoing edges for a given vertex. Similarly, a CSC view can be constructed by sorting the edges by destination and recording corresponding offsets, supporting the fast access of the incoming edges for a given vertex.
 


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->

Fix an image cannot display bug when open docs from README docs. 

Currently, the images in the docs are given the relative URL, which will lead to a cannot display bug:
Since clicking from github README, the link will automatically appending a '/', e.g., 
clicking on https://graphar.apache.org/docs/specification/format, 
it actually open the URL https://graphar.apache.org/docs/specification/format/

The endling '/' affected the relative path, (by add an extra level), leading the images cannot by found and return a 404 error. 

<img width="994" alt="Screenshot 2024-07-31 at 15 23 35" src="https://github.com/user-attachments/assets/5c6f0fd3-2fdf-4d9c-860f-6fb19bfe51c1">


### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Using absolute path can solve this problem.
Better still, even the [docs in github repo kept correctly displayed](https://github.com/yecol/incubator-graphar/blob/docs/docs/specification/format.md).

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
