### PR TITLE
feat(java): remove Hadoop dependency and update tests / Local

### DIFF
--- a/maven-projects/info/pom.xml
+++ b/maven-projects/info/pom.xml
@@ -63,11 +63,7 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>3.4.0</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/maven-projects/info/src/main/java/org/apache/graphar/info/saver/LocalYamlGraphSaver.java
+++ b/maven-projects/info/src/main/java/org/apache/graphar/info/saver/LocalYamlGraphSaver.java
@@ -19,51 +19,56 @@
 
 package org.apache.graphar.info.saver;
 
-import java.io.IOException;
 import org.apache.graphar.info.EdgeInfo;
 import org.apache.graphar.info.GraphInfo;
 import org.apache.graphar.info.VertexInfo;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class LocalYamlGraphSaver implements GraphSaver {
-    private static final FileSystem fileSystem;
-
-    static {
-        try {
-            fileSystem = FileSystem.get(new Configuration());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     @Override
     public void save(String path, GraphInfo graphInfo) throws IOException {
-        try (FSDataOutputStream outputStream =
-                fileSystem.create(new Path(path + "/" + graphInfo.getName() + ".graph.yaml"))) {
-            outputStream.writeBytes(graphInfo.dump());
-            for (VertexInfo vertexInfo : graphInfo.getVertexInfos()) {
-                saveVertex(path, vertexInfo);
-            }
-            for (EdgeInfo edgeInfo : graphInfo.getEdgeInfos()) {
-                saveEdge(path, edgeInfo);
-            }
+        final Path outputPath = FileSystems
+            .getDefault()
+            .getPath(path + FileSystems.getDefault().getSeparator() + graphInfo.getName() + ".graph.yaml");
+        Files.createDirectories(outputPath.getParent());
+        Files.createFile(outputPath);
+        final BufferedWriter writer = Files.newBufferedWriter(outputPath);
+        writer.write(graphInfo.dump());
+        writer.close();
+
+        for (VertexInfo vertexInfo : graphInfo.getVertexInfos()) {
+            saveVertex(path, vertexInfo);
+        }
+        for (EdgeInfo edgeInfo : graphInfo.getEdgeInfos()) {
+            saveEdge(path, edgeInfo);
         }
     }
 
     private void saveVertex(String path, VertexInfo vertexInfo) throws IOException {
-        try (FSDataOutputStream outputStream =
-                fileSystem.create(new Path(path + "/" + vertexInfo.getType() + ".vertex.yaml"))) {
-            outputStream.writeBytes(vertexInfo.dump());
-        }
+        final Path outputPath = FileSystems
+            .getDefault()
+            .getPath(path + FileSystems.getDefault().getSeparator() + vertexInfo.getType() + ".vertex.yaml");
+        Files.createDirectories(outputPath.getParent());
+        Files.createFile(outputPath);
+        final BufferedWriter writer = Files.newBufferedWriter(outputPath);
+        writer.write(vertexInfo.dump());
+        writer.close();
     }
 
     private void saveEdge(String path, EdgeInfo edgeInfo) throws IOException {
-        try (FSDataOutputStream outputStream =
-                fileSystem.create(new Path(path + "/" + edgeInfo.getConcat() + ".edge.yaml"))) {
-            outputStream.writeBytes(edgeInfo.dump());
-        }
+        final Path outputPath = FileSystems
+            .getDefault()
+            .getPath(path + FileSystems.getDefault().getSeparator() + edgeInfo.getConcat() + ".edge.yaml");
+        Files.createDirectories(outputPath.getParent());
+        Files.createFile(outputPath);
+        final BufferedWriter writer = Files.newBufferedWriter(outputPath);
+        writer.write(edgeInfo.dump());
+        writer.close();
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
Close #664 


### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Removing of Hadoop dependencies
- Corresponding updates of LocalGrapheSaver/Loader

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
All the existing tests are passed.

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No. GraphAr-Info is not used at the moment, the package is under active development.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
