### PR TITLE
chore(spark): remove `Utils.redact`

### DIFF
--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/util/Utils.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/util/Utils.scala
@@ -35,24 +35,6 @@ import org.apache.graphar.{
 
 object Utils {
 
-  private val REDACTION_REPLACEMENT_TEXT = "*********(redacted)"
-
-  /**
-   * Redact the sensitive information in the given string.
-   */
-  // folk of Utils.redact of spark
-  def redact(regex: Option[Regex], text: String): String = {
-    regex match {
-      case None => text
-      case Some(r) =>
-        if (text == null || text.isEmpty) {
-          text
-        } else {
-          r.replaceAllIn(text, REDACTION_REPLACEMENT_TEXT)
-        }
-    }
-  }
-
   def sparkDataType2GraphArTypeName(dataType: DataType): String = {
     val typeName = dataType.typeName
     val grapharTypeName = typeName match {


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
Since the `redact` has been copy to datasource, the code in Utils can be removed

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
remove the `redact` code from Utils
### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes
### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->
no
<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
