### PR TITLE
feat!(format):change the naming of vertex/edge unique identify type from `label` to `type`

### DIFF
--- a/cpp/examples/bfs_father_example.cc
+++ b/cpp/examples/bfs_father_example.cc
@@ -42,9 +42,9 @@ int main(int argc, char* argv[]) {
 
   // get the "person_knows_person" edges of graph
   std::string src_type = "person", edge_type = "knows", dst_type = "person";
-  auto maybe_edges = graphar::EdgesCollection::Make(
-      graph_info, src_type, edge_type, dst_type,
-      graphar::AdjListType::unordered_by_source);
+  auto maybe_edges =
+      graphar::EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
+                                     graphar::AdjListType::unordered_by_source);
   ASSERT(!maybe_edges.has_error());
   auto& edges = maybe_edges.value();
 

--- a/cpp/examples/bfs_father_example.cc
+++ b/cpp/examples/bfs_father_example.cc
@@ -41,9 +41,9 @@ int main(int argc, char* argv[]) {
   std::cout << "num_vertices: " << num_vertices << std::endl;
 
   // get the "person_knows_person" edges of graph
-  std::string src_label = "person", edge_label = "knows", dst_label = "person";
+  std::string src_type = "person", edge_type = "knows", dst_type = "person";
   auto maybe_edges = graphar::EdgesCollection::Make(
-      graph_info, src_label, edge_label, dst_label,
+      graph_info, src_type, edge_type, dst_type,
       graphar::AdjListType::unordered_by_source);
   ASSERT(!maybe_edges.has_error());
   auto& edges = maybe_edges.value();
@@ -130,16 +130,16 @@ int main(int argc, char* argv[]) {
   ASSERT(writer.WriteTable(table, group, 0).ok());
 
   // construct a new graph
-  src_label = "person";
-  edge_label = "bfs";
-  dst_label = "person";
+  src_type = "person";
+  edge_type = "bfs";
+  dst_type = "person";
   int edge_chunk_size = 1024, src_chunk_size = 100, dst_chunk_size = 100;
   bool directed = true;
   auto version = graphar::InfoVersion::Parse("gar/v1").value();
   auto al = graphar::CreateAdjacentList(graphar::AdjListType::ordered_by_source,
                                         graphar::FileType::CSV);
   auto new_edge_info = graphar::CreateEdgeInfo(
-      src_label, edge_label, dst_label, edge_chunk_size, src_chunk_size,
+      src_type, edge_type, dst_type, edge_chunk_size, src_chunk_size,
       dst_chunk_size, directed, {al}, {}, "", version);
   ASSERT(new_edge_info->IsValidated());
   // save & dump

--- a/cpp/examples/bfs_pull_example.cc
+++ b/cpp/examples/bfs_pull_example.cc
@@ -42,9 +42,9 @@ int main(int argc, char* argv[]) {
 
   // construct edges collection
   std::string src_type = "person", edge_type = "knows", dst_type = "person";
-  auto maybe_edges = graphar::EdgesCollection::Make(
-      graph_info, src_type, edge_type, dst_type,
-      graphar::AdjListType::ordered_by_dest);
+  auto maybe_edges =
+      graphar::EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
+                                     graphar::AdjListType::ordered_by_dest);
   ASSERT(!maybe_edges.has_error());
   auto& edges = maybe_edges.value();
 

--- a/cpp/examples/bfs_pull_example.cc
+++ b/cpp/examples/bfs_pull_example.cc
@@ -41,9 +41,9 @@ int main(int argc, char* argv[]) {
   std::cout << "num_vertices: " << num_vertices << std::endl;
 
   // construct edges collection
-  std::string src_label = "person", edge_label = "knows", dst_label = "person";
+  std::string src_type = "person", edge_type = "knows", dst_type = "person";
   auto maybe_edges = graphar::EdgesCollection::Make(
-      graph_info, src_label, edge_label, dst_label,
+      graph_info, src_type, edge_type, dst_type,
       graphar::AdjListType::ordered_by_dest);
   ASSERT(!maybe_edges.has_error());
   auto& edges = maybe_edges.value();

--- a/cpp/examples/bfs_push_example.cc
+++ b/cpp/examples/bfs_push_example.cc
@@ -41,9 +41,9 @@ int main(int argc, char* argv[]) {
   std::cout << "num_vertices: " << num_vertices << std::endl;
 
   // construct edges collection
-  std::string src_label = "person", edge_label = "knows", dst_label = "person";
+  std::string src_type = "person", edge_type = "knows", dst_type = "person";
   auto maybe_edges = graphar::EdgesCollection::Make(
-      graph_info, src_label, edge_label, dst_label,
+      graph_info, src_type, edge_type, dst_type,
       graphar::AdjListType::ordered_by_source);
   ASSERT(!maybe_edges.has_error());
   auto& edges = maybe_edges.value();

--- a/cpp/examples/bfs_push_example.cc
+++ b/cpp/examples/bfs_push_example.cc
@@ -42,9 +42,9 @@ int main(int argc, char* argv[]) {
 
   // construct edges collection
   std::string src_type = "person", edge_type = "knows", dst_type = "person";
-  auto maybe_edges = graphar::EdgesCollection::Make(
-      graph_info, src_type, edge_type, dst_type,
-      graphar::AdjListType::ordered_by_source);
+  auto maybe_edges =
+      graphar::EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
+                                     graphar::AdjListType::ordered_by_source);
   ASSERT(!maybe_edges.has_error());
   auto& edges = maybe_edges.value();
 

--- a/cpp/examples/bfs_stream_example.cc
+++ b/cpp/examples/bfs_stream_example.cc
@@ -42,9 +42,9 @@ int main(int argc, char* argv[]) {
 
   // construct edges collection
   std::string src_type = "person", edge_type = "knows", dst_type = "person";
-  auto maybe_edges = graphar::EdgesCollection::Make(
-      graph_info, src_type, edge_type, dst_type,
-      graphar::AdjListType::unordered_by_source);
+  auto maybe_edges =
+      graphar::EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
+                                     graphar::AdjListType::unordered_by_source);
   ASSERT(!maybe_edges.has_error());
   auto& edges = maybe_edges.value();
 

--- a/cpp/examples/bfs_stream_example.cc
+++ b/cpp/examples/bfs_stream_example.cc
@@ -41,9 +41,9 @@ int main(int argc, char* argv[]) {
   std::cout << "num_vertices: " << num_vertices << std::endl;
 
   // construct edges collection
-  std::string src_label = "person", edge_label = "knows", dst_label = "person";
+  std::string src_type = "person", edge_type = "knows", dst_type = "person";
   auto maybe_edges = graphar::EdgesCollection::Make(
-      graph_info, src_label, edge_label, dst_label,
+      graph_info, src_type, edge_type, dst_type,
       graphar::AdjListType::unordered_by_source);
   ASSERT(!maybe_edges.has_error());
   auto& edges = maybe_edges.value();

--- a/cpp/examples/bgl_example.cc
+++ b/cpp/examples/bgl_example.cc
@@ -48,9 +48,9 @@ int main(int argc, char* argv[]) {
   std::cout << "num_vertices: " << num_vertices << std::endl;
 
   // construct edges collection
-  std::string src_label = "person", edge_label = "knows", dst_label = "person";
+  std::string src_type = "person", edge_type = "knows", dst_type = "person";
   auto maybe_edges = graphar::EdgesCollection::Make(
-      graph_info, src_label, edge_label, dst_label,
+      graph_info, src_type, edge_type, dst_type,
       graphar::AdjListType::ordered_by_source);
   ASSERT(!maybe_edges.has_error());
   auto& edges = maybe_edges.value();
@@ -108,10 +108,10 @@ int main(int argc, char* argv[]) {
   auto group =
       graphar::CreatePropertyGroup(property_vector, graphar::FileType::PARQUET);
   // construct new vertex info
-  std::string vertex_label = "cc_result", vertex_prefix = "result/";
+  std::string type = "cc_result", vertex_prefix = "result/";
   int chunk_size = 100;
   auto version = graphar::InfoVersion::Parse("gar/v1").value();
-  auto new_info = graphar::CreateVertexInfo(vertex_label, chunk_size, {group},
+  auto new_info = graphar::CreateVertexInfo(type, chunk_size, {group},
                                             vertex_prefix, version);
   // dump new vertex info
   ASSERT(new_info->IsValidated());

--- a/cpp/examples/bgl_example.cc
+++ b/cpp/examples/bgl_example.cc
@@ -49,9 +49,9 @@ int main(int argc, char* argv[]) {
 
   // construct edges collection
   std::string src_type = "person", edge_type = "knows", dst_type = "person";
-  auto maybe_edges = graphar::EdgesCollection::Make(
-      graph_info, src_type, edge_type, dst_type,
-      graphar::AdjListType::ordered_by_source);
+  auto maybe_edges =
+      graphar::EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
+                                     graphar::AdjListType::ordered_by_source);
   ASSERT(!maybe_edges.has_error());
   auto& edges = maybe_edges.value();
 

--- a/cpp/examples/cc_push_example.cc
+++ b/cpp/examples/cc_push_example.cc
@@ -42,14 +42,14 @@ int main(int argc, char* argv[]) {
   std::cout << "num_vertices: " << num_vertices << std::endl;
 
   // construct edges collection
-  std::string src_label = "person", edge_label = "knows", dst_label = "person";
+  std::string src_type = "person", edge_type = "knows", dst_type = "person";
   auto expect1 = graphar::EdgesCollection::Make(
-      graph_info, src_label, edge_label, dst_label,
+      graph_info, src_type, edge_type, dst_type,
       graphar::AdjListType::ordered_by_source);
   ASSERT(!expect1.has_error());
   auto& edges1 = expect1.value();
   auto expect2 = graphar::EdgesCollection::Make(
-      graph_info, src_label, edge_label, dst_label,
+      graph_info, src_type, edge_type, dst_type,
       graphar::AdjListType::ordered_by_dest);
   ASSERT(!expect2.has_error());
   auto& edges2 = expect2.value();

--- a/cpp/examples/cc_push_example.cc
+++ b/cpp/examples/cc_push_example.cc
@@ -43,14 +43,14 @@ int main(int argc, char* argv[]) {
 
   // construct edges collection
   std::string src_type = "person", edge_type = "knows", dst_type = "person";
-  auto expect1 = graphar::EdgesCollection::Make(
-      graph_info, src_type, edge_type, dst_type,
-      graphar::AdjListType::ordered_by_source);
+  auto expect1 =
+      graphar::EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
+                                     graphar::AdjListType::ordered_by_source);
   ASSERT(!expect1.has_error());
   auto& edges1 = expect1.value();
-  auto expect2 = graphar::EdgesCollection::Make(
-      graph_info, src_type, edge_type, dst_type,
-      graphar::AdjListType::ordered_by_dest);
+  auto expect2 =
+      graphar::EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
+                                     graphar::AdjListType::ordered_by_dest);
   ASSERT(!expect2.has_error());
   auto& edges2 = expect2.value();
 

--- a/cpp/examples/cc_stream_example.cc
+++ b/cpp/examples/cc_stream_example.cc
@@ -43,9 +43,9 @@ int main(int argc, char* argv[]) {
 
   // construct edges collection
   std::string src_type = "person", edge_type = "knows", dst_type = "person";
-  auto maybe_edges = graphar::EdgesCollection::Make(
-      graph_info, src_type, edge_type, dst_type,
-      graphar::AdjListType::ordered_by_source);
+  auto maybe_edges =
+      graphar::EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
+                                     graphar::AdjListType::ordered_by_source);
   ASSERT(!maybe_edges.has_error());
   auto& edges = maybe_edges.value();
 

--- a/cpp/examples/cc_stream_example.cc
+++ b/cpp/examples/cc_stream_example.cc
@@ -42,9 +42,9 @@ int main(int argc, char* argv[]) {
   std::cout << "num_vertices: " << num_vertices << std::endl;
 
   // construct edges collection
-  std::string src_label = "person", edge_label = "knows", dst_label = "person";
+  std::string src_type = "person", edge_type = "knows", dst_type = "person";
   auto maybe_edges = graphar::EdgesCollection::Make(
-      graph_info, src_label, edge_label, dst_label,
+      graph_info, src_type, edge_type, dst_type,
       graphar::AdjListType::ordered_by_source);
   ASSERT(!maybe_edges.has_error());
   auto& edges = maybe_edges.value();

--- a/cpp/examples/construct_info_example.cc
+++ b/cpp/examples/construct_info_example.cc
@@ -43,8 +43,8 @@ int main(int argc, char* argv[]) {
       graphar::CreatePropertyGroup(property_vector_2, graphar::FileType::ORC);
 
   // create vertex info
-  auto vertex_info = graphar::CreateVertexInfo(
-      type, chunk_size, {group1}, vertex_prefix, version);
+  auto vertex_info = graphar::CreateVertexInfo(type, chunk_size, {group1},
+                                               vertex_prefix, version);
 
   ASSERT(vertex_info != nullptr);
   ASSERT(vertex_info->GetType() == type);

--- a/cpp/examples/construct_info_example.cc
+++ b/cpp/examples/construct_info_example.cc
@@ -27,7 +27,7 @@ int main(int argc, char* argv[]) {
   auto version = graphar::InfoVersion::Parse("gar/v1").value();
 
   // meta info
-  std::string vertex_label = "person", vertex_prefix = "vertex/person/";
+  std::string type = "person", vertex_prefix = "vertex/person/";
   int chunk_size = 100;
 
   // construct properties and property groups
@@ -44,10 +44,10 @@ int main(int argc, char* argv[]) {
 
   // create vertex info
   auto vertex_info = graphar::CreateVertexInfo(
-      vertex_label, chunk_size, {group1}, vertex_prefix, version);
+      type, chunk_size, {group1}, vertex_prefix, version);
 
   ASSERT(vertex_info != nullptr);
-  ASSERT(vertex_info->GetLabel() == vertex_label);
+  ASSERT(vertex_info->GetType() == type);
   ASSERT(vertex_info->GetChunkSize() == chunk_size);
   ASSERT(vertex_info->GetPropertyGroups().size() == 1);
   ASSERT(vertex_info->HasProperty("id"));
@@ -75,7 +75,7 @@ int main(int argc, char* argv[]) {
 
   /*------------------construct edge info------------------*/
   // meta info
-  std::string src_label = "person", edge_label = "knows", dst_label = "person",
+  std::string src_type = "person", edge_type = "knows", dst_type = "person",
               edge_prefix = "edge/person_knows_person/";
   int edge_chunk_size = 1024, src_chunk_size = 100, dst_chunk_size = 100;
   bool directed = false;
@@ -94,13 +94,13 @@ int main(int argc, char* argv[]) {
 
   // create edge info
   auto edge_info = graphar::CreateEdgeInfo(
-      src_label, edge_label, dst_label, edge_chunk_size, src_chunk_size,
+      src_type, edge_type, dst_type, edge_chunk_size, src_chunk_size,
       dst_chunk_size, directed, adjacent_lists, {group3}, edge_prefix, version);
 
   ASSERT(edge_info != nullptr);
-  ASSERT(edge_info->GetSrcLabel() == src_label);
-  ASSERT(edge_info->GetEdgeLabel() == edge_label);
-  ASSERT(edge_info->GetDstLabel() == dst_label);
+  ASSERT(edge_info->GetSrcType() == src_type);
+  ASSERT(edge_info->GetEdgeType() == edge_type);
+  ASSERT(edge_info->GetDstType() == dst_type);
   ASSERT(edge_info->GetChunkSize() == edge_chunk_size);
   ASSERT(edge_info->GetSrcChunkSize() == src_chunk_size);
   ASSERT(edge_info->GetDstChunkSize() == dst_chunk_size);
@@ -154,14 +154,14 @@ int main(int argc, char* argv[]) {
   ASSERT(graph_info->GetName() == name);
   ASSERT(graph_info->GetPrefix() == prefix);
   ASSERT(graph_info->GetVertexInfos().size() == 1);
-  ASSERT(graph_info->GetVertexInfo(vertex_label) != nullptr);
-  auto vertex_info_from_graph = graph_info->GetVertexInfo(vertex_label);
+  ASSERT(graph_info->GetVertexInfo(type) != nullptr);
+  auto vertex_info_from_graph = graph_info->GetVertexInfo(type);
   ASSERT(vertex_info_from_graph != nullptr);
   ASSERT(vertex_info_from_graph->HasPropertyGroup(group1));
   ASSERT(vertex_info_from_graph->HasPropertyGroup(group2));
   ASSERT(graph_info->GetEdgeInfos().size() == 1);
   auto edge_info_from_graph =
-      graph_info->GetEdgeInfo(src_label, edge_label, dst_label);
+      graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
   ASSERT(edge_info_from_graph != nullptr);
   ASSERT(edge_info_from_graph->PropertyGroupNum() == 1);
   ASSERT(edge_info_from_graph->HasPropertyGroup(group3));

--- a/cpp/examples/high_level_reader_example.cc
+++ b/cpp/examples/high_level_reader_example.cc
@@ -75,9 +75,9 @@ void vertices_collection(
 
 void edges_collection(const std::shared_ptr<graphar::GraphInfo>& graph_info) {
   // construct edges collection
-  std::string src_label = "person", edge_label = "knows", dst_label = "person";
+  std::string src_type = "person", edge_type = "knows", dst_type = "person";
   auto expect = graphar::EdgesCollection::Make(
-      graph_info, src_label, edge_label, dst_label,
+      graph_info, src_type, edge_type, dst_type,
       graphar::AdjListType::ordered_by_source);
   ASSERT(!expect.has_error());
   auto edges = expect.value();

--- a/cpp/examples/high_level_reader_example.cc
+++ b/cpp/examples/high_level_reader_example.cc
@@ -76,9 +76,9 @@ void vertices_collection(
 void edges_collection(const std::shared_ptr<graphar::GraphInfo>& graph_info) {
   // construct edges collection
   std::string src_type = "person", edge_type = "knows", dst_type = "person";
-  auto expect = graphar::EdgesCollection::Make(
-      graph_info, src_type, edge_type, dst_type,
-      graphar::AdjListType::ordered_by_source);
+  auto expect =
+      graphar::EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
+                                     graphar::AdjListType::ordered_by_source);
   ASSERT(!expect.has_error());
   auto edges = expect.value();
 

--- a/cpp/examples/low_level_reader_example.cc
+++ b/cpp/examples/low_level_reader_example.cc
@@ -61,9 +61,9 @@ void vertex_property_chunk_info_reader(
 void adj_list_chunk_info_reader(
     const std::shared_ptr<graphar::GraphInfo>& graph_info) {
   // construct reader
-  std::string src_label = "person", edge_label = "knows", dst_label = "person";
+  std::string src_type = "person", edge_type = "knows", dst_type = "person";
   auto maybe_reader = graphar::AdjListChunkInfoReader::Make(
-      graph_info, src_label, edge_label, dst_label,
+      graph_info, src_type, edge_type, dst_type,
       graphar::AdjListType::ordered_by_source);
   ASSERT(maybe_reader.status().ok());
   auto reader = maybe_reader.value();
@@ -92,11 +92,11 @@ void adj_list_chunk_info_reader(
 void adj_list_property_chunk_info_reader(
     const std::shared_ptr<graphar::GraphInfo>& graph_info) {
   // construct reader
-  std::string src_label = "person", edge_label = "knows", dst_label = "person",
+  std::string src_type = "person", edge_type = "knows", dst_type = "person",
               property_name = "creationDate";
 
   auto maybe_property_reader = graphar::AdjListPropertyChunkInfoReader::Make(
-      graph_info, src_label, edge_label, dst_label, property_name,
+      graph_info, src_type, edge_type, dst_type, property_name,
       graphar::AdjListType::ordered_by_source);
   ASSERT(maybe_property_reader.status().ok());
   auto reader = maybe_property_reader.value();

--- a/cpp/examples/mid_level_reader_example.cc
+++ b/cpp/examples/mid_level_reader_example.cc
@@ -89,9 +89,9 @@ void vertex_property_chunk_reader(
 void adj_list_chunk_reader(
     const std::shared_ptr<graphar::GraphInfo>& graph_info) {
   // create reader
-  std::string src_label = "person", edge_label = "knows", dst_label = "person";
+  std::string src_type = "person", edge_type = "knows", dst_type = "person";
   auto maybe_reader = graphar::AdjListArrowChunkReader::Make(
-      graph_info, src_label, edge_label, dst_label,
+      graph_info, src_type, edge_type, dst_type,
       graphar::AdjListType::ordered_by_source);
   ASSERT(maybe_reader.status().ok());
 
@@ -124,10 +124,10 @@ void adj_list_chunk_reader(
 void adj_list_property_chunk_reader(
     const std::shared_ptr<graphar::GraphInfo>& graph_info) {
   // create reader
-  std::string src_label = "person", edge_label = "knows", dst_label = "person",
+  std::string src_type = "person", edge_type = "knows", dst_type = "person",
               property_name = "creationDate";
   auto maybe_reader = graphar::AdjListPropertyArrowChunkReader::Make(
-      graph_info, src_label, edge_label, dst_label, property_name,
+      graph_info, src_type, edge_type, dst_type, property_name,
       graphar::AdjListType::ordered_by_source);
   ASSERT(maybe_reader.status().ok());
   auto reader = maybe_reader.value();
@@ -165,7 +165,7 @@ void adj_list_property_chunk_reader(
   auto filter = graphar::_And(expr1, expr2);
   std::vector<std::string> expected_cols{"creationDate"};
   auto maybe_filter_reader = graphar::AdjListPropertyArrowChunkReader::Make(
-      graph_info, src_label, edge_label, dst_label, property_name,
+      graph_info, src_type, edge_type, dst_type, property_name,
       graphar::AdjListType::ordered_by_source);
   ASSERT(maybe_filter_reader.status().ok());
   auto filter_reader = maybe_filter_reader.value();
@@ -181,9 +181,9 @@ void adj_list_property_chunk_reader(
 void adj_list_offset_chunk_reader(
     const std::shared_ptr<graphar::GraphInfo>& graph_info) {
   // create reader
-  std::string src_label = "person", edge_label = "knows", dst_label = "person";
+  std::string src_type = "person", edge_type = "knows", dst_type = "person";
   auto maybe_reader = graphar::AdjListOffsetArrowChunkReader::Make(
-      graph_info, src_label, edge_label, dst_label,
+      graph_info, src_type, edge_type, dst_type,
       graphar::AdjListType::ordered_by_source);
   ASSERT(maybe_reader.status().ok());
   auto reader = maybe_reader.value();

--- a/cpp/examples/mid_level_writer_example.cc
+++ b/cpp/examples/mid_level_writer_example.cc
@@ -107,7 +107,7 @@ void vertex_property_writer(
       GetTestingResourceRoot() + "/ldbc_sample/parquet/" + "person.vertex.yml";
   auto vertex_meta = graphar::Yaml::LoadFile(vertex_meta_file).value();
   auto vertex_info = graphar::VertexInfo::Load(vertex_meta).value();
-  ASSERT(vertex_info->GetLabel() == "person");
+  ASSERT(vertex_info->GetType() == "person");
 
   auto maybe_writer = graphar::VertexPropertyWriter::Make(vertex_info, "/tmp/");
   ASSERT(maybe_writer.status().ok());

--- a/cpp/examples/pagerank_example.cc
+++ b/cpp/examples/pagerank_example.cc
@@ -43,9 +43,9 @@ int main(int argc, char* argv[]) {
 
   // construct edges collection
   std::string src_type = "person", edge_type = "knows", dst_type = "person";
-  auto maybe_edges = graphar::EdgesCollection::Make(
-      graph_info, src_type, edge_type, dst_type,
-      graphar::AdjListType::ordered_by_source);
+  auto maybe_edges =
+      graphar::EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
+                                     graphar::AdjListType::ordered_by_source);
   ASSERT(!maybe_edges.has_error());
   auto& edges = maybe_edges.value();
 

--- a/cpp/examples/pagerank_example.cc
+++ b/cpp/examples/pagerank_example.cc
@@ -42,9 +42,9 @@ int main(int argc, char* argv[]) {
   std::cout << "num_vertices: " << num_vertices << std::endl;
 
   // construct edges collection
-  std::string src_label = "person", edge_label = "knows", dst_label = "person";
+  std::string src_type = "person", edge_type = "knows", dst_type = "person";
   auto maybe_edges = graphar::EdgesCollection::Make(
-      graph_info, src_label, edge_label, dst_label,
+      graph_info, src_type, edge_type, dst_type,
       graphar::AdjListType::ordered_by_source);
   ASSERT(!maybe_edges.has_error());
   auto& edges = maybe_edges.value();

--- a/cpp/examples/snap_dataset_to_graphar.cc
+++ b/cpp/examples/snap_dataset_to_graphar.cc
@@ -46,10 +46,10 @@ int main(int argc, char* argv[]) {
   auto version = graphar::InfoVersion::Parse("gar/v1").value();
 
   // meta info
-  std::string vertex_label = "node", vertex_prefix = "vertex/node/";
+  std::string type = "node", vertex_prefix = "vertex/node/";
 
   // create vertex info
-  auto vertex_info = graphar::CreateVertexInfo(vertex_label, VERTEX_CHUNK_SIZE,
+  auto vertex_info = graphar::CreateVertexInfo(type, VERTEX_CHUNK_SIZE,
                                                {}, vertex_prefix, version);
 
   // save & dump
@@ -57,7 +57,7 @@ int main(int argc, char* argv[]) {
   ASSERT(vertex_info->Save(save_path + "node.vertex.yml").ok());
 
   /*------------------construct edge info------------------*/
-  std::string src_label = "node", edge_label = "links", dst_label = "node",
+  std::string src_type = "node", edge_type = "links", dst_type = "node",
               edge_prefix = "edge/node_links_node/";
   bool directed = IS_DIRECTED;
 
@@ -66,7 +66,7 @@ int main(int argc, char* argv[]) {
       graphar::CreateAdjacentList(ADJLIST_TYPE, PAYLOAD_TYPE)};
   // create edge info
   auto edge_info = graphar::CreateEdgeInfo(
-      src_label, edge_label, dst_label, EDGE_CHUNK_SIZE, VERTEX_CHUNK_SIZE,
+      src_type, edge_type, dst_type, EDGE_CHUNK_SIZE, VERTEX_CHUNK_SIZE,
       VERTEX_CHUNK_SIZE, directed, adjacent_lists, {}, edge_prefix, version);
 
   // save & dump

--- a/cpp/examples/snap_dataset_to_graphar.cc
+++ b/cpp/examples/snap_dataset_to_graphar.cc
@@ -49,8 +49,8 @@ int main(int argc, char* argv[]) {
   std::string type = "node", vertex_prefix = "vertex/node/";
 
   // create vertex info
-  auto vertex_info = graphar::CreateVertexInfo(type, VERTEX_CHUNK_SIZE,
-                                               {}, vertex_prefix, version);
+  auto vertex_info = graphar::CreateVertexInfo(type, VERTEX_CHUNK_SIZE, {},
+                                               vertex_prefix, version);
 
   // save & dump
   ASSERT(!vertex_info->Dump().has_error());

--- a/cpp/src/graphar/arrow/chunk_reader.cc
+++ b/cpp/src/graphar/arrow/chunk_reader.cc
@@ -732,12 +732,12 @@ Status AdjListPropertyArrowChunkReader::next_chunk() {
   while (chunk_index_ >= chunk_num_) {
     ++vertex_chunk_index_;
     if (vertex_chunk_index_ >= vertex_chunk_num_) {
-      return Status::IndexError(
-          "vertex chunk index ", vertex_chunk_index_,
-          " is out-of-bounds for vertex chunk num ", vertex_chunk_num_,
-          " of edge ", edge_info_->GetEdgeType(), " of adj list type ",
-          AdjListTypeToString(adj_list_type_), ", property group ",
-          property_group_, ".");
+      return Status::IndexError("vertex chunk index ", vertex_chunk_index_,
+                                " is out-of-bounds for vertex chunk num ",
+                                vertex_chunk_num_, " of edge ",
+                                edge_info_->GetEdgeType(), " of adj list type ",
+                                AdjListTypeToString(adj_list_type_),
+                                ", property group ", property_group_, ".");
     }
     chunk_index_ = 0;
     GAR_RETURN_NOT_OK(initOrUpdateEdgeChunkNum());
@@ -814,8 +814,8 @@ AdjListPropertyArrowChunkReader::Make(
   auto property_group = edge_info->GetPropertyGroup(property_name);
   if (!property_group) {
     return Status::KeyError("The property ", property_name,
-                            " doesn't exist in edge ", src_type, " ",
-                            edge_type, " ", dst_type, ".");
+                            " doesn't exist in edge ", src_type, " ", edge_type,
+                            " ", dst_type, ".");
   }
   return Make(edge_info, property_group, adj_list_type, graph_info->GetPrefix(),
               options);

--- a/cpp/src/graphar/arrow/chunk_reader.h
+++ b/cpp/src/graphar/arrow/chunk_reader.h
@@ -240,15 +240,15 @@ class AdjListArrowChunkReader {
    * @brief Create an AdjListArrowChunkReader instance from graph info.
    *
    * @param graph_info The graph info.
-   * @param src_label The source vertex label.
-   * @param edge_label The edge label.
-   * @param dst_label The destination vertex label.
+   * @param src_type The source vertex label.
+   * @param edge_type The edge label.
+   * @param dst_type The destination vertex label.
    * @param adj_list_type The adj list type for the edges.
    */
   static Result<std::shared_ptr<AdjListArrowChunkReader>> Make(
       const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_label, const std::string& edge_label,
-      const std::string& dst_label, AdjListType adj_list_type);
+      const std::string& src_type, const std::string& edge_type,
+      const std::string& dst_type, AdjListType adj_list_type);
 
  private:
   Status initOrUpdateEdgeChunkNum();
@@ -326,15 +326,15 @@ class AdjListOffsetArrowChunkReader {
    * @brief Create an AdjListOffsetArrowChunkReader instance from graph info.
    *
    * @param graph_info The graph info.
-   * @param src_label The source vertex label.
-   * @param edge_label The edge label.
-   * @param dst_label The destination vertex label.
+   * @param src_type The source vertex label.
+   * @param edge_type The edge label.
+   * @param dst_type The destination vertex label.
    * @param adj_list_type The adj list type for the edges.
    */
   static Result<std::shared_ptr<AdjListOffsetArrowChunkReader>> Make(
       const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_label, const std::string& edge_label,
-      const std::string& dst_label, AdjListType adj_list_type);
+      const std::string& src_type, const std::string& edge_type,
+      const std::string& dst_type, AdjListType adj_list_type);
 
  private:
   std::shared_ptr<EdgeInfo> edge_info_;
@@ -458,9 +458,9 @@ class AdjListPropertyArrowChunkReader {
    * and property group.
    *
    * @param graph_info The graph info that describes the graph.
-   * @param src_label The source vertex label.
-   * @param edge_label The edge label.
-   * @param dst_label The destination vertex label.
+   * @param src_type The source vertex label.
+   * @param edge_type The edge label.
+   * @param dst_type The destination vertex label.
    * @param property_group The property group that describes the property
    * group.
    * @param adj_list_type The adj list type for the edges.
@@ -468,8 +468,8 @@ class AdjListPropertyArrowChunkReader {
    */
   static Result<std::shared_ptr<AdjListPropertyArrowChunkReader>> Make(
       const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_label, const std::string& edge_label,
-      const std::string& dst_label,
+      const std::string& src_type, const std::string& edge_type,
+      const std::string& dst_type,
       const std::shared_ptr<PropertyGroup>& property_group,
       AdjListType adj_list_type, const util::FilterOptions& options = {});
 
@@ -478,9 +478,9 @@ class AdjListPropertyArrowChunkReader {
    * and property name.
    *
    * @param graph_info The graph info that describes the graph.
-   * @param src_label The source vertex label.
-   * @param edge_label The edge label.
-   * @param dst_label The destination vertex label.
+   * @param src_type The source vertex label.
+   * @param edge_type The edge label.
+   * @param dst_type The destination vertex label.
    * @param property_name The name of one property in the property group you
    * want to read.
    * @param adj_list_type The adj list type for the edges.
@@ -488,8 +488,8 @@ class AdjListPropertyArrowChunkReader {
    */
   static Result<std::shared_ptr<AdjListPropertyArrowChunkReader>> Make(
       const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_label, const std::string& edge_label,
-      const std::string& dst_label, const std::string& property_name,
+      const std::string& src_type, const std::string& edge_type,
+      const std::string& dst_type, const std::string& property_name,
       AdjListType adj_list_type, const util::FilterOptions& options = {});
 
  private:

--- a/cpp/src/graphar/arrow/chunk_reader.h
+++ b/cpp/src/graphar/arrow/chunk_reader.h
@@ -246,9 +246,9 @@ class AdjListArrowChunkReader {
    * @param adj_list_type The adj list type for the edges.
    */
   static Result<std::shared_ptr<AdjListArrowChunkReader>> Make(
-      const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_type, const std::string& edge_type,
-      const std::string& dst_type, AdjListType adj_list_type);
+      const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+      const std::string& edge_type, const std::string& dst_type,
+      AdjListType adj_list_type);
 
  private:
   Status initOrUpdateEdgeChunkNum();
@@ -332,9 +332,9 @@ class AdjListOffsetArrowChunkReader {
    * @param adj_list_type The adj list type for the edges.
    */
   static Result<std::shared_ptr<AdjListOffsetArrowChunkReader>> Make(
-      const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_type, const std::string& edge_type,
-      const std::string& dst_type, AdjListType adj_list_type);
+      const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+      const std::string& edge_type, const std::string& dst_type,
+      AdjListType adj_list_type);
 
  private:
   std::shared_ptr<EdgeInfo> edge_info_;
@@ -467,9 +467,8 @@ class AdjListPropertyArrowChunkReader {
    * @param options The filter options, default is empty.
    */
   static Result<std::shared_ptr<AdjListPropertyArrowChunkReader>> Make(
-      const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_type, const std::string& edge_type,
-      const std::string& dst_type,
+      const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+      const std::string& edge_type, const std::string& dst_type,
       const std::shared_ptr<PropertyGroup>& property_group,
       AdjListType adj_list_type, const util::FilterOptions& options = {});
 
@@ -487,10 +486,10 @@ class AdjListPropertyArrowChunkReader {
    * @param options The filter options, default is empty.
    */
   static Result<std::shared_ptr<AdjListPropertyArrowChunkReader>> Make(
-      const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_type, const std::string& edge_type,
-      const std::string& dst_type, const std::string& property_name,
-      AdjListType adj_list_type, const util::FilterOptions& options = {});
+      const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+      const std::string& edge_type, const std::string& dst_type,
+      const std::string& property_name, AdjListType adj_list_type,
+      const util::FilterOptions& options = {});
 
  private:
   Status initOrUpdateEdgeChunkNum();

--- a/cpp/src/graphar/arrow/chunk_writer.cc
+++ b/cpp/src/graphar/arrow/chunk_writer.cc
@@ -142,7 +142,7 @@ Status VertexPropertyWriter::validate(
   // weak & strong validate
   if (!vertex_info_->HasPropertyGroup(property_group)) {
     return Status::KeyError("The property group", " does not exist in ",
-                            vertex_info_->GetLabel(), " vertex info.");
+                            vertex_info_->GetType(), " vertex info.");
   }
   if (chunk_index < 0) {
     return Status::IndexError("Negative chunk index ", chunk_index, ".");
@@ -227,7 +227,7 @@ Status VertexPropertyWriter::WriteChunk(
     if (indice == -1) {
       return Status::Invalid("Column named ", property.name,
                              " of property group ", property_group,
-                             " of vertex ", vertex_info_->GetLabel(),
+                             " of vertex ", vertex_info_->GetType(),
                              " does not exist in the input table.");
     }
     indices.push_back(indice);
@@ -374,7 +374,7 @@ Status EdgeChunkWriter::validate(IdType count_or_index1, IdType count_or_index2,
   if (!edge_info_->HasAdjacentListType(adj_list_type_)) {
     return Status::KeyError(
         "Adj list type ", AdjListTypeToString(adj_list_type_),
-        " does not exist in the ", edge_info_->GetEdgeLabel(), " edge info.");
+        " does not exist in the ", edge_info_->GetEdgeType(), " edge info.");
   }
   // weak & strong validate for count or index
   if (count_or_index1 < 0 || count_or_index2 < 0) {
@@ -401,7 +401,7 @@ Status EdgeChunkWriter::validate(
   // weak & strong validate for property group
   if (!edge_info_->HasPropertyGroup(property_group)) {
     return Status::KeyError("Property group", " does not exist in the ",
-                            edge_info_->GetEdgeLabel(), " edge info.");
+                            edge_info_->GetEdgeType(), " edge info.");
   }
   return Status::OK();
 }
@@ -477,7 +477,7 @@ Status EdgeChunkWriter::validate(
   if (input_table->num_rows() > edge_info_->GetChunkSize()) {
     return Status::Invalid(
         "The number of rows of input table is ", input_table->num_rows(),
-        " which is larger than the ", edge_info_->GetEdgeLabel(),
+        " which is larger than the ", edge_info_->GetEdgeType(),
         " edge chunk size ", edge_info_->GetChunkSize(), ".");
   }
   // strong validate for the input table
@@ -531,7 +531,7 @@ Status EdgeChunkWriter::validate(
   if (input_table->num_rows() > edge_info_->GetChunkSize()) {
     return Status::Invalid(
         "The number of rows of input table is ", input_table->num_rows(),
-        " which is larger than the ", edge_info_->GetEdgeLabel(),
+        " which is larger than the ", edge_info_->GetEdgeType(),
         " edge chunk size ", edge_info_->GetChunkSize(), ".");
   }
   // strong validate for the input table
@@ -646,7 +646,7 @@ Status EdgeChunkWriter::WritePropertyChunk(
     if (indice == -1) {
       return Status::Invalid("Column named ", property.name,
                              " of property group ", property_group, " of edge ",
-                             edge_info_->GetEdgeLabel(),
+                             edge_info_->GetEdgeType(),
                              " does not exist in the input table.");
     }
     indices.push_back(indice);
@@ -884,20 +884,20 @@ Result<std::shared_ptr<EdgeChunkWriter>> EdgeChunkWriter::Make(
   if (!edge_info->HasAdjacentListType(adj_list_type)) {
     return Status::KeyError(
         "The adjacent list type ", AdjListTypeToString(adj_list_type),
-        " doesn't exist in edge ", edge_info->GetEdgeLabel(), ".");
+        " doesn't exist in edge ", edge_info->GetEdgeType(), ".");
   }
   return std::make_shared<EdgeChunkWriter>(edge_info, prefix, adj_list_type,
                                            validate_level);
 }
 
 Result<std::shared_ptr<EdgeChunkWriter>> EdgeChunkWriter::Make(
-    const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_label,
-    const std::string& edge_label, const std::string& dst_label,
+    const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+    const std::string& edge_type, const std::string& dst_type,
     AdjListType adj_list_type, const ValidateLevel& validate_level) {
-  auto edge_info = graph_info->GetEdgeInfo(src_label, edge_label, dst_label);
+  auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
   if (!edge_info) {
-    return Status::KeyError("The edge ", src_label, " ", edge_label, " ",
-                            dst_label, " doesn't exist.");
+    return Status::KeyError("The edge ", src_type, " ", edge_type, " ",
+                            dst_type, " doesn't exist.");
   }
   return Make(edge_info, graph_info->GetPrefix(), adj_list_type,
               validate_level);

--- a/cpp/src/graphar/arrow/chunk_writer.h
+++ b/cpp/src/graphar/arrow/chunk_writer.h
@@ -557,9 +557,9 @@ class EdgeChunkWriter {
    * no_validate.
    */
   static Result<std::shared_ptr<EdgeChunkWriter>> Make(
-      const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_type, const std::string& edge_type,
-      const std::string& dst_type, AdjListType adj_list_type,
+      const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+      const std::string& edge_type, const std::string& dst_type,
+      AdjListType adj_list_type,
       const ValidateLevel& validate_level = ValidateLevel::no_validate);
 
  private:

--- a/cpp/src/graphar/arrow/chunk_writer.h
+++ b/cpp/src/graphar/arrow/chunk_writer.h
@@ -549,17 +549,17 @@ class EdgeChunkWriter {
    * @brief Construct an EdgeChunkWriter from graph info and edge label.
    *
    * @param graph_info The graph info that describes the graph.
-   * @param src_label The source vertex label.
-   * @param edge_label The edge label.
-   * @param dst_label The destination vertex label.
+   * @param src_type The source vertex label.
+   * @param edge_type The edge label.
+   * @param dst_type The destination vertex label.
    * @param adj_list_type The adj list type for the edges.
    * @param validate_level The global validate level for the writer, default is
    * no_validate.
    */
   static Result<std::shared_ptr<EdgeChunkWriter>> Make(
       const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_label, const std::string& edge_label,
-      const std::string& dst_label, AdjListType adj_list_type,
+      const std::string& src_type, const std::string& edge_type,
+      const std::string& dst_type, AdjListType adj_list_type,
       const ValidateLevel& validate_level = ValidateLevel::no_validate);
 
  private:

--- a/cpp/src/graphar/chunk_info_reader.cc
+++ b/cpp/src/graphar/chunk_info_reader.cc
@@ -54,7 +54,7 @@ Status VertexPropertyChunkInfoReader::seek(IdType id) {
   if (chunk_index_ >= chunk_num_) {
     return Status::IndexError("Internal vertex id ", id, " is out of range [0,",
                               chunk_num_ * vertex_info_->GetChunkSize(),
-                              ") of vertex ", vertex_info_->GetLabel());
+                              ") of vertex ", vertex_info_->GetType());
   }
   return Status::OK();
 }
@@ -69,7 +69,7 @@ Status VertexPropertyChunkInfoReader::next_chunk() {
   if (++chunk_index_ >= chunk_num_) {
     return Status::IndexError(
         "vertex chunk index ", chunk_index_, " is out-of-bounds for vertex ",
-        vertex_info_->GetLabel(), " chunk num ", chunk_num_);
+        vertex_info_->GetType(), " chunk num ", chunk_num_);
   }
   return Status::OK();
 }
@@ -134,7 +134,7 @@ Status AdjListChunkInfoReader::seek_src(IdType id) {
   if (adj_list_type_ != AdjListType::unordered_by_source &&
       adj_list_type_ != AdjListType::ordered_by_source) {
     return Status::Invalid("The seek_src operation is invalid in edge ",
-                           edge_info_->GetEdgeLabel(), " reader with ",
+                           edge_info_->GetEdgeType(), " reader with ",
                            AdjListTypeToString(adj_list_type_), " type.");
   }
 
@@ -143,7 +143,7 @@ Status AdjListChunkInfoReader::seek_src(IdType id) {
     return Status::IndexError(
         "The source internal id ", id, " is out of range [0,",
         edge_info_->GetSrcChunkSize() * vertex_chunk_num_, ") of edge ",
-        edge_info_->GetEdgeLabel(), " reader.");
+        edge_info_->GetEdgeType(), " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -167,7 +167,7 @@ Status AdjListChunkInfoReader::seek_dst(IdType id) {
   if (adj_list_type_ != AdjListType::unordered_by_dest &&
       adj_list_type_ != AdjListType::ordered_by_dest) {
     return Status::Invalid("The seek_dst operation is invalid in edge ",
-                           edge_info_->GetEdgeLabel(), " reader with ",
+                           edge_info_->GetEdgeType(), " reader with ",
                            AdjListTypeToString(adj_list_type_), " type.");
   }
 
@@ -176,7 +176,7 @@ Status AdjListChunkInfoReader::seek_dst(IdType id) {
     return Status::IndexError(
         "The destination internal id ", id, " is out of range [0,",
         edge_info_->GetDstChunkSize() * vertex_chunk_num_, ") of edge ",
-        edge_info_->GetEdgeLabel(), " reader.");
+        edge_info_->GetEdgeType(), " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -200,7 +200,7 @@ Status AdjListChunkInfoReader::seek(IdType index) {
   if (chunk_index_ >= chunk_num_) {
     return Status::IndexError("The edge offset ", index, " is out of range [0,",
                               edge_info_->GetChunkSize() * chunk_num_,
-                              "), edge type: ", edge_info_->GetEdgeLabel());
+                              "), edge type: ", edge_info_->GetEdgeType());
   }
   return Status::OK();
 }
@@ -235,20 +235,20 @@ Result<std::shared_ptr<AdjListChunkInfoReader>> AdjListChunkInfoReader::Make(
   if (!edge_info->HasAdjacentListType(adj_list_type)) {
     return Status::KeyError(
         "The adjacent list type ", AdjListTypeToString(adj_list_type),
-        " doesn't exist in edge ", edge_info->GetEdgeLabel(), ".");
+        " doesn't exist in edge ", edge_info->GetEdgeType(), ".");
   }
   return std::make_shared<AdjListChunkInfoReader>(edge_info, adj_list_type,
                                                   prefix);
 }
 
 Result<std::shared_ptr<AdjListChunkInfoReader>> AdjListChunkInfoReader::Make(
-    const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_label,
-    const std::string& edge_label, const std::string& dst_label,
+    const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+    const std::string& edge_type, const std::string& dst_type,
     AdjListType adj_list_type) {
-  auto edge_info = graph_info->GetEdgeInfo(src_label, edge_label, dst_label);
+  auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
   if (!edge_info) {
-    return Status::KeyError("The edge ", src_label, " ", edge_label, " ",
-                            dst_label, " doesn't exist.");
+    return Status::KeyError("The edge ", src_type, " ", edge_type, " ",
+                            dst_type, " doesn't exist.");
   }
   return Make(edge_info, adj_list_type, graph_info->GetPrefix());
 }
@@ -315,7 +315,7 @@ AdjListOffsetChunkInfoReader::Make(const std::shared_ptr<EdgeInfo>& edge_info,
   if (!edge_info->HasAdjacentListType(adj_list_type)) {
     return Status::KeyError(
         "The adjacent list type ", AdjListTypeToString(adj_list_type),
-        " doesn't exist in edge ", edge_info->GetEdgeLabel(), ".");
+        " doesn't exist in edge ", edge_info->GetEdgeType(), ".");
   }
   return std::make_shared<AdjListOffsetChunkInfoReader>(edge_info,
                                                         adj_list_type, prefix);
@@ -323,14 +323,14 @@ AdjListOffsetChunkInfoReader::Make(const std::shared_ptr<EdgeInfo>& edge_info,
 
 Result<std::shared_ptr<AdjListOffsetChunkInfoReader>>
 AdjListOffsetChunkInfoReader::Make(const std::shared_ptr<GraphInfo>& graph_info,
-                                   const std::string& src_label,
-                                   const std::string& edge_label,
-                                   const std::string& dst_label,
+                                   const std::string& src_type,
+                                   const std::string& edge_type,
+                                   const std::string& dst_type,
                                    AdjListType adj_list_type) {
-  auto edge_info = graph_info->GetEdgeInfo(src_label, edge_label, dst_label);
+  auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
   if (!edge_info) {
-    return Status::KeyError("The edge ", src_label, " ", edge_label, " ",
-                            dst_label, " doesn't exist.");
+    return Status::KeyError("The edge ", src_type, " ", edge_type, " ",
+                            dst_type, " doesn't exist.");
   }
   return Make(edge_info, adj_list_type, graph_info->GetPrefix());
 }
@@ -362,7 +362,7 @@ Status AdjListPropertyChunkInfoReader::seek_src(IdType id) {
   if (adj_list_type_ != AdjListType::unordered_by_source &&
       adj_list_type_ != AdjListType::ordered_by_source) {
     return Status::Invalid("The seek_src operation is invalid in edge ",
-                           edge_info_->GetEdgeLabel(), " reader with ",
+                           edge_info_->GetEdgeType(), " reader with ",
                            AdjListTypeToString(adj_list_type_), " type.");
   }
 
@@ -371,7 +371,7 @@ Status AdjListPropertyChunkInfoReader::seek_src(IdType id) {
     return Status::IndexError(
         "The source internal id ", id, " is out of range [0,",
         edge_info_->GetSrcChunkSize() * vertex_chunk_num_, ") of edge ",
-        edge_info_->GetEdgeLabel(), " reader.");
+        edge_info_->GetEdgeType(), " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -394,7 +394,7 @@ Status AdjListPropertyChunkInfoReader::seek_dst(IdType id) {
   if (adj_list_type_ != AdjListType::unordered_by_dest &&
       adj_list_type_ != AdjListType::ordered_by_dest) {
     return Status::Invalid("The seek_dst operation is invalid in edge ",
-                           edge_info_->GetEdgeLabel(), " reader with ",
+                           edge_info_->GetEdgeType(), " reader with ",
                            AdjListTypeToString(adj_list_type_), " type.");
   }
 
@@ -403,7 +403,7 @@ Status AdjListPropertyChunkInfoReader::seek_dst(IdType id) {
     return Status::IndexError(
         "The destination internal id ", id, " is out of range [0,",
         edge_info_->GetDstChunkSize() * vertex_chunk_num_, ") of edge ",
-        edge_info_->GetEdgeLabel(), " reader.");
+        edge_info_->GetEdgeType(), " reader.");
   }
   if (vertex_chunk_index_ != new_vertex_chunk_index) {
     vertex_chunk_index_ = new_vertex_chunk_index;
@@ -428,7 +428,7 @@ Status AdjListPropertyChunkInfoReader::seek(IdType offset) {
     return Status::IndexError("The edge offset ", offset,
                               " is out of range [0,",
                               edge_info_->GetChunkSize() * chunk_num_,
-                              "), edge label: ", edge_info_->GetEdgeLabel());
+                              "), edge label: ", edge_info_->GetEdgeType());
   }
   return Status::OK();
 }
@@ -449,7 +449,7 @@ Status AdjListPropertyChunkInfoReader::next_chunk() {
       return Status::IndexError(
           "vertex chunk index ", vertex_chunk_index_,
           " is out-of-bounds for vertex chunk num ", vertex_chunk_num_,
-          " of edge ", edge_info_->GetEdgeLabel(), " of adj list type ",
+          " of edge ", edge_info_->GetEdgeType(), " of adj list type ",
           AdjListTypeToString(adj_list_type_), ", property group ",
           property_group_, ".");
     }
@@ -469,7 +469,7 @@ AdjListPropertyChunkInfoReader::Make(
   if (!edge_info->HasAdjacentListType(adj_list_type)) {
     return Status::KeyError(
         "The adjacent list type ", AdjListTypeToString(adj_list_type),
-        " doesn't exist in edge ", edge_info->GetEdgeLabel(), ".");
+        " doesn't exist in edge ", edge_info->GetEdgeType(), ".");
   }
   return std::make_shared<AdjListPropertyChunkInfoReader>(
       edge_info, property_group, adj_list_type, prefix);
@@ -477,14 +477,14 @@ AdjListPropertyChunkInfoReader::Make(
 
 Result<std::shared_ptr<AdjListPropertyChunkInfoReader>>
 AdjListPropertyChunkInfoReader::Make(
-    const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_label,
-    const std::string& edge_label, const std::string& dst_label,
+    const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+    const std::string& edge_type, const std::string& dst_type,
     const std::shared_ptr<PropertyGroup>& property_group,
     AdjListType adj_list_type) {
-  auto edge_info = graph_info->GetEdgeInfo(src_label, edge_label, dst_label);
+  auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
   if (!edge_info) {
-    return Status::KeyError("The edge ", src_label, " ", edge_label, " ",
-                            dst_label, " doesn't exist.");
+    return Status::KeyError("The edge ", src_type, " ", edge_type, " ",
+                            dst_type, " doesn't exist.");
   }
   return Make(edge_info, property_group, adj_list_type,
               graph_info->GetPrefix());
@@ -492,19 +492,19 @@ AdjListPropertyChunkInfoReader::Make(
 
 Result<std::shared_ptr<AdjListPropertyChunkInfoReader>>
 AdjListPropertyChunkInfoReader::Make(
-    const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_label,
-    const std::string& edge_label, const std::string& dst_label,
+    const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+    const std::string& edge_type, const std::string& dst_type,
     const std::string& property_name, AdjListType adj_list_type) {
-  auto edge_info = graph_info->GetEdgeInfo(src_label, edge_label, dst_label);
+  auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
   if (!edge_info) {
-    return Status::KeyError("The edge ", src_label, " ", edge_label, " ",
-                            dst_label, " doesn't exist.");
+    return Status::KeyError("The edge ", src_type, " ", edge_type, " ",
+                            dst_type, " doesn't exist.");
   }
   auto property_group = edge_info->GetPropertyGroup(property_name);
   if (!property_group) {
     return Status::KeyError("The property ", property_name,
-                            " doesn't exist in edge ", src_label, " ",
-                            edge_label, " ", dst_label, ".");
+                            " doesn't exist in edge ", src_type, " ",
+                            edge_type, " ", dst_type, ".");
   }
   return Make(edge_info, property_group, adj_list_type,
               graph_info->GetPrefix());

--- a/cpp/src/graphar/chunk_info_reader.cc
+++ b/cpp/src/graphar/chunk_info_reader.cc
@@ -446,12 +446,12 @@ Status AdjListPropertyChunkInfoReader::next_chunk() {
   while (chunk_index_ >= chunk_num_) {
     ++vertex_chunk_index_;
     if (vertex_chunk_index_ >= vertex_chunk_num_) {
-      return Status::IndexError(
-          "vertex chunk index ", vertex_chunk_index_,
-          " is out-of-bounds for vertex chunk num ", vertex_chunk_num_,
-          " of edge ", edge_info_->GetEdgeType(), " of adj list type ",
-          AdjListTypeToString(adj_list_type_), ", property group ",
-          property_group_, ".");
+      return Status::IndexError("vertex chunk index ", vertex_chunk_index_,
+                                " is out-of-bounds for vertex chunk num ",
+                                vertex_chunk_num_, " of edge ",
+                                edge_info_->GetEdgeType(), " of adj list type ",
+                                AdjListTypeToString(adj_list_type_),
+                                ", property group ", property_group_, ".");
     }
     chunk_index_ = 0;
     GAR_ASSIGN_OR_RAISE_ERROR(
@@ -503,8 +503,8 @@ AdjListPropertyChunkInfoReader::Make(
   auto property_group = edge_info->GetPropertyGroup(property_name);
   if (!property_group) {
     return Status::KeyError("The property ", property_name,
-                            " doesn't exist in edge ", src_type, " ",
-                            edge_type, " ", dst_type, ".");
+                            " doesn't exist in edge ", src_type, " ", edge_type,
+                            " ", dst_type, ".");
   }
   return Make(edge_info, property_group, adj_list_type,
               graph_info->GetPrefix());

--- a/cpp/src/graphar/chunk_info_reader.h
+++ b/cpp/src/graphar/chunk_info_reader.h
@@ -188,9 +188,9 @@ class AdjListChunkInfoReader {
    * @param adj_list_type The adj list type for the edges.
    */
   static Result<std::shared_ptr<AdjListChunkInfoReader>> Make(
-      const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_type, const std::string& edge_type,
-      const std::string& dst_type, AdjListType adj_list_type);
+      const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+      const std::string& edge_type, const std::string& dst_type,
+      AdjListType adj_list_type);
 
  private:
   std::shared_ptr<EdgeInfo> edge_info_;
@@ -261,9 +261,9 @@ class AdjListOffsetChunkInfoReader {
    * @param adj_list_type The adj list type for the edges.
    */
   static Result<std::shared_ptr<AdjListOffsetChunkInfoReader>> Make(
-      const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_type, const std::string& edge_type,
-      const std::string& dst_type, AdjListType adj_list_type);
+      const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+      const std::string& edge_type, const std::string& dst_type,
+      AdjListType adj_list_type);
 
  private:
   std::shared_ptr<EdgeInfo> edge_info_;
@@ -351,9 +351,8 @@ class AdjListPropertyChunkInfoReader {
    * @param adj_list_type The adj list type for the edge.
    */
   static Result<std::shared_ptr<AdjListPropertyChunkInfoReader>> Make(
-      const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_type, const std::string& edge_type,
-      const std::string& dst_type,
+      const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+      const std::string& edge_type, const std::string& dst_type,
       const std::shared_ptr<PropertyGroup>& property_group,
       AdjListType adj_list_type);
 
@@ -370,10 +369,9 @@ class AdjListPropertyChunkInfoReader {
    * @param adj_list_type The adj list type for the edge.
    */
   static Result<std::shared_ptr<AdjListPropertyChunkInfoReader>> Make(
-      const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_type, const std::string& edge_type,
-      const std::string& dst_type, const std::string& property_name,
-      AdjListType adj_list_type);
+      const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+      const std::string& edge_type, const std::string& dst_type,
+      const std::string& property_name, AdjListType adj_list_type);
 
  private:
   std::shared_ptr<EdgeInfo> edge_info_;

--- a/cpp/src/graphar/chunk_info_reader.h
+++ b/cpp/src/graphar/chunk_info_reader.h
@@ -182,15 +182,15 @@ class AdjListChunkInfoReader {
    * @brief Create an AdjListChunkInfoReader instance from graph info.
    *
    * @param graph_info The graph info.
-   * @param src_label The source vertex label.
-   * @param edge_label The edge label.
-   * @param dst_label The destination vertex label.
+   * @param src_type The source vertex label.
+   * @param edge_type The edge label.
+   * @param dst_type The destination vertex label.
    * @param adj_list_type The adj list type for the edges.
    */
   static Result<std::shared_ptr<AdjListChunkInfoReader>> Make(
       const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_label, const std::string& edge_label,
-      const std::string& dst_label, AdjListType adj_list_type);
+      const std::string& src_type, const std::string& edge_type,
+      const std::string& dst_type, AdjListType adj_list_type);
 
  private:
   std::shared_ptr<EdgeInfo> edge_info_;
@@ -255,15 +255,15 @@ class AdjListOffsetChunkInfoReader {
    * @brief Create an AdjListOffsetChunkInfoReader instance from graph info.
    *
    * @param graph_info The graph info.
-   * @param src_label The source vertex label.
-   * @param edge_label The edge label.
-   * @param dst_label The destination vertex label.
+   * @param src_type The source vertex label.
+   * @param edge_type The edge label.
+   * @param dst_type The destination vertex label.
    * @param adj_list_type The adj list type for the edges.
    */
   static Result<std::shared_ptr<AdjListOffsetChunkInfoReader>> Make(
       const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_label, const std::string& edge_label,
-      const std::string& dst_label, AdjListType adj_list_type);
+      const std::string& src_type, const std::string& edge_type,
+      const std::string& dst_type, AdjListType adj_list_type);
 
  private:
   std::shared_ptr<EdgeInfo> edge_info_;
@@ -344,16 +344,16 @@ class AdjListPropertyChunkInfoReader {
    * and property group.
    *
    * @param graph_info The graph info.
-   * @param src_label The source vertex label.
-   * @param edge_label The edge label.
-   * @param dst_label The destination vertex label.
+   * @param src_type The source vertex label.
+   * @param edge_type The edge label.
+   * @param dst_type The destination vertex label.
    * @param property_group The property group of the edge property.
    * @param adj_list_type The adj list type for the edge.
    */
   static Result<std::shared_ptr<AdjListPropertyChunkInfoReader>> Make(
       const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_label, const std::string& edge_label,
-      const std::string& dst_label,
+      const std::string& src_type, const std::string& edge_type,
+      const std::string& dst_type,
       const std::shared_ptr<PropertyGroup>& property_group,
       AdjListType adj_list_type);
 
@@ -362,17 +362,17 @@ class AdjListPropertyChunkInfoReader {
    * and property name.
    *
    * @param graph_info The graph info.
-   * @param src_label The source vertex label.
-   * @param edge_label The edge label.
-   * @param dst_label The destination vertex label.
+   * @param src_type The source vertex label.
+   * @param edge_type The edge label.
+   * @param dst_type The destination vertex label.
    * @param property_name The name of one property in the property group you
    * want to read.
    * @param adj_list_type The adj list type for the edge.
    */
   static Result<std::shared_ptr<AdjListPropertyChunkInfoReader>> Make(
       const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_label, const std::string& edge_label,
-      const std::string& dst_label, const std::string& property_name,
+      const std::string& src_type, const std::string& edge_type,
+      const std::string& dst_type, const std::string& property_name,
       AdjListType adj_list_type);
 
  private:

--- a/cpp/src/graphar/chunk_info_writer.cc
+++ b/cpp/src/graphar/chunk_info_writer.cc
@@ -53,7 +53,7 @@ Status VertexChunkInfoWriter::validate(
   // weak & strong validate
   if (!vertex_info_->HasPropertyGroup(property_group)) {
     return Status::KeyError("The property group", " does not exist in ",
-                            vertex_info_->GetLabel(), " vertex info.");
+                            vertex_info_->GetType(), " vertex info.");
   }
   if (chunk_index < 0) {
     return Status::IndexError("Negative chunk index ", chunk_index, ".");
@@ -117,7 +117,7 @@ Status EdgeChunkInfoWriter::validate(IdType count_or_index1,
   if (!edge_info_->HasAdjacentListType(adj_list_type_)) {
     return Status::KeyError(
         "Adj list type ", AdjListTypeToString(adj_list_type_),
-        " does not exist in the ", edge_info_->GetEdgeLabel(), " edge info.");
+        " does not exist in the ", edge_info_->GetEdgeType(), " edge info.");
   }
   // weak & strong validate for count or index
   if (count_or_index1 < 0 || count_or_index2 < 0) {
@@ -144,7 +144,7 @@ Status EdgeChunkInfoWriter::validate(
   // weak & strong validate for property group
   if (!edge_info_->HasPropertyGroup(property_group)) {
     return Status::KeyError("Property group", " does not exist in the ",
-                            edge_info_->GetEdgeLabel(), " edge info.");
+                            edge_info_->GetEdgeType(), " edge info.");
   }
   return Status::OK();
 }

--- a/cpp/src/graphar/fwd.h
+++ b/cpp/src/graphar/fwd.h
@@ -139,9 +139,9 @@ std::shared_ptr<VertexInfo> CreateVertexInfo(
 /**
  * @brief Create an EdgeInfo instance
  *
- * @param src_label The label of the source vertex.
- * @param edge_label The label of the edge
- * @param dst_label The label of the destination vertex
+ * @param src_type The label of the source vertex.
+ * @param edge_type The label of the edge
+ * @param dst_type The label of the destination vertex
  * @param chunk_size The number of edges in each edge chunk
  * @param src_chunk_size The number of source vertices in each vertex chunk
  * @param dst_chunk_size The number of destination vertices in each vertex
@@ -154,8 +154,8 @@ std::shared_ptr<VertexInfo> CreateVertexInfo(
  * @return edge_info shared_ptr to EdgeInfo
  */
 std::shared_ptr<EdgeInfo> CreateEdgeInfo(
-    const std::string& src_label, const std::string& edge_label,
-    const std::string& dst_label, IdType chunk_size, IdType src_chunk_size,
+    const std::string& src_type, const std::string& edge_type,
+    const std::string& dst_type, IdType chunk_size, IdType src_chunk_size,
     IdType dst_chunk_size, bool directed,
     const AdjacentListVector& adjacent_lists,
     const PropertyGroupVector& property_groups, const std::string& prefix = "",

--- a/cpp/src/graphar/graph_info.cc
+++ b/cpp/src/graphar/graph_info.cc
@@ -380,8 +380,8 @@ std::shared_ptr<VertexInfo> CreateVertexInfo(
   if (type.empty() || chunk_size <= 0) {
     return nullptr;
   }
-  return std::make_shared<VertexInfo>(type, chunk_size, property_groups,
-                                      prefix, version);
+  return std::make_shared<VertexInfo>(type, chunk_size, property_groups, prefix,
+                                      version);
 }
 
 Result<std::shared_ptr<VertexInfo>> VertexInfo::Load(
@@ -430,8 +430,8 @@ Result<std::shared_ptr<VertexInfo>> VertexInfo::Load(
           std::make_shared<PropertyGroup>(property_vec, file_type, pg_prefix));
     }
   }
-  return std::make_shared<VertexInfo>(type, chunk_size, property_groups,
-                                      prefix, version);
+  return std::make_shared<VertexInfo>(type, chunk_size, property_groups, prefix,
+                                      version);
 }
 
 Result<std::shared_ptr<VertexInfo>> VertexInfo::Load(const std::string& input) {
@@ -504,8 +504,8 @@ class EdgeInfo::Impl {
         property_groups_(std::move(property_groups)),
         version_(std::move(version)) {
     if (prefix_.empty()) {
-      prefix_ = src_type_ + REGULAR_SEPARATOR + edge_type_ +
-                REGULAR_SEPARATOR + dst_type_ + "/";  // default prefix
+      prefix_ = src_type_ + REGULAR_SEPARATOR + edge_type_ + REGULAR_SEPARATOR +
+                dst_type_ + "/";  // default prefix
     }
     for (size_t i = 0; i < adjacent_lists_.size(); i++) {
       if (!adjacent_lists_[i]) {
@@ -590,9 +590,9 @@ EdgeInfo::EdgeInfo(const std::string& src_type, const std::string& edge_type,
                    const PropertyGroupVector& property_groups,
                    const std::string& prefix,
                    std::shared_ptr<const InfoVersion> version)
-    : impl_(new Impl(src_type, edge_type, dst_type, chunk_size,
-                     src_chunk_size, dst_chunk_size, directed, prefix,
-                     adjacent_lists, property_groups, version)) {}
+    : impl_(new Impl(src_type, edge_type, dst_type, chunk_size, src_chunk_size,
+                     dst_chunk_size, directed, prefix, adjacent_lists,
+                     property_groups, version)) {}
 
 EdgeInfo::~EdgeInfo() = default;
 
@@ -782,9 +782,9 @@ Result<std::shared_ptr<EdgeInfo>> EdgeInfo::AddAdjacentList(
                            AdjListTypeToString(adj_list->GetType()));
   }
   return std::make_shared<EdgeInfo>(
-      impl_->src_type_, impl_->edge_type_, impl_->dst_type_,
-      impl_->chunk_size_, impl_->src_chunk_size_, impl_->dst_chunk_size_,
-      impl_->directed_, AddVectorElement(impl_->adjacent_lists_, adj_list),
+      impl_->src_type_, impl_->edge_type_, impl_->dst_type_, impl_->chunk_size_,
+      impl_->src_chunk_size_, impl_->dst_chunk_size_, impl_->directed_,
+      AddVectorElement(impl_->adjacent_lists_, adj_list),
       impl_->property_groups_, impl_->prefix_, impl_->version_);
 }
 
@@ -800,9 +800,9 @@ Result<std::shared_ptr<EdgeInfo>> EdgeInfo::AddPropertyGroup(
     }
   }
   return std::make_shared<EdgeInfo>(
-      impl_->src_type_, impl_->edge_type_, impl_->dst_type_,
-      impl_->chunk_size_, impl_->src_chunk_size_, impl_->dst_chunk_size_,
-      impl_->directed_, impl_->adjacent_lists_,
+      impl_->src_type_, impl_->edge_type_, impl_->dst_type_, impl_->chunk_size_,
+      impl_->src_chunk_size_, impl_->dst_chunk_size_, impl_->directed_,
+      impl_->adjacent_lists_,
       AddVectorElement(impl_->property_groups_, property_group), impl_->prefix_,
       impl_->version_);
 }
@@ -821,10 +821,9 @@ std::shared_ptr<EdgeInfo> CreateEdgeInfo(
       adjacent_lists.empty()) {
     return nullptr;
   }
-  return std::make_shared<EdgeInfo>(src_type, edge_type, dst_type,
-                                    chunk_size, src_chunk_size, dst_chunk_size,
-                                    directed, adjacent_lists, property_groups,
-                                    prefix, version);
+  return std::make_shared<EdgeInfo>(
+      src_type, edge_type, dst_type, chunk_size, src_chunk_size, dst_chunk_size,
+      directed, adjacent_lists, property_groups, prefix, version);
 }
 
 Result<std::shared_ptr<EdgeInfo>> EdgeInfo::Load(std::shared_ptr<Yaml> yaml) {
@@ -897,10 +896,9 @@ Result<std::shared_ptr<EdgeInfo>> EdgeInfo::Load(std::shared_ptr<Yaml> yaml) {
           std::make_shared<PropertyGroup>(property_vec, file_type, pg_prefix));
     }
   }
-  return std::make_shared<EdgeInfo>(src_type, edge_type, dst_type,
-                                    chunk_size, src_chunk_size, dst_chunk_size,
-                                    directed, adjacent_lists, property_groups,
-                                    prefix, version);
+  return std::make_shared<EdgeInfo>(
+      src_type, edge_type, dst_type, chunk_size, src_chunk_size, dst_chunk_size,
+      directed, adjacent_lists, property_groups, prefix, version);
 }
 
 Result<std::shared_ptr<EdgeInfo>> EdgeInfo::Load(const std::string& input) {

--- a/cpp/src/graphar/graph_info.cc
+++ b/cpp/src/graphar/graph_info.cc
@@ -42,11 +42,11 @@ namespace graphar {
 
 namespace {
 
-std::string ConcatEdgeTriple(const std::string& src_label,
-                             const std::string& edge_label,
-                             const std::string& dst_label) {
-  return src_label + REGULAR_SEPARATOR + edge_label + REGULAR_SEPARATOR +
-         dst_label;
+std::string ConcatEdgeTriple(const std::string& src_type,
+                             const std::string& edge_type,
+                             const std::string& dst_type) {
+  return src_type + REGULAR_SEPARATOR + edge_type + REGULAR_SEPARATOR +
+         dst_type;
 }
 
 template <int NotFoundValue = -1>
@@ -189,16 +189,16 @@ std::shared_ptr<AdjacentList> CreateAdjacentList(AdjListType type,
 
 class VertexInfo::Impl {
  public:
-  Impl(const std::string& label, IdType chunk_size, const std::string& prefix,
+  Impl(const std::string& type, IdType chunk_size, const std::string& prefix,
        const PropertyGroupVector& property_groups,
        std::shared_ptr<const InfoVersion> version)
-      : label_(label),
+      : type_(type),
         chunk_size_(chunk_size),
         property_groups_(std::move(property_groups)),
         prefix_(prefix),
         version_(std::move(version)) {
     if (prefix_.empty()) {
-      prefix_ = label_ + "/";  // default prefix
+      prefix_ = type_ + "/";  // default prefix
     }
     for (size_t i = 0; i < property_groups_.size(); i++) {
       const auto& pg = property_groups_[i];
@@ -215,7 +215,7 @@ class VertexInfo::Impl {
   }
 
   bool is_validated() const noexcept {
-    if (label_.empty() || chunk_size_ <= 0 || prefix_.empty()) {
+    if (type_.empty() || chunk_size_ <= 0 || prefix_.empty()) {
       return false;
     }
     std::unordered_set<std::string> check_property_unique_set;
@@ -238,7 +238,7 @@ class VertexInfo::Impl {
     return true;
   }
 
-  std::string label_;
+  std::string type_;
   IdType chunk_size_;
   PropertyGroupVector property_groups_;
   std::string prefix_;
@@ -250,15 +250,15 @@ class VertexInfo::Impl {
       property_name_to_type_;
 };
 
-VertexInfo::VertexInfo(const std::string& label, IdType chunk_size,
+VertexInfo::VertexInfo(const std::string& type, IdType chunk_size,
                        const PropertyGroupVector& property_groups,
                        const std::string& prefix,
                        std::shared_ptr<const InfoVersion> version)
-    : impl_(new Impl(label, chunk_size, prefix, property_groups, version)) {}
+    : impl_(new Impl(type, chunk_size, prefix, property_groups, version)) {}
 
 VertexInfo::~VertexInfo() = default;
 
-const std::string& VertexInfo::GetLabel() const { return impl_->label_; }
+const std::string& VertexInfo::GetType() const { return impl_->type_; }
 
 IdType VertexInfo::GetChunkSize() const { return impl_->chunk_size_; }
 
@@ -366,7 +366,7 @@ Result<std::shared_ptr<VertexInfo>> VertexInfo::AddPropertyGroup(
     }
   }
   return std::make_shared<VertexInfo>(
-      impl_->label_, impl_->chunk_size_,
+      impl_->type_, impl_->chunk_size_,
       AddVectorElement(impl_->property_groups_, property_group), impl_->prefix_,
       impl_->version_);
 }
@@ -374,13 +374,13 @@ Result<std::shared_ptr<VertexInfo>> VertexInfo::AddPropertyGroup(
 bool VertexInfo::IsValidated() const { return impl_->is_validated(); }
 
 std::shared_ptr<VertexInfo> CreateVertexInfo(
-    const std::string& label, IdType chunk_size,
+    const std::string& type, IdType chunk_size,
     const PropertyGroupVector& property_groups, const std::string& prefix,
     std::shared_ptr<const InfoVersion> version) {
-  if (label.empty() || chunk_size <= 0) {
+  if (type.empty() || chunk_size <= 0) {
     return nullptr;
   }
-  return std::make_shared<VertexInfo>(label, chunk_size, property_groups,
+  return std::make_shared<VertexInfo>(type, chunk_size, property_groups,
                                       prefix, version);
 }
 
@@ -389,7 +389,7 @@ Result<std::shared_ptr<VertexInfo>> VertexInfo::Load(
   if (yaml == nullptr) {
     return Status::Invalid("yaml shared pointer is nullptr");
   }
-  std::string label = yaml->operator[]("label").As<std::string>();
+  std::string type = yaml->operator[]("type").As<std::string>();
   IdType chunk_size =
       static_cast<IdType>(yaml->operator[]("chunk_size").As<int64_t>());
   std::string prefix;
@@ -430,7 +430,7 @@ Result<std::shared_ptr<VertexInfo>> VertexInfo::Load(
           std::make_shared<PropertyGroup>(property_vec, file_type, pg_prefix));
     }
   }
-  return std::make_shared<VertexInfo>(label, chunk_size, property_groups,
+  return std::make_shared<VertexInfo>(type, chunk_size, property_groups,
                                       prefix, version);
 }
 
@@ -446,7 +446,7 @@ Result<std::string> VertexInfo::Dump() const noexcept {
   std::string dump_string;
   ::Yaml::Node node;
   try {
-    node["label"] = impl_->label_;
+    node["type"] = impl_->type_;
     node["chunk_size"] = std::to_string(impl_->chunk_size_);
     node["prefix"] = impl_->prefix_;
     for (const auto& pg : impl_->property_groups_) {
@@ -486,15 +486,15 @@ Status VertexInfo::Save(const std::string& path) const {
 
 class EdgeInfo::Impl {
  public:
-  Impl(const std::string& src_label, const std::string& edge_label,
-       const std::string& dst_label, IdType chunk_size, IdType src_chunk_size,
+  Impl(const std::string& src_type, const std::string& edge_type,
+       const std::string& dst_type, IdType chunk_size, IdType src_chunk_size,
        IdType dst_chunk_size, bool directed, const std::string& prefix,
        const AdjacentListVector& adjacent_lists,
        const PropertyGroupVector& property_groups,
        std::shared_ptr<const InfoVersion> version)
-      : src_label_(src_label),
-        edge_label_(edge_label),
-        dst_label_(dst_label),
+      : src_type_(src_type),
+        edge_type_(edge_type),
+        dst_type_(dst_type),
         chunk_size_(chunk_size),
         src_chunk_size_(src_chunk_size),
         dst_chunk_size_(dst_chunk_size),
@@ -504,8 +504,8 @@ class EdgeInfo::Impl {
         property_groups_(std::move(property_groups)),
         version_(std::move(version)) {
     if (prefix_.empty()) {
-      prefix_ = src_label_ + REGULAR_SEPARATOR + edge_label_ +
-                REGULAR_SEPARATOR + dst_label_ + "/";  // default prefix
+      prefix_ = src_type_ + REGULAR_SEPARATOR + edge_type_ +
+                REGULAR_SEPARATOR + dst_type_ + "/";  // default prefix
     }
     for (size_t i = 0; i < adjacent_lists_.size(); i++) {
       if (!adjacent_lists_[i]) {
@@ -530,7 +530,7 @@ class EdgeInfo::Impl {
   }
 
   bool is_validated() const noexcept {
-    if (src_label_.empty() || edge_label_.empty() || dst_label_.empty() ||
+    if (src_type_.empty() || edge_type_.empty() || dst_type_.empty() ||
         chunk_size_ <= 0 || src_chunk_size_ <= 0 || dst_chunk_size_ <= 0 ||
         prefix_.empty() || adjacent_lists_.empty()) {
       return false;
@@ -564,9 +564,9 @@ class EdgeInfo::Impl {
     return true;
   }
 
-  std::string src_label_;
-  std::string edge_label_;
-  std::string dst_label_;
+  std::string src_type_;
+  std::string edge_type_;
+  std::string dst_type_;
   IdType chunk_size_;
   IdType src_chunk_size_;
   IdType dst_chunk_size_;
@@ -583,24 +583,24 @@ class EdgeInfo::Impl {
   std::shared_ptr<const InfoVersion> version_;
 };
 
-EdgeInfo::EdgeInfo(const std::string& src_label, const std::string& edge_label,
-                   const std::string& dst_label, IdType chunk_size,
+EdgeInfo::EdgeInfo(const std::string& src_type, const std::string& edge_type,
+                   const std::string& dst_type, IdType chunk_size,
                    IdType src_chunk_size, IdType dst_chunk_size, bool directed,
                    const AdjacentListVector& adjacent_lists,
                    const PropertyGroupVector& property_groups,
                    const std::string& prefix,
                    std::shared_ptr<const InfoVersion> version)
-    : impl_(new Impl(src_label, edge_label, dst_label, chunk_size,
+    : impl_(new Impl(src_type, edge_type, dst_type, chunk_size,
                      src_chunk_size, dst_chunk_size, directed, prefix,
                      adjacent_lists, property_groups, version)) {}
 
 EdgeInfo::~EdgeInfo() = default;
 
-const std::string& EdgeInfo::GetSrcLabel() const { return impl_->src_label_; }
+const std::string& EdgeInfo::GetSrcType() const { return impl_->src_type_; }
 
-const std::string& EdgeInfo::GetEdgeLabel() const { return impl_->edge_label_; }
+const std::string& EdgeInfo::GetEdgeType() const { return impl_->edge_type_; }
 
-const std::string& EdgeInfo::GetDstLabel() const { return impl_->dst_label_; }
+const std::string& EdgeInfo::GetDstType() const { return impl_->dst_type_; }
 
 IdType EdgeInfo::GetChunkSize() const { return impl_->chunk_size_; }
 
@@ -782,7 +782,7 @@ Result<std::shared_ptr<EdgeInfo>> EdgeInfo::AddAdjacentList(
                            AdjListTypeToString(adj_list->GetType()));
   }
   return std::make_shared<EdgeInfo>(
-      impl_->src_label_, impl_->edge_label_, impl_->dst_label_,
+      impl_->src_type_, impl_->edge_type_, impl_->dst_type_,
       impl_->chunk_size_, impl_->src_chunk_size_, impl_->dst_chunk_size_,
       impl_->directed_, AddVectorElement(impl_->adjacent_lists_, adj_list),
       impl_->property_groups_, impl_->prefix_, impl_->version_);
@@ -800,7 +800,7 @@ Result<std::shared_ptr<EdgeInfo>> EdgeInfo::AddPropertyGroup(
     }
   }
   return std::make_shared<EdgeInfo>(
-      impl_->src_label_, impl_->edge_label_, impl_->dst_label_,
+      impl_->src_type_, impl_->edge_type_, impl_->dst_type_,
       impl_->chunk_size_, impl_->src_chunk_size_, impl_->dst_chunk_size_,
       impl_->directed_, impl_->adjacent_lists_,
       AddVectorElement(impl_->property_groups_, property_group), impl_->prefix_,
@@ -810,18 +810,18 @@ Result<std::shared_ptr<EdgeInfo>> EdgeInfo::AddPropertyGroup(
 bool EdgeInfo::IsValidated() const { return impl_->is_validated(); }
 
 std::shared_ptr<EdgeInfo> CreateEdgeInfo(
-    const std::string& src_label, const std::string& edge_label,
-    const std::string& dst_label, IdType chunk_size, IdType src_chunk_size,
+    const std::string& src_type, const std::string& edge_type,
+    const std::string& dst_type, IdType chunk_size, IdType src_chunk_size,
     IdType dst_chunk_size, bool directed,
     const AdjacentListVector& adjacent_lists,
     const PropertyGroupVector& property_groups, const std::string& prefix,
     std::shared_ptr<const InfoVersion> version) {
-  if (src_label.empty() || edge_label.empty() || dst_label.empty() ||
+  if (src_type.empty() || edge_type.empty() || dst_type.empty() ||
       chunk_size <= 0 || src_chunk_size <= 0 || dst_chunk_size <= 0 ||
       adjacent_lists.empty()) {
     return nullptr;
   }
-  return std::make_shared<EdgeInfo>(src_label, edge_label, dst_label,
+  return std::make_shared<EdgeInfo>(src_type, edge_type, dst_type,
                                     chunk_size, src_chunk_size, dst_chunk_size,
                                     directed, adjacent_lists, property_groups,
                                     prefix, version);
@@ -831,9 +831,9 @@ Result<std::shared_ptr<EdgeInfo>> EdgeInfo::Load(std::shared_ptr<Yaml> yaml) {
   if (yaml == nullptr) {
     return Status::Invalid("yaml shared pointer is nullptr.");
   }
-  std::string src_label = yaml->operator[]("src_label").As<std::string>();
-  std::string edge_label = yaml->operator[]("edge_label").As<std::string>();
-  std::string dst_label = yaml->operator[]("dst_label").As<std::string>();
+  std::string src_type = yaml->operator[]("src_type").As<std::string>();
+  std::string edge_type = yaml->operator[]("edge_type").As<std::string>();
+  std::string dst_type = yaml->operator[]("dst_type").As<std::string>();
   IdType chunk_size =
       static_cast<IdType>(yaml->operator[]("chunk_size").As<int64_t>());
   IdType src_chunk_size =
@@ -897,7 +897,7 @@ Result<std::shared_ptr<EdgeInfo>> EdgeInfo::Load(std::shared_ptr<Yaml> yaml) {
           std::make_shared<PropertyGroup>(property_vec, file_type, pg_prefix));
     }
   }
-  return std::make_shared<EdgeInfo>(src_label, edge_label, dst_label,
+  return std::make_shared<EdgeInfo>(src_type, edge_type, dst_type,
                                     chunk_size, src_chunk_size, dst_chunk_size,
                                     directed, adjacent_lists, property_groups,
                                     prefix, version);
@@ -915,9 +915,9 @@ Result<std::string> EdgeInfo::Dump() const noexcept {
   std::string dump_string;
   ::Yaml::Node node;
   try {
-    node["src_label"] = impl_->src_label_;
-    node["edge_label"] = impl_->edge_label_;
-    node["dst_label"] = impl_->dst_label_;
+    node["src_type"] = impl_->src_type_;
+    node["edge_type"] = impl_->edge_type_;
+    node["dst_type"] = impl_->dst_type_;
     node["chunk_size"] = std::to_string(impl_->chunk_size_);
     node["src_chunk_size"] = std::to_string(impl_->src_chunk_size_);
     node["dst_chunk_size"] = std::to_string(impl_->dst_chunk_size_);
@@ -1064,15 +1064,15 @@ class GraphInfo::Impl {
         extra_info_(extra_info) {
     for (size_t i = 0; i < vertex_infos_.size(); i++) {
       if (vertex_infos_[i] != nullptr) {
-        vlabel_to_index_[vertex_infos_[i]->GetLabel()] = i;
+        vtype_to_index_[vertex_infos_[i]->GetType()] = i;
       }
     }
     for (size_t i = 0; i < edge_infos_.size(); i++) {
       if (edge_infos_[i] != nullptr) {
-        std::string edge_key = ConcatEdgeTriple(edge_infos_[i]->GetSrcLabel(),
-                                                edge_infos_[i]->GetEdgeLabel(),
-                                                edge_infos_[i]->GetDstLabel());
-        elabel_to_index_[edge_key] = i;
+        std::string edge_key = ConcatEdgeTriple(edge_infos_[i]->GetSrcType(),
+                                                edge_infos_[i]->GetEdgeType(),
+                                                edge_infos_[i]->GetDstType());
+        etype_to_index_[edge_key] = i;
       }
     }
   }
@@ -1091,8 +1091,8 @@ class GraphInfo::Impl {
         return false;
       }
     }
-    if (vertex_infos_.size() != vlabel_to_index_.size() ||
-        edge_infos_.size() != elabel_to_index_.size()) {
+    if (vertex_infos_.size() != vtype_to_index_.size() ||
+        edge_infos_.size() != etype_to_index_.size()) {
       return false;
     }
     return true;
@@ -1104,8 +1104,8 @@ class GraphInfo::Impl {
   std::string prefix_;
   std::shared_ptr<const InfoVersion> version_;
   std::unordered_map<std::string, std::string> extra_info_;
-  std::unordered_map<std::string, int> vlabel_to_index_;
-  std::unordered_map<std::string, int> elabel_to_index_;
+  std::unordered_map<std::string, int> vtype_to_index_;
+  std::unordered_map<std::string, int> etype_to_index_;
 };
 
 GraphInfo::GraphInfo(
@@ -1138,21 +1138,21 @@ std::shared_ptr<VertexInfo> GraphInfo::GetVertexInfo(
 }
 
 int GraphInfo::GetVertexInfoIndex(const std::string& type) const {
-  return LookupKeyIndex(impl_->vlabel_to_index_, type);
+  return LookupKeyIndex(impl_->vtype_to_index_, type);
 }
 
 std::shared_ptr<EdgeInfo> GraphInfo::GetEdgeInfo(
-    const std::string& src_label, const std::string& edge_label,
-    const std::string& dst_label) const {
-  int i = GetEdgeInfoIndex(src_label, edge_label, dst_label);
+    const std::string& src_type, const std::string& edge_type,
+    const std::string& dst_type) const {
+  int i = GetEdgeInfoIndex(src_type, edge_type, dst_type);
   return i == -1 ? nullptr : impl_->edge_infos_[i];
 }
 
-int GraphInfo::GetEdgeInfoIndex(const std::string& src_label,
-                                const std::string& edge_label,
-                                const std::string& dst_label) const {
-  std::string edge_key = ConcatEdgeTriple(src_label, edge_label, dst_label);
-  return LookupKeyIndex(impl_->elabel_to_index_, edge_key);
+int GraphInfo::GetEdgeInfoIndex(const std::string& src_type,
+                                const std::string& edge_type,
+                                const std::string& dst_type) const {
+  std::string edge_key = ConcatEdgeTriple(src_type, edge_type, dst_type);
+  return LookupKeyIndex(impl_->etype_to_index_, edge_key);
 }
 
 int GraphInfo::VertexInfoNum() const {
@@ -1193,7 +1193,7 @@ Result<std::shared_ptr<GraphInfo>> GraphInfo::AddVertex(
   if (vertex_info == nullptr) {
     return Status::Invalid("vertex info is nullptr");
   }
-  if (GetVertexInfoIndex(vertex_info->GetLabel()) != -1) {
+  if (GetVertexInfoIndex(vertex_info->GetType()) != -1) {
     return Status::Invalid("vertex info already exists");
   }
   return std::make_shared<GraphInfo>(
@@ -1206,8 +1206,8 @@ Result<std::shared_ptr<GraphInfo>> GraphInfo::AddEdge(
   if (edge_info == nullptr) {
     return Status::Invalid("edge info is nullptr");
   }
-  if (GetEdgeInfoIndex(edge_info->GetSrcLabel(), edge_info->GetEdgeLabel(),
-                       edge_info->GetDstLabel()) != -1) {
+  if (GetEdgeInfoIndex(edge_info->GetSrcType(), edge_info->GetEdgeType(),
+                       edge_info->GetDstType()) != -1) {
     return Status::Invalid("edge info already exists");
   }
   return std::make_shared<GraphInfo>(
@@ -1268,13 +1268,13 @@ Result<std::string> GraphInfo::Dump() const {
     for (const auto& vertex : GetVertexInfos()) {
       node["vertices"].PushBack();
       node["vertices"][node["vertices"].Size() - 1] =
-          vertex->GetLabel() + ".vertex.yaml";
+          vertex->GetType() + ".vertex.yaml";
     }
     for (const auto& edge : GetEdgeInfos()) {
       node["edges"].PushBack();
       node["edges"][node["edges"].Size() - 1] =
-          ConcatEdgeTriple(edge->GetSrcLabel(), edge->GetEdgeLabel(),
-                           edge->GetDstLabel()) +
+          ConcatEdgeTriple(edge->GetSrcType(), edge->GetEdgeType(),
+                           edge->GetDstType()) +
           ".edge.yaml";
     }
     if (impl_->version_ != nullptr) {

--- a/cpp/src/graphar/graph_info.h
+++ b/cpp/src/graphar/graph_info.h
@@ -169,7 +169,7 @@ class AdjacentList {
 /**
  * \class VertexInfo
  * \brief VertexInfo is a class to describe the vertex information, including
- * the vertex label, chunk size, property groups, and prefix.
+ * the vertex type, chunk size, property groups, and prefix.
  */
 class VertexInfo {
  public:
@@ -177,14 +177,14 @@ class VertexInfo {
    * Construct a VertexInfo object with the given information and property
    * group.
    *
-   * @param label The label of the vertex.
+   * @param type The type of the vertex.
    * @param chunk_size The number of vertices in each vertex chunk.
    * @param property_groups The property group vector of the vertex.
    * @param prefix The prefix of the vertex info. If left empty, the default
-   *        prefix will be set to the label of the vertex.
+   *        prefix will be set to the type of the vertex.
    * @param version The format version of the vertex info.
    */
-  explicit VertexInfo(const std::string& label, IdType chunk_size,
+  explicit VertexInfo(const std::string& type, IdType chunk_size,
                       const PropertyGroupVector& property_groups,
                       const std::string& prefix = "",
                       std::shared_ptr<const InfoVersion> version = nullptr);
@@ -200,11 +200,11 @@ class VertexInfo {
       std::shared_ptr<PropertyGroup> property_group) const;
 
   /**
-   * Get the label of the vertex.
+   * Get the type of the vertex.
    *
-   * @return The label of the vertex.
+   * @return The type of the vertex.
    */
-  const std::string& GetLabel() const;
+  const std::string& GetType() const;
 
   /**
    * Get the chunk size of the vertex.
@@ -376,7 +376,7 @@ class VertexInfo {
 /**
  * \class EdgeInfo
  * \brief EdgeInfo is a class to describe the edge information, including the
- * source vertex label, edge label, destination vertex label, chunk size,
+ * source vertex type, edge type, destination vertex type, chunk size,
  * adjacent list property groups, and prefix.
  */
 class EdgeInfo {
@@ -385,9 +385,9 @@ class EdgeInfo {
    * @brief Construct an EdgeInfo object with the given information and property
    * groups.
    *
-   * @param src_label The label of the source vertex.
-   * @param edge_label The label of the edge.
-   * @param dst_label The label of the destination vertex.
+   * @param src_type The type of the source vertex.
+   * @param edge_type The type of the edge.
+   * @param dst_type The type of the destination vertex.
    * @param chunk_size The number of edges in each edge chunk.
    * @param src_chunk_size The number of source vertices in each vertex chunk.
    * @param dst_chunk_size The number of destination vertices in each vertex
@@ -398,8 +398,8 @@ class EdgeInfo {
    * @param prefix The path prefix of the edge info.
    * @param version The version of the edge info.
    */
-  explicit EdgeInfo(const std::string& src_label, const std::string& edge_label,
-                    const std::string& dst_label, IdType chunk_size,
+  explicit EdgeInfo(const std::string& src_type, const std::string& edge_type,
+                    const std::string& dst_type, IdType chunk_size,
                     IdType src_chunk_size, IdType dst_chunk_size, bool directed,
                     const AdjacentListVector& adjacent_lists,
                     const PropertyGroupVector& property_groups,
@@ -427,22 +427,22 @@ class EdgeInfo {
       std::shared_ptr<PropertyGroup> property_group) const;
 
   /**
-   * Get the label of the source vertex.
-   * @return The label of the source vertex.
+   * Get the type of the source vertex.
+   * @return The type of the source vertex.
    */
-  const std::string& GetSrcLabel() const;
+  const std::string& GetSrcType() const;
 
   /**
-   * Get the label of the edge.
-   * @return The label of the edge.
+   * Get the type of the edge.
+   * @return The type of the edge.
    */
-  const std::string& GetEdgeLabel() const;
+  const std::string& GetEdgeType() const;
 
   /**
-   * Get the label of the destination vertex.
-   * @return The label of the destination vertex.
+   * Get the type of the destination vertex.
+   * @return The type of the destination vertex.
    */
-  const std::string& GetDstLabel() const;
+  const std::string& GetDstType() const;
 
   /**
    * Get the number of edges in each edge chunk.
@@ -774,36 +774,36 @@ class GraphInfo {
   const std::unordered_map<std::string, std::string>& GetExtraInfo() const;
 
   /**
-   * @brief Get the vertex info with the given label.
-   * @param label The label of the vertex.
-   * @return vertex info may be nullptr if the label is not found.
+   * @brief Get the vertex info with the given type.
+   * @param type The type of the vertex.
+   * @return vertex info may be nullptr if the type is not found.
    */
-  std::shared_ptr<VertexInfo> GetVertexInfo(const std::string& label) const;
+  std::shared_ptr<VertexInfo> GetVertexInfo(const std::string& type) const;
 
   /**
-   * @brief Get the edge info with the given source vertex label, edge label,
-   * and destination vertex label.
-   * @param src_label The label of the source vertex.
-   * @param edge_label The label of the edge.
-   * @param dst_label The label of the destination vertex.
-   * @return edge info may be nullptr if the label is not found.
+   * @brief Get the edge info with the given source vertex type, edge type,
+   * and destination vertex type.
+   * @param src_type The type of the source vertex.
+   * @param edge_type The type of the edge.
+   * @param dst_type The type of the destination vertex.
+   * @return edge info may be nullptr if the type is not found.
    */
-  std::shared_ptr<EdgeInfo> GetEdgeInfo(const std::string& src_label,
-                                        const std::string& edge_label,
-                                        const std::string& dst_label) const;
+  std::shared_ptr<EdgeInfo> GetEdgeInfo(const std::string& src_type,
+                                        const std::string& edge_type,
+                                        const std::string& dst_type) const;
 
   /**
-   * @brief Get the vertex info index with the given label.
+   * @brief Get the vertex info index with the given type.
    */
-  int GetVertexInfoIndex(const std::string& label) const;
+  int GetVertexInfoIndex(const std::string& type) const;
 
   /**
-   * @brief Get the edge info index with the given source vertex label, edge
-   * label, and destination label.
+   * @brief Get the edge info index with the given source vertex type, edge
+   * type, and destination type.
    */
-  int GetEdgeInfoIndex(const std::string& src_label,
-                       const std::string& edge_label,
-                       const std::string& dst_label) const;
+  int GetEdgeInfoIndex(const std::string& src_type,
+                       const std::string& edge_type,
+                       const std::string& dst_type) const;
 
   /**
    * @brief Get the number of vertex infos.

--- a/cpp/src/graphar/high-level/edges_builder.cc
+++ b/cpp/src/graphar/high-level/edges_builder.cc
@@ -102,7 +102,7 @@ Status EdgesBuilder::validate(const Edge& e,
   if (!edge_info_->HasAdjacentListType(adj_list_type_)) {
     return Status::KeyError(
         "Adj list type ", AdjListTypeToString(adj_list_type_),
-        " does not exist in the ", edge_info_->GetEdgeLabel(), " edge info.");
+        " does not exist in the ", edge_info_->GetEdgeType(), " edge info.");
   }
 
   // strong validate
@@ -112,7 +112,7 @@ Status EdgesBuilder::validate(const Edge& e,
       if (!edge_info_->HasProperty(property.first)) {
         return Status::KeyError("Property with name ", property.first,
                                 " is not contained in the ",
-                                edge_info_->GetEdgeLabel(), " edge info.");
+                                edge_info_->GetEdgeType(), " edge info.");
       }
       // check if the property type is correct
       auto type = edge_info_->GetPropertyType(property.first).value();

--- a/cpp/src/graphar/high-level/edges_builder.h
+++ b/cpp/src/graphar/high-level/edges_builder.h
@@ -308,10 +308,9 @@ class EdgesBuilder {
    * no_validate.
    */
   static Result<std::shared_ptr<EdgesBuilder>> Make(
-      const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_type, const std::string& edge_type,
-      const std::string& dst_type, const AdjListType& adj_list_type,
-      IdType num_vertices,
+      const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+      const std::string& edge_type, const std::string& dst_type,
+      const AdjListType& adj_list_type, IdType num_vertices,
       const ValidateLevel& validate_level = ValidateLevel::no_validate) {
     auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
     if (!edge_info) {

--- a/cpp/src/graphar/high-level/edges_builder.h
+++ b/cpp/src/graphar/high-level/edges_builder.h
@@ -289,7 +289,7 @@ class EdgesBuilder {
     if (!edge_info->HasAdjacentListType(adj_list_type)) {
       return Status::KeyError(
           "The adjacent list type ", AdjListTypeToString(adj_list_type),
-          " doesn't exist in edge ", edge_info->GetEdgeLabel(), ".");
+          " doesn't exist in edge ", edge_info->GetEdgeType(), ".");
     }
     return std::make_shared<EdgesBuilder>(edge_info, prefix, adj_list_type,
                                           num_vertices, validate_level);
@@ -299,9 +299,9 @@ class EdgesBuilder {
    * @brief Construct an EdgesBuilder from graph info.
    *
    * @param graph_info The graph info that describes the graph.
-   * @param src_label The label of the source vertex type.
-   * @param edge_label The label of the edge type.
-   * @param dst_label The label of the destination vertex type.
+   * @param src_type The label of the source vertex type.
+   * @param edge_type The label of the edge type.
+   * @param dst_type The label of the destination vertex type.
    * @param adj_list_type The adj list type of the edges.
    * @param num_vertices The total number of vertices for source or destination.
    * @param validate_level The global validate level for the builder, default is
@@ -309,14 +309,14 @@ class EdgesBuilder {
    */
   static Result<std::shared_ptr<EdgesBuilder>> Make(
       const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_label, const std::string& edge_label,
-      const std::string& dst_label, const AdjListType& adj_list_type,
+      const std::string& src_type, const std::string& edge_type,
+      const std::string& dst_type, const AdjListType& adj_list_type,
       IdType num_vertices,
       const ValidateLevel& validate_level = ValidateLevel::no_validate) {
-    auto edge_info = graph_info->GetEdgeInfo(src_label, edge_label, dst_label);
+    auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
     if (!edge_info) {
-      return Status::KeyError("The edge ", src_label, " ", edge_label, " ",
-                              dst_label, " doesn't exist.");
+      return Status::KeyError("The edge ", src_type, " ", edge_type, " ",
+                              dst_type, " doesn't exist.");
     }
     return Make(edge_info, graph_info->GetPrefix(), adj_list_type, num_vertices,
                 validate_level);

--- a/cpp/src/graphar/high-level/graph_reader.cc
+++ b/cpp/src/graphar/high-level/graph_reader.cc
@@ -544,17 +544,17 @@ bool EdgeIter::first_dst(const EdgeIter& from, IdType id) {
 }
 
 Result<std::shared_ptr<EdgesCollection>> EdgesCollection::Make(
-    const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_label,
-    const std::string& edge_label, const std::string& dst_label,
+    const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+    const std::string& edge_type, const std::string& dst_type,
     AdjListType adj_list_type, const IdType vertex_chunk_begin,
     const IdType vertex_chunk_end) noexcept {
-  auto edge_info = graph_info->GetEdgeInfo(src_label, edge_label, dst_label);
+  auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
   if (!edge_info) {
-    return Status::KeyError("The edge ", src_label, " ", edge_label, " ",
-                            dst_label, " doesn't exist.");
+    return Status::KeyError("The edge ", src_type, " ", edge_type, " ",
+                            dst_type, " doesn't exist.");
   }
   if (!edge_info->HasAdjacentListType(adj_list_type)) {
-    return Status::Invalid("The edge ", edge_label, " of adj list type ",
+    return Status::Invalid("The edge ", edge_type, " of adj list type ",
                            AdjListTypeToString(adj_list_type),
                            " doesn't exist.");
   }

--- a/cpp/src/graphar/high-level/graph_reader.h
+++ b/cpp/src/graphar/high-level/graph_reader.h
@@ -707,9 +707,9 @@ class EdgesCollection {
    * @brief Construct an EdgesCollection from graph info and edge label.
    *
    * @param graph_info The graph info.
-   * @param src_label The source vertex label.
-   * @param edge_label The edge label.
-   * @param dst_label The destination vertex label.
+   * @param src_type The source vertex label.
+   * @param edge_type The edge label.
+   * @param dst_type The destination vertex label.
    * @param adj_list_type The type of adjList.
    * @param vertex_chunk_begin The index of the begin vertex chunk, default 0.
    * @param vertex_chunk_end The index of the end vertex chunk (not included),
@@ -717,8 +717,8 @@ class EdgesCollection {
    */
   static Result<std::shared_ptr<EdgesCollection>> Make(
       const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_label, const std::string& edge_label,
-      const std::string& dst_label, AdjListType adj_list_type,
+      const std::string& src_type, const std::string& edge_type,
+      const std::string& dst_type, AdjListType adj_list_type,
       const IdType vertex_chunk_begin = 0,
       const IdType vertex_chunk_end =
           std::numeric_limits<int64_t>::max()) noexcept;

--- a/cpp/src/graphar/high-level/graph_reader.h
+++ b/cpp/src/graphar/high-level/graph_reader.h
@@ -716,10 +716,9 @@ class EdgesCollection {
    * default max.
    */
   static Result<std::shared_ptr<EdgesCollection>> Make(
-      const std::shared_ptr<GraphInfo>& graph_info,
-      const std::string& src_type, const std::string& edge_type,
-      const std::string& dst_type, AdjListType adj_list_type,
-      const IdType vertex_chunk_begin = 0,
+      const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+      const std::string& edge_type, const std::string& dst_type,
+      AdjListType adj_list_type, const IdType vertex_chunk_begin = 0,
       const IdType vertex_chunk_end =
           std::numeric_limits<int64_t>::max()) noexcept;
 

--- a/cpp/src/graphar/high-level/vertices_builder.cc
+++ b/cpp/src/graphar/high-level/vertices_builder.cc
@@ -59,7 +59,7 @@ Status VerticesBuilder::validate(const Vertex& v, IdType index,
       if (!vertex_info_->HasProperty(property.first)) {
         return Status::KeyError("Property with name ", property.first,
                                 " is not contained in the ",
-                                vertex_info_->GetLabel(), " vertex info.");
+                                vertex_info_->GetType(), " vertex info.");
       }
       // check if the property type is correct
       auto type = vertex_info_->GetPropertyType(property.first).value();

--- a/cpp/test/test_arrow_chunk_reader.cc
+++ b/cpp/test/test_arrow_chunk_reader.cc
@@ -107,7 +107,6 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
       auto origin_property = pg->GetProperties()[0];
       REQUIRE(origin_property.type->Equals(int64()));
 
-
       // change to int32_t
       Property new_property("id", int32(), origin_property.is_primary,
                             origin_property.is_nullable);
@@ -235,9 +234,9 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
   }
 
   SECTION("AdjListArrowChunkReader") {
-    auto maybe_reader = AdjListArrowChunkReader::Make(
-        graph_info, src_type, edge_type, dst_type,
-        AdjListType::ordered_by_source);
+    auto maybe_reader =
+        AdjListArrowChunkReader::Make(graph_info, src_type, edge_type, dst_type,
+                                      AdjListType::ordered_by_source);
     REQUIRE(maybe_reader.status().ok());
     auto reader = maybe_reader.value();
     SECTION("Basics") {
@@ -462,17 +461,16 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
 TEST_CASE_METHOD(GlobalFixture, "EmptyChunkTest") {
   // read file and construct graph info
   std::string path = test_data_dir + "/neo4j/MovieGraph.graph.yml";
-  std::string src_type = "Person", edge_type = "REVIEWED",
-              dst_type = "Movie";
+  std::string src_type = "Person", edge_type = "REVIEWED", dst_type = "Movie";
   std::string edge_property_name = "rating";
   auto maybe_graph_info = GraphInfo::Load(path);
   REQUIRE(maybe_graph_info.status().ok());
   auto graph_info = maybe_graph_info.value();
 
   SECTION("AdjListArrowChunkReader") {
-    auto maybe_reader = AdjListArrowChunkReader::Make(
-        graph_info, src_type, edge_type, dst_type,
-        AdjListType::ordered_by_source);
+    auto maybe_reader =
+        AdjListArrowChunkReader::Make(graph_info, src_type, edge_type, dst_type,
+                                      AdjListType::ordered_by_source);
     REQUIRE(maybe_reader.status().ok());
     auto reader = maybe_reader.value();
     auto result = reader->GetChunk();

--- a/cpp/test/test_arrow_chunk_reader.cc
+++ b/cpp/test/test_arrow_chunk_reader.cc
@@ -31,24 +31,24 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
   // read file and construct graph info
   std::string path =
       test_data_dir + "/ldbc_sample/parquet/ldbc_sample.graph.yml";
-  std::string src_label = "person", edge_label = "knows", dst_label = "person";
+  std::string src_type = "person", edge_type = "knows", dst_type = "person";
   std::string vertex_property_name = "id";
   std::string edge_property_name = "creationDate";
   auto maybe_graph_info = GraphInfo::Load(path);
   REQUIRE(maybe_graph_info.status().ok());
   auto graph_info = maybe_graph_info.value();
-  auto vertex_info = graph_info->GetVertexInfo(src_label);
+  auto vertex_info = graph_info->GetVertexInfo(src_type);
   REQUIRE(vertex_info != nullptr);
   auto v_pg = vertex_info->GetPropertyGroup(vertex_property_name);
   REQUIRE(v_pg != nullptr);
-  auto edge_info = graph_info->GetEdgeInfo(src_label, edge_label, dst_label);
+  auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
   REQUIRE(edge_info != nullptr);
   auto e_pg = edge_info->GetPropertyGroup(edge_property_name);
   REQUIRE(e_pg != nullptr);
 
   SECTION("VertexPropertyArrowChunkReader") {
     auto maybe_reader = VertexPropertyArrowChunkReader::Make(
-        graph_info, src_label, vertex_property_name);
+        graph_info, src_type, vertex_property_name);
     REQUIRE(maybe_reader.status().ok());
     auto reader = maybe_reader.value();
     REQUIRE(reader->GetChunkNum() == 10);
@@ -106,6 +106,7 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
       REQUIRE(pg->GetProperties().size() == 1);
       auto origin_property = pg->GetProperties()[0];
       REQUIRE(origin_property.type->Equals(int64()));
+
 
       // change to int32_t
       Property new_property("id", int32(), origin_property.is_primary,
@@ -167,7 +168,7 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
         options.filter = filter;
         options.columns = expected_cols;
         auto maybe_reader = VertexPropertyArrowChunkReader::Make(
-            graph_info, src_label, filter_property, options);
+            graph_info, src_type, filter_property, options);
         REQUIRE(maybe_reader.status().ok());
         walkReader(maybe_reader.value());
       }
@@ -175,7 +176,7 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
       SECTION("pushdown by function Filter() & Select()") {
         std::cout << "Vertex property pushdown by Filter() & Select():\n";
         auto maybe_reader = VertexPropertyArrowChunkReader::Make(
-            graph_info, src_label, filter_property);
+            graph_info, src_type, filter_property);
         REQUIRE(maybe_reader.status().ok());
         auto reader = maybe_reader.value();
         reader->Filter(filter);
@@ -190,7 +191,7 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
         options.filter = filter;
         options.columns = expected_cols;
         auto maybe_reader = VertexPropertyArrowChunkReader::Make(
-            graph_info, src_label, filter_property, options);
+            graph_info, src_type, filter_property, options);
         REQUIRE(maybe_reader.status().ok());
         auto reader = maybe_reader.value();
         auto result = reader->GetChunk();
@@ -207,7 +208,7 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
         options.filter = filter;
         options.columns = expected_cols_2;
         auto maybe_reader = VertexPropertyArrowChunkReader::Make(
-            graph_info, src_label, filter_property, options);
+            graph_info, src_type, filter_property, options);
         REQUIRE(maybe_reader.status().ok());
         auto reader = maybe_reader.value();
         auto result = reader->GetChunk();
@@ -218,7 +219,7 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
 
     SECTION("Make from graph info and property group") {
       auto maybe_reader =
-          VertexPropertyArrowChunkReader::Make(graph_info, src_label, v_pg);
+          VertexPropertyArrowChunkReader::Make(graph_info, src_type, v_pg);
       REQUIRE(maybe_reader.status().ok());
       auto reader = maybe_reader.value();
       REQUIRE(reader->GetChunkNum() == 10);
@@ -235,7 +236,7 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
 
   SECTION("AdjListArrowChunkReader") {
     auto maybe_reader = AdjListArrowChunkReader::Make(
-        graph_info, src_label, edge_label, dst_label,
+        graph_info, src_type, edge_type, dst_type,
         AdjListType::ordered_by_source);
     REQUIRE(maybe_reader.status().ok());
     auto reader = maybe_reader.value();
@@ -284,7 +285,7 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
 
     SECTION("set start vertex chunk index by seek_chunk_index") {
       auto maybe_reader = AdjListArrowChunkReader::Make(
-          graph_info, src_label, edge_label, dst_label,
+          graph_info, src_type, edge_type, dst_type,
           AdjListType::ordered_by_source);
       auto reader = maybe_reader.value();
       // check reader start from vertex chunk 0
@@ -303,7 +304,7 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
 
   SECTION("AdjListPropertyArrowChunkReader") {
     auto maybe_reader = AdjListPropertyArrowChunkReader::Make(
-        graph_info, src_label, edge_label, dst_label, edge_property_name,
+        graph_info, src_type, edge_type, dst_type, edge_property_name,
         AdjListType::ordered_by_source);
     REQUIRE(maybe_reader.status().ok());
     auto reader = maybe_reader.value();
@@ -390,7 +391,7 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
       SECTION("pushdown by helper function") {
         std::cout << "Adj list property pushdown by helper function: \n";
         auto maybe_reader = AdjListPropertyArrowChunkReader::Make(
-            graph_info, src_label, edge_label, dst_label, edge_property_name,
+            graph_info, src_type, edge_type, dst_type, edge_property_name,
             AdjListType::ordered_by_source, options);
         REQUIRE(maybe_reader.status().ok());
         auto reader = maybe_reader.value();
@@ -401,7 +402,7 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
         std::cout << "Adj list property pushdown by Filter() & Select():"
                   << std::endl;
         auto maybe_reader = AdjListPropertyArrowChunkReader::Make(
-            graph_info, src_label, edge_label, dst_label, edge_property_name,
+            graph_info, src_type, edge_type, dst_type, edge_property_name,
             AdjListType::ordered_by_source);
         REQUIRE(maybe_reader.status().ok());
         auto reader = maybe_reader.value();
@@ -413,7 +414,7 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
 
     SECTION("set start vertex chunk index by seek_chunk_index") {
       auto maybe_reader = AdjListPropertyArrowChunkReader::Make(
-          graph_info, src_label, edge_label, dst_label, edge_property_name,
+          graph_info, src_type, edge_type, dst_type, edge_property_name,
           AdjListType::ordered_by_source);
       REQUIRE(maybe_reader.status().ok());
       auto reader = maybe_reader.value();
@@ -433,7 +434,7 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
 
   SECTION("AdjListOffsetArrowChunkReader") {
     auto maybe_reader = AdjListOffsetArrowChunkReader::Make(
-        graph_info, src_label, edge_label, dst_label,
+        graph_info, src_type, edge_type, dst_type,
         AdjListType::ordered_by_source);
     REQUIRE(maybe_reader.status().ok());
     auto reader = maybe_reader.value();
@@ -461,8 +462,8 @@ TEST_CASE_METHOD(GlobalFixture, "ArrowChunkReader") {
 TEST_CASE_METHOD(GlobalFixture, "EmptyChunkTest") {
   // read file and construct graph info
   std::string path = test_data_dir + "/neo4j/MovieGraph.graph.yml";
-  std::string src_label = "Person", edge_label = "REVIEWED",
-              dst_label = "Movie";
+  std::string src_type = "Person", edge_type = "REVIEWED",
+              dst_type = "Movie";
   std::string edge_property_name = "rating";
   auto maybe_graph_info = GraphInfo::Load(path);
   REQUIRE(maybe_graph_info.status().ok());
@@ -470,7 +471,7 @@ TEST_CASE_METHOD(GlobalFixture, "EmptyChunkTest") {
 
   SECTION("AdjListArrowChunkReader") {
     auto maybe_reader = AdjListArrowChunkReader::Make(
-        graph_info, src_label, edge_label, dst_label,
+        graph_info, src_type, edge_type, dst_type,
         AdjListType::ordered_by_source);
     REQUIRE(maybe_reader.status().ok());
     auto reader = maybe_reader.value();
@@ -482,7 +483,7 @@ TEST_CASE_METHOD(GlobalFixture, "EmptyChunkTest") {
 
   SECTION("AdjListPropertyArrowChunkReader") {
     auto maybe_reader = AdjListPropertyArrowChunkReader::Make(
-        graph_info, src_label, edge_label, dst_label, edge_property_name,
+        graph_info, src_type, edge_type, dst_type, edge_property_name,
         AdjListType::ordered_by_source);
     REQUIRE(maybe_reader.status().ok());
     auto reader = maybe_reader.value();
@@ -496,24 +497,24 @@ TEST_CASE_METHOD(GlobalFixture, "EmptyChunkTest") {
 TEST_CASE_METHOD(GlobalFixture, "JSON_TEST") {
   // read file and construct graph info
   std::string path = test_data_dir + "/ldbc_sample/json/LdbcSample.graph.yml";
-  std::string src_label = "Person", edge_label = "Knows", dst_label = "Person";
+  std::string src_type = "Person", edge_type = "Knows", dst_type = "Person";
   std::string vertex_property_name = "id";
   std::string edge_property_name = "creationDate";
   auto maybe_graph_info = GraphInfo::Load(path);
   REQUIRE(maybe_graph_info.status().ok());
   auto graph_info = maybe_graph_info.value();
-  auto vertex_info = graph_info->GetVertexInfo(src_label);
+  auto vertex_info = graph_info->GetVertexInfo(src_type);
   REQUIRE(vertex_info != nullptr);
   auto v_pg = vertex_info->GetPropertyGroup(vertex_property_name);
   REQUIRE(v_pg != nullptr);
-  auto edge_info = graph_info->GetEdgeInfo(src_label, edge_label, dst_label);
+  auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
   REQUIRE(edge_info != nullptr);
   auto e_pg = edge_info->GetPropertyGroup(edge_property_name);
   REQUIRE(e_pg != nullptr);
 
   SECTION("VertexPropertyArrowChunkReader") {
     auto maybe_reader = VertexPropertyArrowChunkReader::Make(
-        graph_info, src_label, vertex_property_name);
+        graph_info, src_type, vertex_property_name);
     REQUIRE(maybe_reader.status().ok());
     auto reader = maybe_reader.value();
     REQUIRE(reader->GetChunkNum() == 10);

--- a/cpp/test/test_chunk_info_reader.cc
+++ b/cpp/test/test_chunk_info_reader.cc
@@ -30,17 +30,17 @@ TEST_CASE_METHOD(GlobalFixture, "ChunkInfoReader") {
   // read file and construct graph info
   std::string path =
       test_data_dir + "/ldbc_sample/parquet/ldbc_sample.graph.yml";
-  std::string src_label = "person", edge_label = "knows", dst_label = "person";
+  std::string src_type = "person", edge_type = "knows", dst_type = "person";
   std::string vertex_property_name = "id";
   std::string edge_property_name = "creationDate";
   auto maybe_graph_info = GraphInfo::Load(path);
   REQUIRE(maybe_graph_info.status().ok());
   auto graph_info = maybe_graph_info.value();
-  auto vertex_info = graph_info->GetVertexInfo(src_label);
+  auto vertex_info = graph_info->GetVertexInfo(src_type);
   REQUIRE(vertex_info != nullptr);
   auto v_pg = vertex_info->GetPropertyGroup(vertex_property_name);
   REQUIRE(v_pg != nullptr);
-  auto edge_info = graph_info->GetEdgeInfo(src_label, edge_label, dst_label);
+  auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
   REQUIRE(edge_info != nullptr);
   auto e_pg = edge_info->GetPropertyGroup(edge_property_name);
   REQUIRE(e_pg != nullptr);
@@ -48,7 +48,7 @@ TEST_CASE_METHOD(GlobalFixture, "ChunkInfoReader") {
   SECTION("VertexPropertyChunkInfoReader") {
     // make from graph info and property name
     auto maybe_reader = VertexPropertyChunkInfoReader::Make(
-        graph_info, src_label, vertex_property_name);
+        graph_info, src_type, vertex_property_name);
     REQUIRE(!maybe_reader.has_error());
     auto reader = maybe_reader.value();
     REQUIRE(reader->GetChunkNum() == 10);
@@ -85,7 +85,7 @@ TEST_CASE_METHOD(GlobalFixture, "ChunkInfoReader") {
 
     SECTION("Make from graph info and property group") {
       auto maybe_reader =
-          VertexPropertyChunkInfoReader::Make(graph_info, src_label, v_pg);
+          VertexPropertyChunkInfoReader::Make(graph_info, src_type, v_pg);
       REQUIRE(!maybe_reader.has_error());
       auto reader = maybe_reader.value();
       REQUIRE(reader->GetChunkNum() == 10);
@@ -102,8 +102,8 @@ TEST_CASE_METHOD(GlobalFixture, "ChunkInfoReader") {
 
   SECTION("AdjListChunkInfoReader") {
     auto maybe_reader =
-        AdjListChunkInfoReader::Make(graph_info, src_label, edge_label,
-                                     dst_label, AdjListType::ordered_by_source);
+        AdjListChunkInfoReader::Make(graph_info, src_type, edge_type,
+                                     dst_type, AdjListType::ordered_by_source);
     REQUIRE(maybe_reader.status().ok());
     auto reader = maybe_reader.value();
 
@@ -173,7 +173,7 @@ TEST_CASE_METHOD(GlobalFixture, "ChunkInfoReader") {
 
   SECTION("AdjListOffsetChunkInfoReader") {
     auto maybe_offset_reader = AdjListOffsetChunkInfoReader::Make(
-        graph_info, src_label, edge_label, dst_label,
+        graph_info, src_type, edge_type, dst_type,
         AdjListType::ordered_by_source);
     REQUIRE(maybe_offset_reader.status().ok());
     auto reader = maybe_offset_reader.value();
@@ -222,7 +222,7 @@ TEST_CASE_METHOD(GlobalFixture, "ChunkInfoReader") {
 
   SECTION("AdjListPropertyChunkInfoReader") {
     auto maybe_property_reader = AdjListPropertyChunkInfoReader::Make(
-        graph_info, src_label, edge_label, dst_label, edge_property_name,
+        graph_info, src_type, edge_type, dst_type, edge_property_name,
         AdjListType::ordered_by_source);
     REQUIRE(maybe_property_reader.status().ok());
     auto reader = maybe_property_reader.value();
@@ -275,7 +275,7 @@ TEST_CASE_METHOD(GlobalFixture, "ChunkInfoReader") {
     SECTION("Make from graph info and property group") {
       // test reader to read ordered by dest
       auto maybe_dst_reader = AdjListPropertyChunkInfoReader::Make(
-          graph_info, src_label, edge_label, dst_label, e_pg,
+          graph_info, src_type, edge_type, dst_type, e_pg,
           AdjListType::ordered_by_dest);
       REQUIRE(maybe_dst_reader.status().ok());
       auto dst_reader = maybe_dst_reader.value();

--- a/cpp/test/test_chunk_info_reader.cc
+++ b/cpp/test/test_chunk_info_reader.cc
@@ -102,8 +102,8 @@ TEST_CASE_METHOD(GlobalFixture, "ChunkInfoReader") {
 
   SECTION("AdjListChunkInfoReader") {
     auto maybe_reader =
-        AdjListChunkInfoReader::Make(graph_info, src_type, edge_type,
-                                     dst_type, AdjListType::ordered_by_source);
+        AdjListChunkInfoReader::Make(graph_info, src_type, edge_type, dst_type,
+                                     AdjListType::ordered_by_source);
     REQUIRE(maybe_reader.status().ok());
     auto reader = maybe_reader.value();
 

--- a/cpp/test/test_graph.cc
+++ b/cpp/test/test_graph.cc
@@ -113,8 +113,7 @@ TEST_CASE_METHOD(GlobalFixture, "Graph") {
   }
 
   SECTION("EdgesCollection") {
-    std::string src_type = "person", edge_type = "knows",
-                dst_type = "person";
+    std::string src_type = "person", edge_type = "knows", dst_type = "person";
     // iterate edges of vertex chunk 0
     auto expect =
         EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,

--- a/cpp/test/test_graph.cc
+++ b/cpp/test/test_graph.cc
@@ -113,11 +113,11 @@ TEST_CASE_METHOD(GlobalFixture, "Graph") {
   }
 
   SECTION("EdgesCollection") {
-    std::string src_label = "person", edge_label = "knows",
-                dst_label = "person";
+    std::string src_type = "person", edge_type = "knows",
+                dst_type = "person";
     // iterate edges of vertex chunk 0
     auto expect =
-        EdgesCollection::Make(graph_info, src_label, edge_label, dst_label,
+        EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
                               AdjListType::ordered_by_source, 0, 1);
     REQUIRE(!expect.has_error());
     auto edges = expect.value();
@@ -144,7 +144,7 @@ TEST_CASE_METHOD(GlobalFixture, "Graph") {
 
     // iterate edges of vertex chunk [2, 4)
     auto expect1 =
-        EdgesCollection::Make(graph_info, src_label, edge_label, dst_label,
+        EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
                               AdjListType::ordered_by_dest, 2, 4);
     REQUIRE(!expect1.has_error());
     auto edges1 = expect1.value();
@@ -158,7 +158,7 @@ TEST_CASE_METHOD(GlobalFixture, "Graph") {
 
     // iterate all edges
     auto expect2 =
-        EdgesCollection::Make(graph_info, src_label, edge_label, dst_label,
+        EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
                               AdjListType::ordered_by_source);
     REQUIRE(!expect2.has_error());
     auto& edges2 = expect2.value();
@@ -175,7 +175,7 @@ TEST_CASE_METHOD(GlobalFixture, "Graph") {
 
     // empty collection
     auto expect3 =
-        EdgesCollection::Make(graph_info, src_label, edge_label, dst_label,
+        EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
                               AdjListType::unordered_by_source, 5, 5);
     REQUIRE(!expect2.has_error());
     auto edges3 = expect3.value();
@@ -190,7 +190,7 @@ TEST_CASE_METHOD(GlobalFixture, "Graph") {
 
     // invalid adjlist type
     auto expect4 =
-        EdgesCollection::Make(graph_info, src_label, edge_label, dst_label,
+        EdgesCollection::Make(graph_info, src_type, edge_type, dst_type,
                               AdjListType::unordered_by_dest);
     REQUIRE(expect4.status().IsInvalid());
   }

--- a/cpp/test/test_info.cc
+++ b/cpp/test/test_info.cc
@@ -223,8 +223,8 @@ TEST_CASE_METHOD(GlobalFixture, "VertexInfo") {
     REQUIRE(vertex_info->IsValidated() == true);
     auto invalid_pg =
         CreatePropertyGroup({Property("p0", nullptr, true)}, FileType::CSV);
-    auto invalid_vertex_info0 = CreateVertexInfo(
-        type, chunk_size, {invalid_pg}, "test_vertex/", version);
+    auto invalid_vertex_info0 = CreateVertexInfo(type, chunk_size, {invalid_pg},
+                                                 "test_vertex/", version);
     REQUIRE(invalid_vertex_info0->IsValidated() == false);
     VertexInfo invalid_vertex_info1("", chunk_size, {pg}, "test_vertex/",
                                     version);
@@ -415,17 +415,17 @@ TEST_CASE_METHOD(GlobalFixture, "EdgeInfo") {
     for (int i = 0; i < 3; i++) {
       std::vector<std::string> types = {src_type, edge_type, dst_type};
       types[i] = "";
-      auto edge_info = CreateEdgeInfo(
-          types[0], types[1], types[2], chunk_size, src_chunk_size,
-          dst_chunk_size, directed, {adj_list}, {pg}, "test_edge/", version);
+      auto edge_info = CreateEdgeInfo(types[0], types[1], types[2], chunk_size,
+                                      src_chunk_size, dst_chunk_size, directed,
+                                      {adj_list}, {pg}, "test_edge/", version);
       REQUIRE(edge_info == nullptr);
     }
     for (int i = 0; i < 3; i++) {
       std::vector<int> sizes = {chunk_size, src_chunk_size, dst_chunk_size};
       sizes[i] = 0;
-      auto edge_info = CreateEdgeInfo(src_type, edge_type, dst_type,
-                                      sizes[0], sizes[1], sizes[2], directed,
-                                      {adj_list}, {pg}, "test_edge/", version);
+      auto edge_info = CreateEdgeInfo(src_type, edge_type, dst_type, sizes[0],
+                                      sizes[1], sizes[2], directed, {adj_list},
+                                      {pg}, "test_edge/", version);
       REQUIRE(edge_info == nullptr);
     }
     auto edge_info_empty_adjlist = CreateEdgeInfo(
@@ -667,8 +667,9 @@ vertices:
     REQUIRE(extend_info->EdgeInfoNum() == 2);
     REQUIRE(extend_info->GetEdgeInfoByIndex(1)->GetEdgeType() == "knows2");
     REQUIRE(extend_info->GetEdgeInfoByIndex(2) == nullptr);
-    REQUIRE(extend_info->GetEdgeInfo("person", "knows2", "person")
-                ->GetEdgeType() == "knows2");
+    REQUIRE(
+        extend_info->GetEdgeInfo("person", "knows2", "person")->GetEdgeType() ==
+        "knows2");
     REQUIRE(extend_info->GetEdgeInfo("not_exist", "knows2", "person") ==
             nullptr);
     REQUIRE(extend_info->GetEdgeInfos().size() == 2);

--- a/docs/libraries/cpp/examples/bgl.md
+++ b/docs/libraries/cpp/examples/bgl.md
@@ -86,9 +86,9 @@ std::vector<graphar::Property> property_vector = {cc};
 auto group = graphar::CreatePropertyGroup(property_vector, graphar::FileType::PARQUET);
 
 // construct the new vertex info
-std::string vertex_type = "cc_result", vertex_prefix = "result/";
+std::string vertex_label = "cc_result", vertex_prefix = "result/";
 int chunk_size = 100;
-auto new_info = graphar::CreateVertexInfo(vertex_type, chunk_size, {group}, vertex_prefix);
+auto new_info = graphar::CreateVertexInfo(vertex_label, chunk_size, {group}, vertex_prefix);
 
 // access the vertices via the index map and vertex iterator of BGL
 typedef boost::property_map<Graph, boost::vertex_index_t>::type IndexMap;

--- a/docs/libraries/cpp/examples/bgl.md
+++ b/docs/libraries/cpp/examples/bgl.md
@@ -86,9 +86,9 @@ std::vector<graphar::Property> property_vector = {cc};
 auto group = graphar::CreatePropertyGroup(property_vector, graphar::FileType::PARQUET);
 
 // construct the new vertex info
-std::string vertex_label = "cc_result", vertex_prefix = "result/";
+std::string vertex_type = "cc_result", vertex_prefix = "result/";
 int chunk_size = 100;
-auto new_info = graphar::CreateVertexInfo(vertex_label, chunk_size, {group}, vertex_prefix);
+auto new_info = graphar::CreateVertexInfo(vertex_type, chunk_size, {group}, vertex_prefix);
 
 // access the vertices via the index map and vertex iterator of BGL
 typedef boost::property_map<Graph, boost::vertex_index_t>::type IndexMap;

--- a/docs/libraries/cpp/examples/snap-to-graphar.md
+++ b/docs/libraries/cpp/examples/snap-to-graphar.md
@@ -32,11 +32,11 @@ storage of the vertex information file.
 auto version = graphar::InfoVersion::Parse("gar/v1").value();
 
 // meta info
-std::string vertex_label = "node", vertex_prefix = "vertex/node/";
+std::string vertex_type = "node", vertex_prefix = "vertex/node/";
 
 // create vertex info
 auto vertex_info = graphar::CreateVertexInfo(
-    vertex_label, VERTEX_CHUNK_SIZE, {}, vertex_prefix, version);
+    vertex_type, VERTEX_CHUNK_SIZE, {}, vertex_prefix, version);
 
 // save & dump vertex info
 ASSERT(!vertex_info->Dump().has_error());

--- a/docs/libraries/cpp/examples/snap-to-graphar.md
+++ b/docs/libraries/cpp/examples/snap-to-graphar.md
@@ -32,11 +32,11 @@ storage of the vertex information file.
 auto version = graphar::InfoVersion::Parse("gar/v1").value();
 
 // meta info
-std::string vertex_type = "node", vertex_prefix = "vertex/node/";
+std::string vertex_label = "node", vertex_prefix = "vertex/node/";
 
 // create vertex info
 auto vertex_info = graphar::CreateVertexInfo(
-    vertex_type, VERTEX_CHUNK_SIZE, {}, vertex_prefix, version);
+    vertex_label, VERTEX_CHUNK_SIZE, {}, vertex_prefix, version);
 
 // save & dump vertex info
 ASSERT(!vertex_info->Dump().has_error());

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/EdgeInfo.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/EdgeInfo.scala
@@ -29,9 +29,9 @@ import org.yaml.snakeyaml.LoaderOptions
 
 /** Edge info is a class to store the edge meta information. */
 class EdgeInfo() {
-  @BeanProperty var src_label: String = ""
-  @BeanProperty var edge_label: String = ""
-  @BeanProperty var dst_label: String = ""
+  @BeanProperty var src_type: String = ""
+  @BeanProperty var edge_type: String = ""
+  @BeanProperty var dst_type: String = ""
   @BeanProperty var chunk_size: Long = 0
   @BeanProperty var src_chunk_size: Long = 0
   @BeanProperty var dst_chunk_size: Long = 0
@@ -277,7 +277,7 @@ class EdgeInfo() {
 
   /** Check if the edge info is validated. */
   def isValidated(): Boolean = {
-    if (src_label == "" || edge_label == "" || dst_label == "") {
+    if (src_type == "" || edge_type == "" || dst_type == "") {
       return false
     }
     if (chunk_size <= 0 || src_chunk_size <= 0 || dst_chunk_size <= 0) {
@@ -585,15 +585,15 @@ class EdgeInfo() {
   }
 
   def getConcatKey(): String = {
-    return getSrc_label + GeneralParams.regularSeparator + getEdge_label + GeneralParams.regularSeparator + getDst_label
+    return getSrc_type + GeneralParams.regularSeparator + getEdge_type + GeneralParams.regularSeparator + getDst_type
   }
 
   /** Dump to Yaml string. */
   def dump(): String = {
     val data = new java.util.HashMap[String, Object]()
-    data.put("src_label", src_label)
-    data.put("edge_label", edge_label)
-    data.put("dst_label", dst_label)
+    data.put("src_type", src_type)
+    data.put("edge_type", edge_type)
+    data.put("dst_type", dst_type)
     data.put("chunk_size", new java.lang.Long(chunk_size))
     data.put("src_chunk_size", new java.lang.Long(src_chunk_size))
     data.put("dst_chunk_size", new java.lang.Long(dst_chunk_size))

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/GraphInfo.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/GraphInfo.scala
@@ -323,24 +323,24 @@ class GraphInfo() {
   var edgeInfos: Map[String, EdgeInfo] = Map[String, EdgeInfo]()
 
   def addVertexInfo(vertexInfo: VertexInfo): Unit = {
-    vertexInfos += (vertexInfo.getLabel -> vertexInfo)
+    vertexInfos += (vertexInfo.getType -> vertexInfo)
   }
 
   def addEdgeInfo(edgeInfo: EdgeInfo): Unit = {
     edgeInfos += (edgeInfo.getConcatKey() -> edgeInfo)
   }
 
-  def getVertexInfo(label: String): VertexInfo = {
-    vertexInfos(label)
+  def getVertexInfo(vertexType: String): VertexInfo = {
+    vertexInfos(vertexType)
   }
 
   def getEdgeInfo(
-      srcLabel: String,
-      edgeLabel: String,
-      dstLabel: String
+      srcType: String,
+      edgeType: String,
+      dstType: String
   ): EdgeInfo = {
     val key =
-      srcLabel + GeneralParams.regularSeparator + edgeLabel + GeneralParams.regularSeparator + dstLabel
+      srcType + GeneralParams.regularSeparator + edgeType + GeneralParams.regularSeparator + dstType
     edgeInfos(key)
   }
 

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/VertexInfo.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/VertexInfo.scala
@@ -28,7 +28,7 @@ import org.yaml.snakeyaml.LoaderOptions
 
 /** VertexInfo is a class to store the vertex meta information. */
 class VertexInfo() {
-  @BeanProperty var label: String = ""
+  @BeanProperty var `type`: String = ""
   @BeanProperty var chunk_size: Long = 0
   @BeanProperty var prefix: String = ""
   @BeanProperty var property_groups = new java.util.ArrayList[PropertyGroup]()
@@ -200,7 +200,7 @@ class VertexInfo() {
    *   true if the vertex info is validated, otherwise return false.
    */
   def isValidated(): Boolean = {
-    if (label == "" || chunk_size <= 0) {
+    if (`type` == "" || chunk_size <= 0) {
       return false
     }
     val len: Int = property_groups.size
@@ -283,7 +283,7 @@ class VertexInfo() {
   /** Dump to Yaml string. */
   def dump(): String = {
     val data = new java.util.HashMap[String, Object]()
-    data.put("label", label)
+    data.put("type", `type`)
     data.put("chunk_size", new java.lang.Long(chunk_size))
     if (prefix != "") data.put("prefix", prefix)
     data.put("version", version)

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/example/GraphAr2Nebula.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/example/GraphAr2Nebula.scala
@@ -84,10 +84,10 @@ object GraphAr2Nebula {
       edgeData: Map[(String, String, String), Map[String, DataFrame]]
   ): Unit = {
     // write each edge type to Nebula
-    edgeData.foreach { case (srcEdgeDstLabels, orderMap) =>
-      val sourceTag = srcEdgeDstLabels._1
-      val edgeType = srcEdgeDstLabels._2
-      val targetTag = srcEdgeDstLabels._3
+    edgeData.foreach { case (srcEdgeDstTypes, orderMap) =>
+      val sourceTag = srcEdgeDstTypes._1
+      val edgeType = srcEdgeDstTypes._2
+      val targetTag = srcEdgeDstTypes._3
       val sourcePrimaryKey = graphInfo.getVertexInfo(sourceTag).getPrimaryKey()
       val targetPrimaryKey = graphInfo.getVertexInfo(targetTag).getPrimaryKey()
       val sourceDF = vertexData(sourceTag)

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/example/GraphAr2Neo4j.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/example/GraphAr2Neo4j.scala
@@ -72,7 +72,7 @@ object GraphAr2Neo4j {
           .write
           .format("org.neo4j.spark.DataSource")
           .mode(SaveMode.Overwrite)
-          .option("types", ":" + key)
+          .option("labels", ":" + key)
           .option("node.keys", primaryKey)
           .save()
       }
@@ -114,10 +114,10 @@ object GraphAr2Neo4j {
           .mode(SaveMode.Overwrite)
           .option("relationship", edgeType)
           .option("relationship.save.strategy", "keys")
-          .option("relationship.source.types", ":" + sourceType)
+          .option("relationship.source.labels", ":" + sourceType)
           .option("relationship.source.save.mode", "match")
           .option("relationship.source.node.keys", "src:" + sourcePrimaryKey)
-          .option("relationship.target.types", ":" + targetType)
+          .option("relationship.target.labels", ":" + targetType)
           .option("relationship.target.save.mode", "match")
           .option("relationship.target.node.keys", "dst:" + targetPrimaryKey)
           .option("relationship.properties", properties)

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/example/GraphAr2Neo4j.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/example/GraphAr2Neo4j.scala
@@ -72,7 +72,7 @@ object GraphAr2Neo4j {
           .write
           .format("org.neo4j.spark.DataSource")
           .mode(SaveMode.Overwrite)
-          .option("labels", ":" + key)
+          .option("types", ":" + key)
           .option("node.keys", primaryKey)
           .save()
       }
@@ -88,15 +88,15 @@ object GraphAr2Neo4j {
     // write each edge type to Neo4j
     edgeData.foreach {
       case (key, value) => {
-        val sourceLabel = key._1
-        val edgeLabel = key._2
-        val targetLabel = key._3
+        val sourceType = key._1
+        val edgeType = key._2
+        val targetType = key._3
         val sourcePrimaryKey =
-          graphInfo.getVertexInfo(sourceLabel).getPrimaryKey()
+          graphInfo.getVertexInfo(sourceType).getPrimaryKey()
         val targetPrimaryKey =
-          graphInfo.getVertexInfo(targetLabel).getPrimaryKey()
-        val sourceDf = vertexData(sourceLabel)
-        val targetDf = vertexData(targetLabel)
+          graphInfo.getVertexInfo(targetType).getPrimaryKey()
+        val sourceDf = vertexData(sourceType)
+        val targetDf = vertexData(targetType)
         // convert the source and target index column to the primary key column
         val df = Utils.joinEdgesWithVertexPrimaryKey(
           value.head._2,
@@ -107,17 +107,17 @@ object GraphAr2Neo4j {
         ) // use the first DataFrame of (adj_list_type_str, DataFrame) map
 
         // FIXME: use properties message in edge info
-        val properties = if (edgeLabel == "REVIEWED") "rating,summary" else ""
+        val properties = if (edgeType == "REVIEWED") "rating,summary" else ""
 
         df.write
           .format("org.neo4j.spark.DataSource")
           .mode(SaveMode.Overwrite)
-          .option("relationship", edgeLabel)
+          .option("relationship", edgeType)
           .option("relationship.save.strategy", "keys")
-          .option("relationship.source.labels", ":" + sourceLabel)
+          .option("relationship.source.types", ":" + sourceType)
           .option("relationship.source.save.mode", "match")
           .option("relationship.source.node.keys", "src:" + sourcePrimaryKey)
-          .option("relationship.target.labels", ":" + targetLabel)
+          .option("relationship.target.types", ":" + targetType)
           .option("relationship.target.save.mode", "match")
           .option("relationship.target.node.keys", "dst:" + targetPrimaryKey)
           .option("relationship.properties", properties)

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/example/LdbcSample2GraphAr.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/example/LdbcSample2GraphAr.scala
@@ -81,14 +81,14 @@ object LdbcSample2GraphAr {
       personInputPath: String,
       personKnowsPersonInputPath: String
   ): Unit = {
-    // read vertices with label "Person" from given path as a DataFrame
+    // read vertices with type "Person" from given path as a DataFrame
     val person_df = spark.read
       .option("delimiter", "|")
       .option("header", "true")
       .option("inferSchema", "true")
       .format("csv")
       .load(personInputPath)
-    // put into writer, vertex label is "Person"
+    // put into writer, vertex type is "Person"
     writer.PutVertexData("Person", person_df)
 
     // read edges with type "Person"->"Knows"->"Person" from given path as a DataFrame
@@ -98,8 +98,8 @@ object LdbcSample2GraphAr {
       .option("inferSchema", "true")
       .format("csv")
       .load(personKnowsPersonInputPath)
-    // put into writer, source vertex label is "Person", edge label is "Knows"
-    // target vertex label is "Person"
+    // put into writer, source vertex type is "Person", edge type is "Knows"
+    // target vertex type is "Person"
     writer.PutEdgeData(("Person", "Knows", "Person"), knows_edge_df)
   }
 }

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/example/Neo4j2GraphAr.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/example/Neo4j2GraphAr.scala
@@ -82,7 +82,7 @@ object Neo4j2GraphAr {
       .option("query", "MATCH (n:Person) RETURN n.name AS name, n.born as born")
       .option("schema.flatten.limit", 1)
       .load()
-    // put into writer, vertex label is "Person"
+    // put into writer, vertex type is "Person"
     writer.PutVertexData("Person", person_df)
 
     // read vertices with label "Movie" from Neo4j as a DataFrame
@@ -94,7 +94,7 @@ object Neo4j2GraphAr {
       )
       .option("schema.flatten.limit", 1)
       .load()
-    // put into writer, vertex label is "Movie"
+    // put into writer, vertex type is "Movie"
     writer.PutVertexData("Movie", movie_df)
 
     // read edges with type "Person"->"PRODUCED"->"Movie" from Neo4j as a DataFrame
@@ -106,8 +106,8 @@ object Neo4j2GraphAr {
       )
       .option("schema.flatten.limit", 1)
       .load()
-    // put into writer, source vertex label is "Person", edge label is "PRODUCED"
-    // target vertex label is "Movie"
+    // put into writer, source vertex type is "Person", edge type is "PRODUCED"
+    // target vertex type is "Movie"
     writer.PutEdgeData(("Person", "PRODUCED", "Movie"), produced_edge_df)
 
     // read edges with type "Person"->"ACTED_IN"->"Movie" from Neo4j as a DataFrame
@@ -119,8 +119,8 @@ object Neo4j2GraphAr {
       )
       .option("schema.flatten.limit", 1)
       .load()
-    // put into writer, source vertex label is "Person", edge label is "ACTED_IN"
-    // target vertex label is "Movie"
+    // put into writer, source vertex type is "Person", edge type is "ACTED_IN"
+    // target vertex type is "Movie"
     writer.PutEdgeData(("Person", "ACTED_IN", "Movie"), acted_in_edge_df)
 
     // read edges with type "Person"->"DIRECTED"->"Movie" from Neo4j as a DataFrame
@@ -132,8 +132,8 @@ object Neo4j2GraphAr {
       )
       .option("schema.flatten.limit", 1)
       .load()
-    // put into writer, source vertex label is "Person", edge label is "DIRECTED"
-    // target vertex label is "Movie"
+    // put into writer, source vertex type is "Person", edge type is "DIRECTED"
+    // target vertex type is "Movie"
     writer.PutEdgeData(("Person", "DIRECTED", "Movie"), directed_edge_df)
 
     // read edges with type "Person"->"FOLLOWS"->"Person" from Neo4j as a DataFrame
@@ -145,8 +145,8 @@ object Neo4j2GraphAr {
       )
       .option("schema.flatten.limit", 1)
       .load()
-    // put into writer, source vertex label is "Person", edge label is "FOLLOWS"
-    // target vertex label is "Person"
+    // put into writer, source vertex type is "Person", edge type is "FOLLOWS"
+    // target vertex type is "Person"
     writer.PutEdgeData(("Person", "FOLLOWS", "Person"), follows_edge_df)
 
     // read edges with type "Person"->"REVIEWED"->"Movie" from Neo4j as a DataFrame
@@ -158,8 +158,8 @@ object Neo4j2GraphAr {
       )
       .option("schema.flatten.limit", 1)
       .load()
-    // put into writer, source vertex label is "Person", edge label is "REVIEWED"
-    // target vertex label is "Movie"
+    // put into writer, source vertex type is "Person", edge type is "REVIEWED"
+    // target vertex type is "Movie"
     writer.PutEdgeData(("Person", "REVIEWED", "Movie"), reviewed_edge_df)
 
     // read edges with type "Person"->"WROTE"->"Movie" from Neo4j as a DataFrame
@@ -171,8 +171,8 @@ object Neo4j2GraphAr {
       )
       .option("schema.flatten.limit", 1)
       .load()
-    // put into writer, source vertex label is "Person", edge label is "WROTE"
-    // target vertex label is "Movie"
+    // put into writer, source vertex type is "Person", edge type is "WROTE"
+    // target vertex type is "Movie"
     writer.PutEdgeData(("Person", "WROTE", "Movie"), wrote_edge_df)
   }
 }

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/graph/GraphReader.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/graph/GraphReader.scala
@@ -35,11 +35,11 @@ object GraphReader {
    * @param prefix
    *   The absolute prefix.
    * @param vertexInfos
-   *   The map of (vertex label -> VertexInfo) for the graph.
+   *   The map of (vertex type -> VertexInfo) for the graph.
    * @param spark
    *   The Spark session for the reading.
    * @return
-   *   The map of (vertex label -> DataFrame)
+   *   The map of (vertex type -> DataFrame)
    */
   private def readAllVertices(
       prefix: String,
@@ -47,9 +47,9 @@ object GraphReader {
       spark: SparkSession
   ): Map[String, DataFrame] = {
     val vertex_dataframes: Map[String, DataFrame] = vertexInfos.map {
-      case (label, vertexInfo) => {
+      case (vertex_type, vertexInfo) => {
         val reader = new VertexReader(prefix, vertexInfo, spark)
-        (label, reader.readAllVertexPropertyGroups())
+        (vertex_type, reader.readAllVertexPropertyGroups())
       }
     }
     return vertex_dataframes
@@ -61,11 +61,11 @@ object GraphReader {
    * @param prefix
    *   The absolute prefix.
    * @param edgeInfos
-   *   The map of ((srcLabel, edgeLabel, dstLabel) -> EdgeInfo) for the graph.
+   *   The map of ((srcType, edgeType, dstType) -> EdgeInfo) for the graph.
    * @param spark
    *   The Spark session for the reading.
    * @return
-   *   The map of ((srcLabel, edgeLabel, dstLabel) -> (adj_list_type_str ->
+   *   The map of ((srcType, edgeType, dstType) -> (adj_list_type_str ->
    *   DataFrame))
    */
   private def readAllEdges(
@@ -91,9 +91,9 @@ object GraphReader {
           }
           (
             (
-              edgeInfo.getSrc_label(),
-              edgeInfo.getEdge_label(),
-              edgeInfo.getDst_label()
+              edgeInfo.getSrc_type(),
+              edgeInfo.getEdge_type(),
+              edgeInfo.getDst_type()
             ),
             adj_list_type_edge_df_map
           )
@@ -111,8 +111,8 @@ object GraphReader {
    *   The Spark session for the loading.
    * @return
    *   Pair of vertex DataFrames and edge DataFrames, the vertex DataFrames are
-   *   stored as the map of (vertex_label -> DataFrame) the edge DataFrames are
-   *   stored as a map of ((srcLabel, edgeLabel, dstLabel) -> (adj_list_type_str
+   *   stored as the map of (vertex_type -> DataFrame) the edge DataFrames are
+   *   stored as a map of ((srcType, edgeType, dstType) -> (adj_list_type_str
    * -> DataFrame))
    */
   def readWithGraphInfo(
@@ -144,8 +144,8 @@ object GraphReader {
    *   The Spark session for the loading.
    * @return
    *   Pair of vertex DataFrames and edge DataFrames, the vertex DataFrames are
-   *   stored as the map of (vertex_label -> DataFrame) the edge DataFrames are
-   *   stored as a map of (srcLabel_edgeLabel_dstLabel -> (adj_list_type_str ->
+   *   stored as the map of (vertex_type -> DataFrame) the edge DataFrames are
+   *   stored as a map of (srcType_edgeType_dstType -> (adj_list_type_str ->
    *   DataFrame))
    */
   def read(

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/graph/GraphTransformer.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/graph/GraphTransformer.scala
@@ -46,7 +46,7 @@ object GraphTransformer {
    * @param destGraphInfo
    *   The info object for the destination graph.
    * @param sourceVertexInfosMap
-   *   The map of (vertex label -> VertexInfo) for the source graph.
+   *   The map of (vertex type -> VertexInfo) for the source graph.
    * @param spark
    *   The Spark session for the transformer.
    */
@@ -66,13 +66,13 @@ object GraphTransformer {
       val path = dest_prefix + dest_vertices_it.next()
       val dest_vertex_info = VertexInfo.loadVertexInfo(path, spark)
       // load source vertex info
-      val label = dest_vertex_info.getLabel()
-      if (!sourceVertexInfosMap.contains(label)) {
+      val vertex_type = dest_vertex_info.getType()
+      if (!sourceVertexInfosMap.contains(vertex_type)) {
         throw new IllegalArgumentException(
-          "vertex info of " + label + " not found in graph info."
+          "vertex info of " + vertex_type + " not found in graph info."
         )
       }
-      val source_vertex_info = sourceVertexInfosMap(label)
+      val source_vertex_info = sourceVertexInfosMap(vertex_type)
       // read vertex chunks from the source graph
       val reader = new VertexReader(source_prefix, source_vertex_info, spark)
       val df = reader.readAllVertexPropertyGroups()
@@ -93,9 +93,9 @@ object GraphTransformer {
    * @param destGraphInfo
    *   The info object for the destination graph.
    * @param sourceVertexInfosMap
-   *   The map of (vertex label -> VertexInfo) for the source graph.
+   *   The map of (vertex type -> VertexInfo) for the source graph.
    * @param sourceEdgeInfosMap
-   *   The map of (edge label -> EdgeInfo) for the source graph.
+   *   The map of (edge type -> EdgeInfo) for the source graph.
    * @param spark
    *   The Spark session for the transformer.
    */
@@ -153,20 +153,20 @@ object GraphTransformer {
         }
 
         // read vertices number
-        val vertex_label = {
+        val vertex_type = {
           if (
             dest_adj_list_type == AdjListType.ordered_by_source || dest_adj_list_type == AdjListType.unordered_by_source
           )
-            dest_edge_info.getSrc_label
+            dest_edge_info.getSrc_type
           else
-            dest_edge_info.getDst_label
+            dest_edge_info.getDst_type
         }
-        if (!sourceVertexInfosMap.contains(vertex_label)) {
+        if (!sourceVertexInfosMap.contains(vertex_type)) {
           throw new IllegalArgumentException(
-            "vertex info of " + vertex_label + " not found in graph info."
+            "vertex info of " + vertex_type + " not found in graph info."
           )
         }
-        val vertex_info = sourceVertexInfosMap(vertex_label)
+        val vertex_info = sourceVertexInfosMap(vertex_type)
         val reader = new VertexReader(source_prefix, vertex_info, spark)
         val vertex_num = reader.readVerticesNumber()
 

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/graph/GraphWriter.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/graph/GraphWriter.scala
@@ -36,8 +36,8 @@ class GraphWriter() {
   /**
    * Put the vertex DataFrame into writer.
    *
-   * @param label
-   *   label of vertex.
+   * @param type
+   *   type of vertex.
    * @param df
    *   DataFrame of the vertex type.
    * @param primaryKey
@@ -45,23 +45,23 @@ class GraphWriter() {
    *   property column as primary key.
    */
   def PutVertexData(
-      label: String,
+      vertexType: String,
       df: DataFrame,
       primaryKey: String = ""
   ): Unit = {
-    if (vertices.exists(_._1 == label)) {
+    if (vertices.exists(_._1 == vertexType)) {
       throw new IllegalArgumentException(
-        "Vertex data of label " + label + " has been put."
+        "Vertex data of type " + vertexType + " has been put."
       )
     }
-    vertices += label -> df
-    primaryKeys += label -> primaryKey
+    vertices += vertexType -> df
+    primaryKeys += vertexType -> primaryKey
   }
 
   /**
    * Put the edge dataframe into writer.
    * @param relation
-   *   3-Tuple (source label, edge label, target label) to indicate edge type.
+   *   3-Tuple (source type, edge type, target type) to indicate edge relation.
    * @param df
    *   data frame of edge type.
    */
@@ -88,25 +88,25 @@ class GraphWriter() {
     var indexMappings: scala.collection.mutable.Map[String, DataFrame] =
       scala.collection.mutable.Map[String, DataFrame]()
     vertexInfos.foreach {
-      case (label, vertexInfo) => {
-        val primaryKey = primaryKeys(label)
-        vertices(label).persist(
+      case (vertexType, vertexInfo) => {
+        val primaryKey = primaryKeys(vertexType)
+        vertices(vertexType).persist(
           GeneralParams.defaultStorageLevel
         ) // cache the vertex DataFrame
         val df_and_mapping = IndexGenerator
-          .generateVertexIndexColumnAndIndexMapping(vertices(label), primaryKey)
+          .generateVertexIndexColumnAndIndexMapping(vertices(vertexType), primaryKey)
         df_and_mapping._1.persist(
           GeneralParams.defaultStorageLevel
         ) // cache the vertex DataFrame with index
         df_and_mapping._2.persist(
           GeneralParams.defaultStorageLevel
         ) // cache the index mapping DataFrame
-        vertices(label).unpersist() // unpersist the vertex DataFrame
+        vertices(vertexType).unpersist() // unpersist the vertex DataFrame
         val df_with_index = df_and_mapping._1
-        indexMappings += label -> df_and_mapping._2
+        indexMappings += vertexType -> df_and_mapping._2
         val writer =
           new VertexWriter(prefix, vertexInfo, df_with_index)
-        vertexNums += label -> writer.getVertexNum()
+        vertexNums += vertexType -> writer.getVertexNum()
         writer.writeVertexProperties()
         df_with_index.unpersist()
       }
@@ -114,19 +114,19 @@ class GraphWriter() {
 
     edgeInfos.foreach {
       case (key, edgeInfo) => {
-        val srcLabel = edgeInfo.getSrc_label
-        val dstLabel = edgeInfo.getDst_label
-        val edgeLabel = edgeInfo.getEdge_label
-        val src_vertex_index_mapping = indexMappings(srcLabel)
+        val srcType = edgeInfo.getSrc_type
+        val dstType = edgeInfo.getDst_type
+        val edgeType = edgeInfo.getEdge_type
+        val src_vertex_index_mapping = indexMappings(srcType)
         val dst_vertex_index_mapping = {
-          if (srcLabel == dstLabel)
+          if (srcType == dstType)
             src_vertex_index_mapping
           else
-            indexMappings(dstLabel)
+            indexMappings(dstType)
         }
         val edge_df_with_index =
           IndexGenerator.generateSrcAndDstIndexForEdgesFromMapping(
-            edges((srcLabel, edgeLabel, dstLabel)),
+            edges((srcType, edgeType, dstType)),
             src_vertex_index_mapping,
             dst_vertex_index_mapping
           )
@@ -142,9 +142,9 @@ class GraphWriter() {
             if (
               adj_list_type == AdjListType.ordered_by_source || adj_list_type == AdjListType.unordered_by_source
             ) {
-              vertexNums(srcLabel)
+              vertexNums(srcType)
             } else {
-              vertexNums(dstLabel)
+              vertexNums(dstType)
             }
           }
           val writer = new EdgeWriter(

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/graph/GraphWriter.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/graph/GraphWriter.scala
@@ -94,7 +94,10 @@ class GraphWriter() {
           GeneralParams.defaultStorageLevel
         ) // cache the vertex DataFrame
         val df_and_mapping = IndexGenerator
-          .generateVertexIndexColumnAndIndexMapping(vertices(vertexType), primaryKey)
+          .generateVertexIndexColumnAndIndexMapping(
+            vertices(vertexType),
+            primaryKey
+          )
         df_and_mapping._1.persist(
           GeneralParams.defaultStorageLevel
         ) // cache the vertex DataFrame with index

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/importer/Neo4j.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/importer/Neo4j.scala
@@ -41,9 +41,9 @@ object Neo4j {
   case class Vertex(label: String, properties: List[String])
   case class Edge(
       label: String,
-      srcType: String,
+      srcLabel: String,
       srcProp: String,
-      dstType: String,
+      dstLabel: String,
       dstProp: String,
       properties: List[String]
   )

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/importer/Neo4j.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/importer/Neo4j.scala
@@ -38,9 +38,9 @@ object Neo4j {
       fileType: String
   )
   case class Neo4j(url: String, username: String, password: String)
-  case class Vertex(vertexType: String, properties: List[String])
+  case class Vertex(label: String, properties: List[String])
   case class Edge(
-      edgeType: String,
+      label: String,
       srcType: String,
       srcProp: String,
       dstType: String,
@@ -105,7 +105,7 @@ object Neo4j {
     for (vertex <- schema.vertices) {
       // construct the cypher
       val cypherBuf = new StringBuilder
-      cypherBuf.append(s"MATCH (n:${vertex.vertexType}) RETURN")
+      cypherBuf.append(s"MATCH (n:${vertex.label}) RETURN")
       for (prop <- vertex.properties) {
         cypherBuf.append(s" n.$prop AS $prop,")
       }
@@ -119,7 +119,7 @@ object Neo4j {
         .option("query", cypherBuf.toString)
         .load()
       // put into writer
-      writer.PutVertexData(vertex.vertexType, vertex_df)
+      writer.PutVertexData(vertex.label, vertex_df)
     }
 
     // read edges
@@ -128,7 +128,7 @@ object Neo4j {
       val cypherBuf = new StringBuilder
       cypherBuf
         .append(
-          s"MATCH (a:${edge.srcType})-[r:${edge.edgeType}]->(b:${edge.dstType}) RETURN"
+          s"MATCH (a:${edge.srcLabel})-[r:${edge.label}]->(b:${edge.dstLabel}) RETURN"
         )
         .append(s" a.${edge.srcProp} AS src,")
         .append(s" b.${edge.dstProp} AS dst")
@@ -142,7 +142,7 @@ object Neo4j {
         .option("query", cypherBuf.toString)
         .load()
       // put into writer
-      writer.PutEdgeData((edge.srcType, edge.edgeType, edge.dstType), edge_df)
+      writer.PutEdgeData((edge.srcLabel, edge.label, edge.dstLabel), edge_df)
     }
   }
 }

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/importer/Neo4j.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/importer/Neo4j.scala
@@ -38,12 +38,12 @@ object Neo4j {
       fileType: String
   )
   case class Neo4j(url: String, username: String, password: String)
-  case class Vertex(label: String, properties: List[String])
+  case class Vertex(vertexType: String, properties: List[String])
   case class Edge(
-      label: String,
-      srcLabel: String,
+      edgeType: String,
+      srcType: String,
       srcProp: String,
-      dstLabel: String,
+      dstType: String,
       dstProp: String,
       properties: List[String]
   )
@@ -105,7 +105,7 @@ object Neo4j {
     for (vertex <- schema.vertices) {
       // construct the cypher
       val cypherBuf = new StringBuilder
-      cypherBuf.append(s"MATCH (n:${vertex.label}) RETURN")
+      cypherBuf.append(s"MATCH (n:${vertex.vertexType}) RETURN")
       for (prop <- vertex.properties) {
         cypherBuf.append(s" n.$prop AS $prop,")
       }
@@ -119,7 +119,7 @@ object Neo4j {
         .option("query", cypherBuf.toString)
         .load()
       // put into writer
-      writer.PutVertexData(vertex.label, vertex_df)
+      writer.PutVertexData(vertex.vertexType, vertex_df)
     }
 
     // read edges
@@ -128,7 +128,7 @@ object Neo4j {
       val cypherBuf = new StringBuilder
       cypherBuf
         .append(
-          s"MATCH (a:${edge.srcLabel})-[r:${edge.label}]->(b:${edge.dstLabel}) RETURN"
+          s"MATCH (a:${edge.srcType})-[r:${edge.edgeType}]->(b:${edge.dstType}) RETURN"
         )
         .append(s" a.${edge.srcProp} AS src,")
         .append(s" b.${edge.dstProp} AS dst")
@@ -142,7 +142,7 @@ object Neo4j {
         .option("query", cypherBuf.toString)
         .load()
       // put into writer
-      writer.PutEdgeData((edge.srcLabel, edge.label, edge.dstLabel), edge_df)
+      writer.PutEdgeData((edge.srcType, edge.edgeType, edge.dstType), edge_df)
     }
   }
 }

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/util/Utils.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/util/Utils.scala
@@ -98,7 +98,7 @@ object Utils {
         val vertexInfo = new VertexInfo()
         val prefix = "vertex/" + key + "/"
         vertexInfo.setPrefix(prefix)
-        vertexInfo.setLabel(key)
+        vertexInfo.setType(key)
         vertexInfo.setChunk_size(vertexChunkSize)
         vertexInfo.setVersion("gar/" + version)
         vertexInfo.getProperty_groups().add(new PropertyGroup())
@@ -128,9 +128,9 @@ object Utils {
     edgeSchemas.foreach {
       case (key, schema) => {
         val edgeInfo = new EdgeInfo()
-        edgeInfo.setSrc_label(key._1)
-        edgeInfo.setEdge_label(key._2)
-        edgeInfo.setDst_label(key._3)
+        edgeInfo.setSrc_type(key._1)
+        edgeInfo.setEdge_type(key._2)
+        edgeInfo.setDst_type(key._3)
         edgeInfo.setChunk_size(edgeChunkSize)
         edgeInfo.setSrc_chunk_size(vertexChunkSize)
         edgeInfo.setDst_chunk_size(vertexChunkSize)

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/writer/EdgeWriter.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/writer/EdgeWriter.scala
@@ -49,7 +49,7 @@ object EdgeWriter {
       edgeDf: DataFrame,
       edgeInfo: EdgeInfo,
       adjListType: AdjListType.Value,
-      vertexNumOfPrimaryVertexLabel: Long
+      vertexNumOfPrimaryVertexType: Long
   ): (DataFrame, ParSeq[(Int, DataFrame)], Array[Long], Map[Long, Int]) = {
     val edgeSchema = edgeDf.schema
     val colName = if (
@@ -63,7 +63,7 @@ object EdgeWriter {
     else edgeInfo.getDst_chunk_size()
     val edgeChunkSize: Long = edgeInfo.getChunk_size()
     val vertexChunkNum: Int =
-      ((vertexNumOfPrimaryVertexLabel + vertexChunkSize - 1) / vertexChunkSize).toInt // ceil
+      ((vertexNumOfPrimaryVertexType + vertexChunkSize - 1) / vertexChunkSize).toInt // ceil
 
     // sort by primary key and generate continue edge id for edge records
     val sortedDfRDD = edgeDf.sort(colName).rdd
@@ -212,7 +212,7 @@ object EdgeWriter {
  * @param adjListType
  *   the adj list type for the edge.
  * @param vertexNum
- *   vertex number of the primary vertex label
+ *   vertex number of the primary vertex type
  * @param edgeDf
  *   the input edge DataFrame.
  */

--- a/maven-projects/spark/graphar/src/test/scala/org/apache/graphar/TestGraphInfo.scala
+++ b/maven-projects/spark/graphar/src/test/scala/org/apache/graphar/TestGraphInfo.scala
@@ -28,7 +28,7 @@ class GraphInfoSuite extends BaseTestSuite {
     val graph_info = GraphInfo.loadGraphInfo(yaml_path, spark)
 
     val vertex_info = graph_info.getVertexInfo("person")
-    assert(vertex_info.getLabel == "person")
+    assert(vertex_info.getType == "person")
 
     assert(graph_info.getName == "ldbc_sample")
     assert(graph_info.getPrefix == prefix)
@@ -47,7 +47,7 @@ class GraphInfoSuite extends BaseTestSuite {
     val yaml_path = testData + "/ldbc_sample/csv/person.vertex.yml"
     val vertex_info = VertexInfo.loadVertexInfo(yaml_path, spark)
 
-    assert(vertex_info.getLabel == "person")
+    assert(vertex_info.getType == "person")
     assert(vertex_info.isValidated)
     assert(vertex_info.getVerticesNumFilePath() == "vertex/person/vertex_count")
     assert(vertex_info.getPrimaryKey() == "id")
@@ -124,9 +124,9 @@ class GraphInfoSuite extends BaseTestSuite {
     val yaml_path = testData + "/ldbc_sample/csv/person_knows_person.edge.yml"
     val edge_info = EdgeInfo.loadEdgeInfo(yaml_path, spark)
 
-    assert(edge_info.getSrc_label == "person")
-    assert(edge_info.getDst_label == "person")
-    assert(edge_info.getEdge_label == "knows")
+    assert(edge_info.getSrc_type == "person")
+    assert(edge_info.getDst_type == "person")
+    assert(edge_info.getEdge_type == "knows")
     assert(edge_info.getChunk_size == 1024)
     assert(edge_info.getSrc_chunk_size == 100)
     assert(edge_info.getDst_chunk_size == 100)

--- a/maven-projects/spark/graphar/src/test/scala/org/apache/graphar/TestGraphReader.scala
+++ b/maven-projects/spark/graphar/src/test/scala/org/apache/graphar/TestGraphReader.scala
@@ -66,9 +66,9 @@ class TestGraphReaderSuite extends BaseTestSuite {
     edgeInfos.foreach {
       case (key, edgeInfo) => {
         val edge_tag = (
-          edgeInfo.getSrc_label(),
-          edgeInfo.getEdge_label(),
-          edgeInfo.getDst_label()
+          edgeInfo.getSrc_type(),
+          edgeInfo.getEdge_type(),
+          edgeInfo.getDst_type()
         )
         assert(edge_dataframes contains edge_tag)
         val adj_list_type_dataframes = edge_dataframes(edge_tag)

--- a/maven-projects/spark/graphar/src/test/scala/org/apache/graphar/TestGraphWriter.scala
+++ b/maven-projects/spark/graphar/src/test/scala/org/apache/graphar/TestGraphWriter.scala
@@ -33,8 +33,8 @@ class TestGraphWriterSuite extends BaseTestSuite {
       .option("delimiter", "|")
       .option("header", "true")
       .csv(vertex_file_path)
-    val label = "person"
-    writer.PutVertexData(label, vertex_df, "id")
+    val vertex_type = "person"
+    writer.PutVertexData(vertex_type, vertex_df, "id")
 
     val file_path = testData + "/ldbc_sample/person_knows_person_0_0.csv"
     val edge_df = spark.read

--- a/pyspark/graphar_pyspark/graph.py
+++ b/pyspark/graphar_pyspark/graph.py
@@ -145,14 +145,14 @@ class GraphWriter:
         """Create an instance of the Class from Python arguments."""
         return GraphWriter(GraphArSession.graphar.graph.GraphWriter())
 
-    def put_vertex_data(self, type: str, df: DataFrame, primary_key: str) -> None:
+    def put_vertex_data(self, vertex_type: str, df: DataFrame, primary_key: str) -> None:
         """Put the vertex DataFrame into writer.
 
         :param type: type of vertex.
         :param df: DataFrame of the vertex type.
         :param primary_key: primary key of the vertex type, default is empty, which take the first property column as primary key.
         """
-        self._jvm_graph_writer_obj.PutVertexData(type, df._jdf, primary_key)
+        self._jvm_graph_writer_obj.PutVertexData(vertex_type, df._jdf, primary_key)
 
     def put_edge_data(self, relation: tuple[str, str, str], df: DataFrame) -> None:
         """Put the egde datafrme into writer.

--- a/pyspark/graphar_pyspark/graph.py
+++ b/pyspark/graphar_pyspark/graph.py
@@ -33,12 +33,12 @@ from graphar_pyspark.info import GraphInfo
 
 
 @dataclass(frozen=True)
-class EdgeLabels:
-    """A triplet that describe edge. Contains source, edge and dest labels. Immutable."""
+class EdgeTypes:
+    """A triplet that describe edge. Contains source, edge and dest types. Immutable."""
 
-    src_label: str
-    edge_label: str
-    dst_label: str
+    src_type: str
+    edge_type: str
+    dst_type: str
 
 
 @dataclass(frozen=True)
@@ -46,7 +46,7 @@ class GraphReaderResult:
     """A simple immutable class, that represent results of reading a graph with GraphReader."""
 
     vertex_dataframes: Mapping[str, DataFrame]
-    edge_dataframes: Mapping[EdgeLabels, Mapping[str, DataFrame]]
+    edge_dataframes: Mapping[EdgeTypes, Mapping[str, DataFrame]]
 
     @staticmethod
     def from_scala(
@@ -85,7 +85,7 @@ class GraphReaderResult:
                     GraphArSession.ss,
                 )
 
-            second_dict[EdgeLabels(k._1(), k._2(), k._3())] = inner_dict
+            second_dict[EdgeTypes(k._1(), k._2(), k._3())] = inner_dict
 
         return GraphReaderResult(
             vertex_dataframes=first_dict,
@@ -145,20 +145,20 @@ class GraphWriter:
         """Create an instance of the Class from Python arguments."""
         return GraphWriter(GraphArSession.graphar.graph.GraphWriter())
 
-    def put_vertex_data(self, label: str, df: DataFrame, primary_key: str) -> None:
+    def put_vertex_data(self, type: str, df: DataFrame, primary_key: str) -> None:
         """Put the vertex DataFrame into writer.
 
-        :param label: label of vertex.
+        :param type: type of vertex.
         :param df: DataFrame of the vertex type.
         :param primary_key: primary key of the vertex type, default is empty, which take the first property column as primary key.
         """
-        self._jvm_graph_writer_obj.PutVertexData(label, df._jdf, primary_key)
+        self._jvm_graph_writer_obj.PutVertexData(type, df._jdf, primary_key)
 
     def put_edge_data(self, relation: tuple[str, str, str], df: DataFrame) -> None:
         """Put the egde datafrme into writer.
 
-        :param relation: 3-Tuple (source label, edge label, target label) to indicate edge type.
-        :param df: data frame of edge type.
+        :param relation: 3-Tuple (source type, edge type, target type) to indicate edge relation.
+        :param df: data frame of edge relation.
         """
         relation_jvm = GraphArSession.jvm.scala.Tuple3(
             relation[0], relation[1], relation[2],

--- a/pyspark/graphar_pyspark/info.py
+++ b/pyspark/graphar_pyspark/info.py
@@ -297,7 +297,7 @@ class VertexInfo:
 
     def __init__(
         self,
-        label: Optional[str],
+        type: Optional[str],
         chunk_size: Optional[int],
         prefix: Optional[str],
         property_groups: Optional[Sequence[PropertyGroup]],
@@ -310,7 +310,7 @@ class VertexInfo:
             self._jvm_vertex_info_obj = jvm_obj
         else:
             vertex_info = GraphArSession.graphar.VertexInfo()
-            vertex_info.setLabel(label)
+            vertex_info.setType(type)
             vertex_info.setChunk_size(chunk_size)
             vertex_info.setPrefix(prefix)
             vertex_info.setProperty_groups(
@@ -319,19 +319,19 @@ class VertexInfo:
             vertex_info.setVersion(version)
             self._jvm_vertex_info_obj = vertex_info
 
-    def get_label(self) -> str:
-        """Get label from the corresponding JVM object.
+    def get_type(self) -> str:
+        """Get type from the corresponding JVM object.
 
-        :returns: label
+        :returns: type
         """
-        return self._jvm_vertex_info_obj.getLabel()
+        return self._jvm_vertex_info_obj.getType()
 
-    def set_label(self, label: str) -> None:
+    def set_type(self, type: str) -> None:
         """Mutate the corresponding JVM object.
 
-        :param label: new label
+        :param type: new type
         """
-        self._jvm_vertex_info_obj.setLabel(label)
+        self._jvm_vertex_info_obj.setType(type)
 
     def get_chunk_size(self) -> int:
         """Get chunk size from the corresponding JVM object.
@@ -539,7 +539,7 @@ class VertexInfo:
     @classmethod
     def from_python(
         cls: type[VertexInfoType],
-        label: str,
+        type: str,
         chunk_size: int,
         prefix: str,
         property_groups: Sequence[PropertyGroup],
@@ -547,13 +547,13 @@ class VertexInfo:
     ) -> VertexInfoType:
         """Create an instance of the class based on python args.
 
-        :param label: label of the vertex
+        :param type: type of the vertex
         :chunk_size: chunk size
         :prefix: vertex prefix
         :property_groups: list of property groups
         :version: version of GraphAr format
         """
-        return VertexInfo(label, chunk_size, prefix, property_groups, version, None)
+        return VertexInfo(type, chunk_size, prefix, property_groups, version, None)
 
 
 # Return type of AdjList classmethods
@@ -707,9 +707,9 @@ class EdgeInfo:
 
     def __init__(
         self,
-        src_label: Optional[str],
-        edge_label: Optional[str],
-        dst_label: Optional[str],
+        src_type: Optional[str],
+        edge_type: Optional[str],
+        dst_type: Optional[str],
         chunk_size: Optional[int],
         src_chunk_size: Optional[int],
         dst_chunk_size: Optional[int],
@@ -726,9 +726,9 @@ class EdgeInfo:
             self._jvm_edge_info_obj = jvm_edge_info_obj
         else:
             edge_info = GraphArSession.graphar.EdgeInfo()
-            edge_info.setSrc_label(src_label)
-            edge_info.setEdge_label(edge_label)
-            edge_info.setDst_label(dst_label)
+            edge_info.setSrc_type(src_type)
+            edge_info.setEdge_type(edge_type)
+            edge_info.setDst_type(dst_type)
             edge_info.setChunk_size(chunk_size)
             edge_info.setSrc_chunk_size(src_chunk_size)
             edge_info.setDst_chunk_size(dst_chunk_size)
@@ -743,47 +743,47 @@ class EdgeInfo:
             edge_info.setVersion(version)
             self._jvm_edge_info_obj = edge_info
 
-    def get_src_label(self) -> str:
-        """Get src label from the corresponding JVM object.
+    def get_src_type(self) -> str:
+        """Get src type from the corresponding JVM object.
 
-        :returns: src label
+        :returns: src type
         """
-        return self._jvm_edge_info_obj.getSrc_label()
+        return self._jvm_edge_info_obj.getSrc_type()
 
-    def set_src_label(self, src_label: str) -> None:
+    def set_src_type(self, src_type: str) -> None:
         """Mutate the corresponding JVM object.
 
-        :param src_label: the new src label
+        :param src_type: the new src type
         """
-        self._jvm_edge_info_obj.setSrc_label(src_label)
+        self._jvm_edge_info_obj.setSrc_type(src_type)
 
-    def get_edge_label(self) -> str:
-        """Get edge label from the corresponding JVM object.
+    def get_edge_type(self) -> str:
+        """Get edge type from the corresponding JVM object.
 
-        :returns: edge label
+        :returns: edge type
         """
-        return self._jvm_edge_info_obj.getEdge_label()
+        return self._jvm_edge_info_obj.getEdge_type()
 
-    def set_edge_label(self, edge_label: str) -> None:
+    def set_edge_type(self, edge_type: str) -> None:
         """Mutate the corresponding JVM object.
 
-        :param edge_label: the new edge label
+        :param edge_type: the new edge type
         """
-        self._jvm_edge_info_obj.setEdge_label(edge_label)
+        self._jvm_edge_info_obj.setEdge_type(edge_type)
 
-    def get_dst_label(self) -> str:
-        """Get dst label from the corresponding JVM object.
+    def get_dst_type(self) -> str:
+        """Get dst type from the corresponding JVM object.
 
-        :returns: dst label
+        :returns: dst type
         """
-        return self._jvm_edge_info_obj.getDst_label()
+        return self._jvm_edge_info_obj.getDst_type()
 
-    def set_dst_label(self, dst_label: str) -> None:
+    def set_dst_type(self, dst_type: str) -> None:
         """Mutate the corresponding JVM object.
 
-        :param dst_label: the new dst label
+        :param dst_type: the new dst type
         """
-        self._jvm_edge_info_obj.setDst_label(dst_label)
+        self._jvm_edge_info_obj.setDst_type(dst_type)
 
     def get_chunk_size(self) -> int:
         """Get chunk size from the corresponding JVM object.
@@ -941,9 +941,9 @@ class EdgeInfo:
     @classmethod
     def from_python(
         cls: type[EdgeInfoType],
-        src_label: str,
-        edge_label: str,
-        dst_label: str,
+        src_type: str,
+        edge_type: str,
+        dst_type: str,
         chunk_size: int,
         src_chunk_size: int,
         dst_chunk_size: int,
@@ -955,9 +955,9 @@ class EdgeInfo:
     ) -> EdgeInfoType:
         """Create an instance of the class from python arguments.
 
-        :param src_label: source vertex label
-        :param edge_label: edges label
-        :param dst_label: destination vertex label
+        :param src_type: source vertex type
+        :param edge_type: edges type
+        :param dst_type: destination vertex type
         :param chunk_size: chunk size
         :param src_chunk_size: source chunk size
         :param dst_chunk_size: destination chunk size
@@ -971,9 +971,9 @@ class EdgeInfo:
             prefix += os.sep
 
         return EdgeInfo(
-            src_label,
-            edge_label,
-            dst_label,
+            src_type,
+            edge_type,
+            dst_type,
             chunk_size,
             src_chunk_size,
             dst_chunk_size,
@@ -1437,33 +1437,33 @@ class GraphInfo:
         """
         self._jvm_graph_info_obj.addEdgeInfo(edge_info.to_scala())
 
-    def get_vertex_info(self, label: str) -> VertexInfo:
+    def get_vertex_info(self, type: str) -> VertexInfo:
         """Get vertex info from the corresponding JVM object.
 
-        :param label: label of vertex
+        :param type: type of vertex
         """
-        return VertexInfo.from_scala(self._jvm_graph_info_obj.getVertexInfo(label))
+        return VertexInfo.from_scala(self._jvm_graph_info_obj.getVertexInfo(type))
 
     def get_edge_info(
         self,
-        src_label: str,
-        edge_label: str,
-        dst_label: str,
+        src_type: str,
+        edge_type: str,
+        dst_type: str,
     ) -> EdgeInfo:
         """Get edge info from the corresponding JVM object.
 
-        :param src_label: source label
-        :param edge_label: edge label
-        :param dst_label: destination label
+        :param src_type: source type
+        :param edge_type: edge type
+        :param dst_type: destination type
         """
         return EdgeInfo.from_scala(
-            self._jvm_graph_info_obj.getEdgeInfo(src_label, edge_label, dst_label),
+            self._jvm_graph_info_obj.getEdgeInfo(src_type, edge_type, dst_type),
         )
 
     def get_vertex_infos(self) -> dict[str, VertexInfo]:
         """Get all vertex infos from the corresponding JVM object.
 
-        :returns: Mapping label -> VertexInfo
+        :returns: Mapping type -> VertexInfo
         """
         scala_map = self._jvm_graph_info_obj.getVertexInfos()
         keys_set_iter = scala_map.keySet().iterator()
@@ -1477,7 +1477,7 @@ class GraphInfo:
     def get_edge_infos(self) -> dict[str, EdgeInfo]:
         """Get all edge infos from the corresponding JVM object.
 
-        :returns: Mapping {src_label}_{edge_label}_{dst_label} -> EdgeInfo
+        :returns: Mapping {src_type}_{edge_type}_{dst_type} -> EdgeInfo
         """
         scala_map = self._jvm_graph_info_obj.getEdgeInfos()
         keys_set_iter = scala_map.keySet().iterator()

--- a/pyspark/graphar_pyspark/info.py
+++ b/pyspark/graphar_pyspark/info.py
@@ -297,7 +297,7 @@ class VertexInfo:
 
     def __init__(
         self,
-        type: Optional[str],
+        vertex_type: Optional[str],
         chunk_size: Optional[int],
         prefix: Optional[str],
         property_groups: Optional[Sequence[PropertyGroup]],
@@ -310,7 +310,7 @@ class VertexInfo:
             self._jvm_vertex_info_obj = jvm_obj
         else:
             vertex_info = GraphArSession.graphar.VertexInfo()
-            vertex_info.setType(type)
+            vertex_info.setType(vertex_type)
             vertex_info.setChunk_size(chunk_size)
             vertex_info.setPrefix(prefix)
             vertex_info.setProperty_groups(
@@ -326,12 +326,12 @@ class VertexInfo:
         """
         return self._jvm_vertex_info_obj.getType()
 
-    def set_type(self, type: str) -> None:
+    def set_type(self, vertex_type: str) -> None:
         """Mutate the corresponding JVM object.
 
-        :param type: new type
+        :param vertex_type: new type of vertex
         """
-        self._jvm_vertex_info_obj.setType(type)
+        self._jvm_vertex_info_obj.setType(vertex_type)
 
     def get_chunk_size(self) -> int:
         """Get chunk size from the corresponding JVM object.
@@ -539,7 +539,7 @@ class VertexInfo:
     @classmethod
     def from_python(
         cls: type[VertexInfoType],
-        type: str,
+        vertex_type: str,
         chunk_size: int,
         prefix: str,
         property_groups: Sequence[PropertyGroup],
@@ -547,13 +547,13 @@ class VertexInfo:
     ) -> VertexInfoType:
         """Create an instance of the class based on python args.
 
-        :param type: type of the vertex
+        :param vertex_type: type of the vertex
         :chunk_size: chunk size
         :prefix: vertex prefix
         :property_groups: list of property groups
         :version: version of GraphAr format
         """
-        return VertexInfo(type, chunk_size, prefix, property_groups, version, None)
+        return VertexInfo(vertex_type, chunk_size, prefix, property_groups, version, None)
 
 
 # Return type of AdjList classmethods
@@ -1437,12 +1437,12 @@ class GraphInfo:
         """
         self._jvm_graph_info_obj.addEdgeInfo(edge_info.to_scala())
 
-    def get_vertex_info(self, type: str) -> VertexInfo:
+    def get_vertex_info(self, vertex_type: str) -> VertexInfo:
         """Get vertex info from the corresponding JVM object.
 
-        :param type: type of vertex
+        :param vertex_type: type of vertex
         """
-        return VertexInfo.from_scala(self._jvm_graph_info_obj.getVertexInfo(type))
+        return VertexInfo.from_scala(self._jvm_graph_info_obj.getVertexInfo(vertex_type))
 
     def get_edge_info(
         self,

--- a/pyspark/graphar_pyspark/writer.py
+++ b/pyspark/graphar_pyspark/writer.py
@@ -158,7 +158,7 @@ class EdgeWriter:
         :param prefix: the absolute prefix.
         :param edge_info: the edge info that describes the ede type.
         :param adj_list_type: the adj list type for the edge.
-        :param vertex_num: vertex number of the primary vertex label
+        :param vertex_num: vertex number of the primary vertex type
         :param edge_df: the input edge DataFrame.
         """
         if not prefix.endswith(os.sep):

--- a/pyspark/tests/test_info.py
+++ b/pyspark/tests/test_info.py
@@ -155,12 +155,12 @@ def test_vertex_info(spark):
     yaml_string = vertex_info_from_py.dump()
     restored_py_obj = yaml.safe_load(yaml_string)
 
-    assert restored_py_obj["label"] == "label"
+    assert restored_py_obj["type"] == "label"
     assert restored_py_obj["prefix"] == "prefix"
 
     # test setters
-    vertex_info_from_py.set_label("new_label")
-    assert vertex_info_from_py.get_label() == "new_label"
+    vertex_info_from_py.set_type("new_label")
+    assert vertex_info_from_py.get_type() == "new_label"
 
     vertex_info_from_py.set_chunk_size(101)
     assert vertex_info_from_py.get_chunk_size() == 101
@@ -206,7 +206,7 @@ def test_vertex_info(spark):
         .absolute()
         .__str__()
     )
-    assert person_info.get_label() == "person"
+    assert person_info.get_type() == "person"
     assert person_info.get_chunk_size() == 50
     assert person_info.get_prefix() == "vertex/person/"
     assert person_info.get_version() == "gar/v1"
@@ -249,9 +249,9 @@ def test_edge_info(spark):
     initialize(spark)
 
     py_edge_info = EdgeInfo.from_python(
-        src_label="src_label",
-        edge_label="edge_label",
-        dst_label="dst_label",
+        src_type="src_label",
+        edge_type="edge_label",
+        dst_type="dst_label",
         chunk_size=100,
         src_chunk_size=101,
         dst_chunk_size=102,
@@ -263,14 +263,14 @@ def test_edge_info(spark):
     )
 
     # getters/setters
-    py_edge_info.set_src_label("new_src_label")
-    assert py_edge_info.get_src_label() == "new_src_label"
+    py_edge_info.set_src_type("new_src_label")
+    assert py_edge_info.get_src_type() == "new_src_label"
 
-    py_edge_info.set_dst_label("new_dst_label")
-    assert py_edge_info.get_dst_label() == "new_dst_label"
+    py_edge_info.set_dst_type("new_dst_label")
+    assert py_edge_info.get_dst_type() == "new_dst_label"
 
-    py_edge_info.set_edge_label("new_edge_label")
-    assert py_edge_info.get_edge_label() == "new_edge_label"
+    py_edge_info.set_edge_type("new_edge_label")
+    assert py_edge_info.get_edge_type() == "new_edge_label"
 
     py_edge_info.set_chunk_size(101)
     assert py_edge_info.get_chunk_size() == 101

--- a/pyspark/tests/test_reader.py
+++ b/pyspark/tests/test_reader.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from graphar_pyspark import initialize
 from graphar_pyspark.enums import AdjListType
-from graphar_pyspark.graph import EdgeLabels, GraphReader
+from graphar_pyspark.graph import EdgeTypes, GraphReader
 from graphar_pyspark.info import EdgeInfo, GraphInfo, VertexInfo
 from graphar_pyspark.reader import EdgeReader, VertexReader
 
@@ -154,15 +154,15 @@ def test_graph_reader(spark):
     assert len(graph_info.edge_dataframes.keys()) > 0
     assert "person" in graph_info.vertex_dataframes.keys()
     assert (
-        EdgeLabels("person", "created", "software") in graph_info.edge_dataframes.keys()
+        EdgeTypes("person", "created", "software") in graph_info.edge_dataframes.keys()
     )
     assert graph_info.vertex_dataframes["person"].count() > 0
     assert (
         "ordered_by_source"
-        in graph_info.edge_dataframes[EdgeLabels("person", "created", "software")]
+        in graph_info.edge_dataframes[EdgeTypes("person", "created", "software")]
     )
     assert (
-        graph_info.edge_dataframes[EdgeLabels("person", "created", "software")][
+        graph_info.edge_dataframes[EdgeTypes("person", "created", "software")][
             "ordered_by_source"
         ].count()
         > 0

--- a/pyspark/tests/test_writer.py
+++ b/pyspark/tests/test_writer.py
@@ -105,8 +105,8 @@ def test_graph_writer(spark):
     assert GraphWriter.from_scala(graph_writer.to_scala()) is not None
     vertex_file_path = GRAPHAR_TESTS_EXAMPLES.joinpath("ldbc_sample/person_0_0.csv").absolute().__str__()
     vertex_df = spark.read.option("delimiter", "|").option("header", "true").csv(vertex_file_path)
-    label = "person"
-    graph_writer.put_vertex_data(label, vertex_df, "id")
+    type = "person"
+    graph_writer.put_vertex_data(type, vertex_df, "id")
 
     edge_file_path = GRAPHAR_TESTS_EXAMPLES.joinpath("ldbc_sample/person_knows_person_0_0.csv").absolute().__str__()
     edge_df = spark.read.option("delimiter", "|").option("header", "true").csv(edge_file_path)


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
https://github.com/apache/incubator-graphar/issues/604

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Change the naming of vertex/edge type from `label` to `type`
### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes, and changed testing https://github.com/apache/incubator-graphar-testing/pull/23
### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
yes
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
**BREAKING CHANGE**: 
- the vertex info and edge info configuration need to update `label` to `type`.
- Some APIs related to `label` of C++/Spark/PySpark library change to `type`, like `getLabel` to `getType`.

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
