### PR TITLE
chore(NOTICE): Update NOTICE year to 2025

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache GraphAr (Incubating)
-Copyright 2024 The Apache Software Foundation
+Copyright 2024-2025 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR

I couldn't find a detailed definition from ASF on this, but it's okay. In short, it’s related to the validity of intellectual property rights. 

 Modern laws may define this differently, but adding the latest NOTICE year is a common practice.
FYI 
https://en.wikipedia.org/wiki/Copyright_notice#Reasons_to_include_an_optional_copyright_notice
https://opensource.stackexchange.com/questions/6389/how-do-the-years-specified-in-a-copyright-statement-work
 
