### PR TITLE
fix(CI): Avoid generating unnecessary static link libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
         popd
 
     - name: Upload libgraphar.a artifact
+      if: github.event_name == 'push'
       uses: actions/upload-artifact@v3
       with:
         name: ubuntu-libgraphar.a
@@ -235,6 +236,7 @@ jobs:
         popd
 
     - name: Upload libgraphar.a artifact
+      if: github.event_name == 'push'
       uses: actions/upload-artifact@v3
       with:
         name: macos-${{ matrix.macos-version }}-libgraphar.a


### PR DESCRIPTION
only generate unnecessary static link libraries when push to 'main' branch.