### PR TITLE
fix(c++): do not run test automatically when building the test

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -385,7 +385,6 @@ if (BUILD_TESTS)
         target_include_directories(${target} PRIVATE ${PROJECT_SOURCE_DIR}/include $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/Catch2/single_include>)
         include(CTest)
         include(Catch)
-        catch_discover_tests(${target})
     endmacro()
 
     add_test(test_info SRCS test/test_info.cc)


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->

as #612 describe

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

remove `catch_discover_tests`

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes
### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
no
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
