### PR TITLE
chore(github): Fix the incorrect configuration in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -40,7 +40,7 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: false
         required_approving_review_count: 1
-        required_linear_history: true    
+      required_linear_history: true
   features:
     issues: true
     discussions: true


### PR DESCRIPTION


<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
**required_linear_history** and **required_pull_request_reviews** were mistakenly nested when they should have been at the same level. 

Since every PR merge notifies INFRA, I fixed the config right away. Hope we can get this merged soon to minimize the noise.
