### PR TITLE
docs: fix a bug prevented highlighting code syntax correctly.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ We expect all community members to follow our [Code of Conduct](https://www.apac
 A good branch name would be the issue number you are working on and a short description of the change,
 like (where issue \#42 is the ticket you're working on):
 
-``` shell
+```shell
 $ git checkout -b 42-add-chinese-translations
 ```
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ GraphAr.
   Scheme\[J\]](https://arxiv.org/abs/2312.09577). arXiv preprint
   arXiv:2312.09577, 2023.
 
-``` bibtex
+```bibtex
 @article{li2023enhancing,
   author = {Xue Li and Weibin Zeng and Zhibin Wang and Diwen Zhu and Jingbo Xu and Wenyuan Yu and Jingren Zhou},
   title = {Enhancing Data Lakes with GraphAr: Efficient Graph Data Management with a Specialized Storage Scheme},

--- a/docs/libraries/cpp/examples/bgl.md
+++ b/docs/libraries/cpp/examples/bgl.md
@@ -21,7 +21,7 @@ The source code of CC based on BGL can be found at
 In this program, the graph information file is first read to get the
 metadata:
 
-``` C++
+```cpp
 std::string path = ... // the path of the graph information file
 auto graph_info = graphar::GraphInfo::Load(path).value();
 ```
@@ -29,7 +29,7 @@ auto graph_info = graphar::GraphInfo::Load(path).value();
 And then, the vertex collection and the edge collection are established
 as the handles to access the graph data:
 
-``` C++
+```cpp
 auto maybe_vertices = graphar::VerticesCollection::Make(graph_info, "person");
 auto vertices = maybe_vertices.value();
 auto maybe_edges = graphar::EdgesCollection::Make(graph_info, "person", "knows", "person", graphar::AdjListType::ordered_by_source);
@@ -40,7 +40,7 @@ Next, we construct the in-memory graph data structure for BGL by
 traversing the vertices and edges via GraphAr's high-level reading
 interface (the vertex iterator and the edge iterator):
 
-``` C++
+```cpp
 // define the Graph type in BGL
 typedef boost::adjacency_list<boost::vecS, // use vector to store edges
                               boost::vecS, // use vector to store vertices
@@ -68,7 +68,7 @@ for (auto it = v_it_begin; it != v_it_end; ++it) {
 
 After that, an internal CC algorithm provided by BGL is called:
 
-``` C++
+```cpp
 // define the external vertex property "component"
 std::vector<int> component(num_vertices);
 // call algorithm: cc
@@ -79,7 +79,7 @@ std::cout << "Total number of components: " << cc_num << std::endl;
 Finally, we could use a **VerticesBuilder** of GraphAr to write the
 results to new generated GraphAr format data:
 
-``` C++
+```cpp
 // construct a new property group
 graphar::Property cc = {"cc", graphar::int32(), false};
 std::vector<graphar::Property> property_vector = {cc};

--- a/docs/libraries/cpp/examples/snap-to-graphar.md
+++ b/docs/libraries/cpp/examples/snap-to-graphar.md
@@ -15,7 +15,7 @@ Before converting, download the ego-Facebook dataset from the SNAP
 website. The dataset is a text file with each line representing an edge
 in the graph.
 
-``` bash
+```bash
 cd /path/to/your/dataset
 wget https://snap.stanford.edu/data/facebook_combined.txt.gz
 gunzip facebook_combined.txt.gz
@@ -28,7 +28,7 @@ GraphInfo objects, which are subsequently serialized into YAML files.
 For instance, the code snippet below illustrates the creation and
 storage of the vertex information file.
 
-``` C++
+```cpp
 auto version = graphar::InfoVersion::Parse("gar/v1").value();
 
 // meta info
@@ -58,7 +58,7 @@ by the GraphAr C++ library to generate payload data files with vertex
 and edge data. The code snippet that follows demonstrates the generation
 and preservation of the edge data file.
 
-``` C++
+```cpp
 // construct edges builder
 auto e_builder = graphar::builder::EdgesBuilder::Make(
                      edge_info, save_path, ADJLIST_TYPE, VERTEX_COUNT)

--- a/docs/libraries/cpp/getting-started.md
+++ b/docs/libraries/cpp/getting-started.md
@@ -25,7 +25,7 @@ GraphAr. For example, the file "ldbc_sample.graph.yml" defines an
 example graph named "ldbc_sample", which includes one type of vertices
 ("person") and one type of edges ("person knows person").
 
-``` Yaml
+```yaml
 name: ldbc_sample
 prefix: ./
 vertices:
@@ -154,7 +154,7 @@ Also, the metadata of a graph can be constructed easily through reading
 the already existed information files, as the following code
 illustrates:
 
-``` C++
+```cpp
 // construct graph information from file
 std::string path = ... // the path of the graph information file (e.g., ldbc_sample.graph.yml)
 auto graph_info = graphar::GraphInfo::Load(path).value();
@@ -185,7 +185,7 @@ As a simple case, the following example shows how to read all vertices
 with label "person" of the graph defined by "graph_info" and output the
 values of "id" and "firstName" for each vertex.
 
-``` C++
+```cpp
 graph_info = ...
 auto vertices = graphar::VerticesCollection::Make(graph_info, "person").value();
 
@@ -200,7 +200,7 @@ for (auto it = vertices->begin(); it != vertices->end(); ++it) {
 The next example reads all edges with label "person_knows_person" from
 the above graph and outputs the end vertices for each edge.
 
-``` C++
+```cpp
 graph_info = ...
 auto expect = graphar::EdgesCollection::Make(graph_info, "person", "konws", "person", graphar::AdjListType::ordered_by_source);
 auto edges = expect.value();
@@ -221,7 +221,7 @@ As the simplest cases, the fist example below adds vertices to
 **VerticesBuilder**, and then dumps the data to files; the second
 example constructs a collection of edges and then dumps them.
 
-``` C++
+```cpp
 vertex_info = ...
 prefix = ...
 graphar::builder::VerticesBuilder builder(vertex_info,  prefix);
@@ -238,7 +238,7 @@ builder.AddVertex(v);
 builder.Dump();
 ```
 
-``` C++
+```cpp
 edge_info = ...
 prefix = ...
 vertices_num = ...


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->

Currently the docs pages do not display code syntax highlight correctly. 
e.g., https://graphar.apache.org/docs/libraries/cpp/examples/bgl

This PR fix a bug and show the syntax like this:
<img width="1421" alt="Screenshot 2024-08-05 at 4 27 49 PM" src="https://github.com/user-attachments/assets/0c107e20-8155-4d0e-9f00-856c2f250349">


### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- code hint: c++ -> cpp

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
