### PR TITLE
chore(spark): fix typo in writer

### DIFF
--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/graph/GraphWriter.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/graph/GraphWriter.scala
@@ -185,7 +185,7 @@ class GraphWriter() {
    * @param spark
    *   the spark session for the writing.
    * @param name
-   *   the name of graph, default is 'grpah'
+   *   the name of graph, default is 'graph'
    * @param vertex_chunk_size
    *   the chunk size for vertices, default is 2^18
    * @param edge_chunk_size

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/writer/EdgeWriter.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/writer/EdgeWriter.scala
@@ -240,11 +240,11 @@ class EdgeWriter(
       )
     }
     // check the src index and dst index column exist
-    val src_filed = StructField(GeneralParams.srcIndexCol, LongType)
-    val dst_filed = StructField(GeneralParams.dstIndexCol, LongType)
+    val src_field = StructField(GeneralParams.srcIndexCol, LongType)
+    val dst_field = StructField(GeneralParams.dstIndexCol, LongType)
     val schema = edgeDf.schema
     if (
-      schema.contains(src_filed) == false || schema.contains(dst_filed) == false
+      schema.contains(src_field) == false || schema.contains(dst_field) == false
     ) {
       throw new IllegalArgumentException(
         "edge DataFrame must contain src index column and dst index column."

--- a/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/writer/VertexWriter.scala
+++ b/maven-projects/spark/graphar/src/main/scala/org/apache/graphar/writer/VertexWriter.scala
@@ -94,9 +94,9 @@ class VertexWriter(
   chunks.persist(GeneralParams.defaultStorageLevel)
 
   private def validate(): Unit = {
-    // check if vertex DataFrame contains the index_filed
-    val index_filed = StructField(GeneralParams.vertexIndexCol, LongType)
-    if (vertexDf.schema.contains(index_filed) == false) {
+    // check if vertex DataFrame contains the index_field
+    val index_field = StructField(GeneralParams.vertexIndexCol, LongType)
+    if (vertexDf.schema.contains(index_field) == false) {
       throw new IllegalArgumentException(
         "vertex DataFrame must contain index column."
       )


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
As  title.

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
