### PR TITLE
Add WriterOption to allow user to configure writer option

### DIFF
--- a/cpp/examples/mid_level_writer_example.cc
+++ b/cpp/examples/mid_level_writer_example.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <arrow/util/type_fwd.h>
 #include <iostream>
 
 #include "arrow/api.h"
@@ -111,10 +112,10 @@ void vertex_property_writer(
   auto vertex_info = graphar::VertexInfo::Load(vertex_meta).value();
   ASSERT(vertex_info->GetType() == "person");
 
-  graphar::WriterOptions::Builder builder(graphar::FileType::CSV);
-  builder.set_include_header(true);
+  auto builder = graphar::WriterOptions::Builder::createParquetBuilder();
+  builder->compression(arrow::Compression::ZSTD);
   auto maybe_writer = graphar::VertexPropertyWriter::Make(vertex_info, "/tmp/",
-                                                          builder.Build());
+                                                          builder->Build());
   ASSERT(maybe_writer.status().ok());
   auto writer = maybe_writer.value();
 

--- a/cpp/examples/mid_level_writer_example.cc
+++ b/cpp/examples/mid_level_writer_example.cc
@@ -25,6 +25,8 @@
 
 #include "./config.h"
 #include "graphar/api/arrow_writer.h"
+#include "graphar/fwd.h"
+#include "graphar/writer_util.h"
 
 arrow::Result<std::shared_ptr<arrow::Table>> generate_vertex_table() {
   // property "id"
@@ -109,7 +111,10 @@ void vertex_property_writer(
   auto vertex_info = graphar::VertexInfo::Load(vertex_meta).value();
   ASSERT(vertex_info->GetType() == "person");
 
-  auto maybe_writer = graphar::VertexPropertyWriter::Make(vertex_info, "/tmp/");
+  graphar::WriterOptions::Builder builder(graphar::FileType::CSV);
+  builder.set_include_header(true);
+  auto maybe_writer = graphar::VertexPropertyWriter::Make(vertex_info, "/tmp/",
+                                                          builder.Build());
   ASSERT(maybe_writer.status().ok());
   auto writer = maybe_writer.value();
 

--- a/cpp/examples/mid_level_writer_example.cc
+++ b/cpp/examples/mid_level_writer_example.cc
@@ -111,11 +111,11 @@ void vertex_property_writer(
   auto vertex_meta = graphar::Yaml::LoadFile(vertex_meta_file).value();
   auto vertex_info = graphar::VertexInfo::Load(vertex_meta).value();
   ASSERT(vertex_info->GetType() == "person");
-
-  auto builder = graphar::WriterOptions::Builder::createParquetBuilder();
-  builder->compression(arrow::Compression::ZSTD);
+  auto builder = graphar::WriterOptions::Builder();
+  auto parquetBuilder = builder.getParquetOptionBuilder();
+  parquetBuilder->compression(arrow::Compression::ZSTD);
   auto maybe_writer = graphar::VertexPropertyWriter::Make(vertex_info, "/tmp/",
-                                                          builder->Build());
+                                                          builder.Build());
   ASSERT(maybe_writer.status().ok());
   auto writer = maybe_writer.value();
 

--- a/cpp/src/graphar/arrow/chunk_writer.cc
+++ b/cpp/src/graphar/arrow/chunk_writer.cc
@@ -217,8 +217,7 @@ Status VertexPropertyWriter::WriteChunk(
     ValidateLevel validate_level) const {
   GAR_RETURN_NOT_OK(
       validate(input_table, property_group, chunk_index, validate_level));
-  auto file_type =
-      options_ ? options_->file_type : property_group->GetFileType();
+  auto file_type = property_group->GetFileType();
   auto schema = input_table->schema();
   int indice = schema->GetFieldIndex(GeneralParams::kVertexIndexCol);
   if (indice == -1) {
@@ -714,9 +713,7 @@ Status EdgeChunkWriter::WriteOffsetChunk(
     const std::shared_ptr<arrow::Table>& input_table, IdType vertex_chunk_index,
     ValidateLevel validate_level) const {
   GAR_RETURN_NOT_OK(validate(input_table, vertex_chunk_index, validate_level));
-  auto file_type =
-      options_ ? options_->file_type
-               : edge_info_->GetAdjacentList(adj_list_type_)->GetFileType();
+  auto file_type = edge_info_->GetAdjacentList(adj_list_type_)->GetFileType();
   auto schema = input_table->schema();
   int index = schema->GetFieldIndex(GeneralParams::kOffsetCol);
   if (index == -1) {
@@ -735,9 +732,7 @@ Status EdgeChunkWriter::WriteAdjListChunk(
     IdType chunk_index, ValidateLevel validate_level) const {
   GAR_RETURN_NOT_OK(
       validate(input_table, vertex_chunk_index, chunk_index, validate_level));
-  auto file_type =
-      options_ ? options_->file_type
-               : edge_info_->GetAdjacentList(adj_list_type_)->GetFileType();
+  auto file_type = edge_info_->GetAdjacentList(adj_list_type_)->GetFileType();
   std::vector<int> indices;
   indices.clear();
   auto schema = input_table->schema();
@@ -771,8 +766,7 @@ Status EdgeChunkWriter::WritePropertyChunk(
     ValidateLevel validate_level) const {
   GAR_RETURN_NOT_OK(validate(input_table, property_group, vertex_chunk_index,
                              chunk_index, validate_level));
-  auto file_type =
-      options_ ? options_->file_type : property_group->GetFileType();
+  auto file_type = property_group->GetFileType();
 
   std::vector<int> indices;
   indices.clear();

--- a/cpp/src/graphar/arrow/chunk_writer.h
+++ b/cpp/src/graphar/arrow/chunk_writer.h
@@ -324,6 +324,7 @@ class EdgeChunkWriter {
   explicit EdgeChunkWriter(
       const std::shared_ptr<EdgeInfo>& edge_info, const std::string& prefix,
       AdjListType adj_list_type,
+      const std::shared_ptr<WriterOptions>& options = nullptr,
       const ValidateLevel& validate_level = ValidateLevel::no_validate);
 
   /**
@@ -597,6 +598,7 @@ class EdgeChunkWriter {
   static Result<std::shared_ptr<EdgeChunkWriter>> Make(
       const std::shared_ptr<EdgeInfo>& edge_info, const std::string& prefix,
       AdjListType adj_list_type,
+      const std::shared_ptr<WriterOptions>& options = nullptr,
       const ValidateLevel& validate_level = ValidateLevel::no_validate);
 
   /**
@@ -614,6 +616,7 @@ class EdgeChunkWriter {
       const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
       const std::string& edge_type, const std::string& dst_type,
       AdjListType adj_list_type,
+      const std::shared_ptr<WriterOptions>& options = nullptr,
       const ValidateLevel& validate_level = ValidateLevel::no_validate);
 
  private:
@@ -724,6 +727,7 @@ class EdgeChunkWriter {
   std::string prefix_;
   std::shared_ptr<FileSystem> fs_;
   ValidateLevel validate_level_;
+  std::shared_ptr<WriterOptions> options_;
 };
 
 }  // namespace graphar

--- a/cpp/src/graphar/arrow/chunk_writer.h
+++ b/cpp/src/graphar/arrow/chunk_writer.h
@@ -68,6 +68,7 @@ class VertexPropertyWriter {
    */
   explicit VertexPropertyWriter(
       const std::shared_ptr<VertexInfo>& vertex_info, const std::string& prefix,
+      const std::shared_ptr<WriterOptions>& options = nullptr,
       const ValidateLevel& validate_level = ValidateLevel::no_validate);
 
   /**
@@ -214,9 +215,11 @@ class VertexPropertyWriter {
    * @param prefix The absolute prefix.
    * @param validate_level The global validate level for the writer, default is
    * no_validate.
+   * @param options Options for writing the table, such as compression.
    */
   static Result<std::shared_ptr<VertexPropertyWriter>> Make(
       const std::shared_ptr<VertexInfo>& vertex_info, const std::string& prefix,
+      const std::shared_ptr<WriterOptions>& options = nullptr,
       const ValidateLevel& validate_level = ValidateLevel::no_validate);
 
   /**
@@ -226,10 +229,16 @@ class VertexPropertyWriter {
    * @param type The vertex type.
    * @param validate_level The global validate level for the writer, default is
    * no_validate.
+   * @param options Options for writing the table, such as compression.
    */
   static Result<std::shared_ptr<VertexPropertyWriter>> Make(
       const std::shared_ptr<GraphInfo>& graph_info, const std::string& type,
+      const std::shared_ptr<WriterOptions>& options = nullptr,
       const ValidateLevel& validate_level = ValidateLevel::no_validate);
+
+  void setWriterOptions(const std::shared_ptr<WriterOptions>& options) {
+    options_ = options;
+  }
 
   Result<std::shared_ptr<arrow::Table>> AddIndexColumn(
       const std::shared_ptr<arrow::Table>& table, IdType chunk_index,
@@ -274,6 +283,7 @@ class VertexPropertyWriter {
   std::string prefix_;
   std::shared_ptr<FileSystem> fs_;
   ValidateLevel validate_level_;
+  std::shared_ptr<WriterOptions> options_;
 };
 
 /**

--- a/cpp/src/graphar/filesystem.cc
+++ b/cpp/src/graphar/filesystem.cc
@@ -108,17 +108,6 @@ std::shared_ptr<ds::FileFormat> FileSystem::GetFileFormat(
   }
 }
 
-void buildOrcWriteOptionsWithWriterOptions(
-    arrow::adapters::orc::WriteOptions& writeOptions,
-    const std::shared_ptr<WriterOptions>& options);
-void buildCsvWriteOptionsWithWriterOptions(
-    arrow::csv::WriteOptions& writeOptions,
-    const std::shared_ptr<WriterOptions>& options);
-void buildParquetWriteOptionsWithWriterOptions(
-    parquet::WriterProperties::Builder& builder,
-    parquet::ArrowWriterProperties::Builder& arrow_writer_porpertices_builder,
-    const std::shared_ptr<WriterOptions>& options);
-
 Result<std::shared_ptr<arrow::Table>> FileSystem::ReadFileToTable(
     const std::string& path, FileType file_type,
     const util::FilterOptions& options) const noexcept {
@@ -281,120 +270,6 @@ Status FileSystem::WriteTableToFile(
   }
   return Status::OK();
 }
-void buildCsvWriteOptionsWithWriterOptions(
-    arrow::csv::WriteOptions& writeOptions,
-    const std::shared_ptr<WriterOptions>& options) {
-  if (!options) {
-    return;
-  }
-  auto csvOption = options->csvOption;
-  if (csvOption) {
-    writeOptions.include_header = csvOption->include_header;
-    writeOptions.batch_size = csvOption->batch_size;
-    writeOptions.delimiter = csvOption->delimiter;
-    writeOptions.null_string = csvOption->null_string;
-    writeOptions.io_context = csvOption->io_context;
-    writeOptions.eol = csvOption->eol;
-    writeOptions.quoting_style = csvOption->quoting_style;
-  }
-}
-void buildParquetWriteOptionsWithWriterOptions(
-    parquet::WriterProperties::Builder& writer_porpertices_builder,
-    parquet::ArrowWriterProperties::Builder& arrow_writer_porpertices_builder,
-    const std::shared_ptr<WriterOptions>& options) {
-  if (!options) {
-    return;
-  }
-  auto parquetOption = options->parquetOption;
-  if (!parquetOption) {
-    return;
-  }
-  if (parquetOption->enable_dictionary) {
-    writer_porpertices_builder.enable_dictionary();
-  }
-  writer_porpertices_builder.dictionary_pagesize_limit(
-      parquetOption->dictionary_pagesize_limit);
-  writer_porpertices_builder.write_batch_size(parquetOption->write_batch_size);
-  writer_porpertices_builder.max_row_group_length(
-      parquetOption->max_row_group_length);
-  writer_porpertices_builder.data_pagesize(parquetOption->data_pagesize);
-  writer_porpertices_builder.data_page_version(
-      parquetOption->data_page_version);
-  writer_porpertices_builder.version(parquetOption->version);
-  writer_porpertices_builder.encoding(parquetOption->encoding);
-  for (const auto& kv : parquetOption->column_encoding) {
-    writer_porpertices_builder.encoding(kv.first, kv.second);
-  }
-  writer_porpertices_builder.compression(parquetOption->compression);
-  for (const auto& kv : parquetOption->column_compression) {
-    writer_porpertices_builder.compression(kv.first, kv.second);
-  }
-  writer_porpertices_builder.compression_level(
-      parquetOption->compression_level);
-  for (const auto& kv : parquetOption->column_compression_level) {
-    writer_porpertices_builder.compression_level(kv.first, kv.second);
-  }
-  writer_porpertices_builder.max_statistics_size(
-      parquetOption->max_statistics_size);
-  if (parquetOption->encryption_properties) {
-    writer_porpertices_builder.encryption(parquetOption->encryption_properties);
-  }
-  if (parquetOption->enable_statistics) {
-    writer_porpertices_builder.enable_statistics();
-  }
-  for (const auto& path_st : parquetOption->column_statistics) {
-    writer_porpertices_builder.enable_statistics(path_st.first);
-  }
-  if (!parquetOption->sorting_columns.empty()) {
-    writer_porpertices_builder.set_sorting_columns(
-        parquetOption->sorting_columns);
-  }
-  if (parquetOption->enable_store_decimal_as_integer) {
-    writer_porpertices_builder.enable_store_decimal_as_integer();
-  }
-  if (parquetOption->enable_write_page_index) {
-    writer_porpertices_builder.enable_write_page_index();
-  }
-  for (const auto& column_pi : parquetOption->column_write_page_index) {
-    writer_porpertices_builder.enable_write_page_index(column_pi.first);
-  }
-  if (parquetOption->compliant_nested_types) {
-    arrow_writer_porpertices_builder.enable_compliant_nested_types();
-  }
-  arrow_writer_porpertices_builder.set_use_threads(parquetOption->use_threads);
-  if (parquetOption->enable_deprecated_int96_timestamps) {
-    arrow_writer_porpertices_builder.enable_deprecated_int96_timestamps();
-  }
-  arrow_writer_porpertices_builder.coerce_timestamps(
-      parquetOption->coerce_timestamps);
-  if (parquetOption->allow_truncated_timestamps) {
-    arrow_writer_porpertices_builder.allow_truncated_timestamps();
-  }
-  if (parquetOption->store_schema) {
-    arrow_writer_porpertices_builder.store_schema();
-  }
-  if (parquetOption->executor) {
-    arrow_writer_porpertices_builder.set_executor(parquetOption->executor);
-  }
-}
-
-void buildOrcWriteOptionsWithWriterOptions(
-    arrow::adapters::orc::WriteOptions& write_options,
-    const std::shared_ptr<WriterOptions>& options) {
-  if (!options) {
-    return;
-  }
-  auto orcOption = options->orcOption;
-  if (!orcOption) {
-    return;
-  }
-  write_options.batch_size = orcOption->batch_size;
-  write_options.compression = orcOption->compression;
-  write_options.stripe_size = orcOption->stripe_size;
-  write_options.file_version = orcOption->file_version;
-  write_options.bloom_filter_columns = orcOption->bloom_filter_columns;
-  write_options.bloom_filter_fpp = orcOption->bloom_filter_fpp;
-}
 
 Status FileSystem::WriteLabelTableToFile(
     const std::shared_ptr<arrow::Table>& table,
@@ -498,4 +373,121 @@ template Result<IdType> FileSystem::ReadFileToValue<IdType>(
 /// template specialization for std::string
 template Status FileSystem::WriteValueToFile<IdType>(
     const IdType&, const std::string&) const noexcept;
+
+void buildParquetWriteOptionsWithWriterOptions(
+    parquet::WriterProperties::Builder& writer_porpertices_builder,
+    parquet::ArrowWriterProperties::Builder& arrow_writer_porpertices_builder,
+    const std::shared_ptr<WriterOptions>& options) {
+  if (!options) {
+    return;
+  }
+  auto parquetOption = options->parquetOption;
+  if (!parquetOption) {
+    return;
+  }
+  if (parquetOption->enable_dictionary) {
+    writer_porpertices_builder.enable_dictionary();
+  }
+  writer_porpertices_builder.dictionary_pagesize_limit(
+      parquetOption->dictionary_pagesize_limit);
+  writer_porpertices_builder.write_batch_size(parquetOption->write_batch_size);
+  writer_porpertices_builder.max_row_group_length(
+      parquetOption->max_row_group_length);
+  writer_porpertices_builder.data_pagesize(parquetOption->data_pagesize);
+  writer_porpertices_builder.data_page_version(
+      parquetOption->data_page_version);
+  writer_porpertices_builder.version(parquetOption->version);
+  writer_porpertices_builder.encoding(parquetOption->encoding);
+  for (const auto& kv : parquetOption->column_encoding) {
+    writer_porpertices_builder.encoding(kv.first, kv.second);
+  }
+  writer_porpertices_builder.compression(parquetOption->compression);
+  for (const auto& kv : parquetOption->column_compression) {
+    writer_porpertices_builder.compression(kv.first, kv.second);
+  }
+  writer_porpertices_builder.compression_level(
+      parquetOption->compression_level);
+  for (const auto& kv : parquetOption->column_compression_level) {
+    writer_porpertices_builder.compression_level(kv.first, kv.second);
+  }
+  writer_porpertices_builder.max_statistics_size(
+      parquetOption->max_statistics_size);
+  if (parquetOption->encryption_properties) {
+    writer_porpertices_builder.encryption(parquetOption->encryption_properties);
+  }
+  if (parquetOption->enable_statistics) {
+    writer_porpertices_builder.enable_statistics();
+  }
+  for (const auto& path_st : parquetOption->column_statistics) {
+    writer_porpertices_builder.enable_statistics(path_st.first);
+  }
+  if (!parquetOption->sorting_columns.empty()) {
+    writer_porpertices_builder.set_sorting_columns(
+        parquetOption->sorting_columns);
+  }
+  if (parquetOption->enable_store_decimal_as_integer) {
+    writer_porpertices_builder.enable_store_decimal_as_integer();
+  }
+  if (parquetOption->enable_write_page_index) {
+    writer_porpertices_builder.enable_write_page_index();
+  }
+  for (const auto& column_pi : parquetOption->column_write_page_index) {
+    writer_porpertices_builder.enable_write_page_index(column_pi.first);
+  }
+  if (parquetOption->compliant_nested_types) {
+    arrow_writer_porpertices_builder.enable_compliant_nested_types();
+  }
+  arrow_writer_porpertices_builder.set_use_threads(parquetOption->use_threads);
+  if (parquetOption->enable_deprecated_int96_timestamps) {
+    arrow_writer_porpertices_builder.enable_deprecated_int96_timestamps();
+  }
+  arrow_writer_porpertices_builder.coerce_timestamps(
+      parquetOption->coerce_timestamps);
+  if (parquetOption->allow_truncated_timestamps) {
+    arrow_writer_porpertices_builder.allow_truncated_timestamps();
+  }
+  if (parquetOption->store_schema) {
+    arrow_writer_porpertices_builder.store_schema();
+  }
+  if (parquetOption->executor) {
+    arrow_writer_porpertices_builder.set_executor(parquetOption->executor);
+  }
+}
+
+void buildCsvWriteOptionsWithWriterOptions(
+    arrow::csv::WriteOptions& writeOptions,
+    const std::shared_ptr<WriterOptions>& options) {
+  if (!options) {
+    return;
+  }
+  auto csvOption = options->csvOption;
+  if (csvOption) {
+    writeOptions.include_header = csvOption->include_header;
+    writeOptions.batch_size = csvOption->batch_size;
+    writeOptions.delimiter = csvOption->delimiter;
+    writeOptions.null_string = csvOption->null_string;
+    writeOptions.io_context = csvOption->io_context;
+    writeOptions.eol = csvOption->eol;
+    writeOptions.quoting_style = csvOption->quoting_style;
+  }
+}
+
+void buildOrcWriteOptionsWithWriterOptions(
+    arrow::adapters::orc::WriteOptions& write_options,
+    const std::shared_ptr<WriterOptions>& options) {
+  if (!options) {
+    return;
+  }
+  auto orcOption = options->orcOption;
+  if (!orcOption) {
+    return;
+  }
+  write_options.batch_size = orcOption->batch_size;
+  write_options.compression = orcOption->compression;
+  write_options.stripe_size = orcOption->stripe_size;
+  write_options.file_version = orcOption->file_version;
+  write_options.bloom_filter_columns = orcOption->bloom_filter_columns;
+  write_options.bloom_filter_fpp = orcOption->bloom_filter_fpp;
+}
+
 }  // namespace graphar

--- a/cpp/src/graphar/filesystem.cc
+++ b/cpp/src/graphar/filesystem.cc
@@ -260,7 +260,12 @@ Status FileSystem::WriteTableToFile(
 #ifdef ARROW_ORC
   case FileType::ORC: {
     auto writer_options = arrow::adapters::orc::WriteOptions();
-    writer_options.compression = arrow::Compression::type::ZSTD;
+    if (options) {
+      writer_options.compression = options->compression;
+    } else {
+      writer_options.compression =
+          arrow::Compression::type::ZSTD;  // enable compression
+    }
     GAR_RETURN_ON_ARROW_ERROR_AND_ASSIGN(
         auto writer, arrow::adapters::orc::ORCFileWriter::Open(
                          output_stream.get(), writer_options));

--- a/cpp/src/graphar/filesystem.h
+++ b/cpp/src/graphar/filesystem.h
@@ -188,4 +188,17 @@ Status InitializeS3();
  */
 Status FinalizeS3();
 
+void buildOrcWriteOptionsWithWriterOptions(
+    arrow::adapters::orc::WriteOptions& writeOptions,
+    const std::shared_ptr<WriterOptions>& options);
+
+void buildCsvWriteOptionsWithWriterOptions(
+    arrow::csv::WriteOptions& writeOptions,
+    const std::shared_ptr<WriterOptions>& options);
+
+void buildParquetWriteOptionsWithWriterOptions(
+    parquet::WriterProperties::Builder& builder,
+    parquet::ArrowWriterProperties::Builder& arrow_writer_porpertices_builder,
+    const std::shared_ptr<WriterOptions>& options);
+
 }  // namespace graphar

--- a/cpp/src/graphar/filesystem.h
+++ b/cpp/src/graphar/filesystem.h
@@ -30,6 +30,7 @@
 #include "graphar/util.h"
 
 #include "graphar/reader_util.h"
+#include "graphar/writer_util.h"
 
 // forward declarations
 namespace arrow {
@@ -100,19 +101,21 @@ class FileSystem {
    * @return A Status indicating OK if successful, or an error if unsuccessful.
    */
   template <typename T>
-  Status WriteValueToFile(const T& value, const std::string& path) const
-      noexcept;
+  Status WriteValueToFile(const T& value,
+                          const std::string& path) const noexcept;
 
   /**
    * @brief Write a table to a file with a specific type.
    * @param input_table The table to write.
    * @param file_type The type of the output file.
    * @param path The path of the output file.
+   * @param options Options for writing the table, such as compression.
    * @return A Status indicating OK if successful, or an error if unsuccessful.
    */
-  Status WriteTableToFile(const std::shared_ptr<arrow::Table>& table,
-                          FileType file_type, const std::string& path) const
-      noexcept;
+  Status WriteTableToFile(
+      const std::shared_ptr<arrow::Table>& table, FileType file_type,
+      const std::string& path,
+      const std::shared_ptr<WriterOptions>& options = nullptr) const noexcept;
 
   /**
    * @brief Write a label table to a file with parquet type.

--- a/cpp/src/graphar/high-level/edges_builder.cc
+++ b/cpp/src/graphar/high-level/edges_builder.cc
@@ -28,7 +28,8 @@ namespace graphar::builder {
 
 Status EdgesBuilder::Dump() {
   // construct the writer
-  EdgeChunkWriter writer(edge_info_, prefix_, adj_list_type_, validate_level_);
+  EdgeChunkWriter writer(edge_info_, prefix_, adj_list_type_, nullptr,
+                         validate_level_);
   // construct empty edge collections for vertex chunks without edges
   IdType num_vertex_chunks =
       (num_vertices_ + vertex_chunk_size_ - 1) / vertex_chunk_size_;

--- a/cpp/src/graphar/high-level/vertices_builder.h
+++ b/cpp/src/graphar/high-level/vertices_builder.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <any>
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -241,7 +242,8 @@ class VerticesBuilder {
    */
   Status Dump() {
     // construct the writer
-    VertexPropertyWriter writer(vertex_info_, prefix_, validate_level_);
+    VertexPropertyWriter writer(vertex_info_, prefix_, nullptr,
+                                validate_level_);
     IdType start_chunk_index =
         start_vertex_index_ / vertex_info_->GetChunkSize();
     // convert to table

--- a/cpp/src/graphar/writer_util.cc
+++ b/cpp/src/graphar/writer_util.cc
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "graphar/writer_util.h"
+#include <arrow/adapters/orc/options.h>
+#include <arrow/csv/options.h>
+#include <arrow/util/compression.h>
+#include <parquet/arrow/writer.h>
+#include <parquet/properties.h>
+#include <parquet/types.h>
+#include <memory>
+namespace graphar {
+std::shared_ptr<WriterOptions::CSVBuilder>
+WriterOptions::Builder::getCsvOptionBuilder() {
+  if (!csvBuilder) {
+    csvBuilder = std::make_shared<CSVBuilder>();
+  }
+  return csvBuilder;
+}
+std::shared_ptr<WriterOptions::ParquetBuilder>
+WriterOptions::Builder::getParquetOptionBuilder() {
+  if (!parquetBuilder) {
+    parquetBuilder = std::make_shared<ParquetBuilder>();
+  }
+  return parquetBuilder;
+}
+std::shared_ptr<WriterOptions::OrcBuilder>
+WriterOptions::Builder::getOrcOptionBuilder() {
+  if (!orcBuilder) {
+    orcBuilder = std::make_shared<OrcBuilder>();
+  }
+  return orcBuilder;
+}
+
+std::shared_ptr<WriterOptions> WriterOptions::Builder::Build() {
+  return std::make_shared<WriterOptions>(this);
+}
+
+WriterOptions::WriterOptions(WriterOptions::Builder* builder) {
+  if (builder->csvBuilder) {
+    auto csvBuilder = builder->csvBuilder;
+    this->csvOption = csvBuilder->option;
+  }
+  if (builder->parquetBuilder) {
+    auto parquetBuilder = builder->parquetBuilder;
+    this->parquetOption = parquetBuilder->option;
+  }
+  if (builder->orcBuilder) {
+    auto orcBuilder = builder->orcBuilder;
+    this->orcOption = orcBuilder->option;
+  }
+}
+}  // namespace graphar

--- a/cpp/src/graphar/writer_util.h
+++ b/cpp/src/graphar/writer_util.h
@@ -19,9 +19,71 @@
 
 #pragma once
 
+#include "graphar/fwd.h"
 #include "graphar/macros.h"
 
+#include <arrow/util/compression.h>
 namespace graphar {
+class WriterOptions {
+ public:
+  class Builder {
+   public:
+    FileType file_type;
+    bool include_header = true;
+    char delimiter = ',';
+    arrow::Compression::type compression;
+    int compression_level = 0;
+
+    Builder(FileType file_type) : file_type(file_type) {}
+
+    void set_include_header(bool value) {
+      if (file_type != FileType::CSV) {
+        throw Status::Invalid("include_header can only be set for CSV files");
+      }
+      include_header = value;
+    }
+    void set_delimiter(char delimiter) {
+      if (file_type != FileType::CSV) {
+        throw Status::Invalid("delimiter can only be set for CSV files");
+      }
+      if (delimiter == '\0') {
+        throw Status::Invalid("delimiter cannot be null character");
+      }
+      this->delimiter = delimiter;
+    }
+    void set_compression(arrow::Compression::type type) {
+      if (file_type != FileType::PARQUET && file_type != FileType::ORC) {
+        throw Status::Invalid(
+            "compression can only be set for PARQUET or ORC files");
+      }
+      compression = type;
+    }
+    void set_compression_level(int level) {
+      if (file_type != FileType::PARQUET && file_type != FileType::ORC) {
+        throw Status::Invalid(
+            "compression_level can only be set for PARQUET or ORC files");
+      }
+      compression_level = level;
+    }
+    std::shared_ptr<WriterOptions> Build() {
+      return std::make_shared<WriterOptions>(this);
+    }
+  };
+
+ public:
+  FileType file_type;
+  bool include_header;
+  char delimiter;
+  arrow::Compression::type compression;
+  int compression_level = 0;
+
+  explicit WriterOptions(const class Builder* builder)
+      : file_type(builder->file_type),
+        include_header(builder->include_header),
+        delimiter(builder->delimiter),
+        compression(builder->compression),
+        compression_level(builder->compression_level) {}
+};
 
 /**
  * @brief The level for validating writing operations.

--- a/cpp/src/graphar/writer_util.h
+++ b/cpp/src/graphar/writer_util.h
@@ -30,6 +30,33 @@
 namespace graphar {
 class WriterOptions {
  public:
+  WriterOptions(const WriterOptions& other)
+      : csvOption(other.csvOption),
+        parquetOption(other.parquetOption),
+        orcOption(other.orcOption) {}
+
+  WriterOptions(WriterOptions&& other) noexcept
+      : csvOption(std::move(other.csvOption)),
+        parquetOption(std::move(other.parquetOption)),
+        orcOption(std::move(other.orcOption)) {}
+
+  WriterOptions& operator=(const WriterOptions& other) {
+    if (this != &other) {
+      csvOption = other.csvOption;
+      parquetOption = other.parquetOption;
+      orcOption = other.orcOption;
+    }
+    return *this;
+  }
+
+  WriterOptions& operator=(WriterOptions&& other) noexcept {
+    if (this != &other) {
+      csvOption = std::move(other.csvOption);
+      parquetOption = std::move(other.parquetOption);
+      orcOption = std::move(other.orcOption);
+    }
+    return *this;
+  }
   class CSVOption {
    public:
     bool include_header = true;
@@ -231,6 +258,35 @@ class WriterOptions {
     friend WriterOptions;
 
    public:
+    Builder() = default;
+    Builder(const Builder& other)
+        : csvBuilder(other.csvBuilder),
+          parquetBuilder(other.parquetBuilder),
+          orcBuilder(other.orcBuilder) {}
+
+    Builder(Builder&& other) noexcept
+        : csvBuilder(std::move(other.csvBuilder)),
+          parquetBuilder(std::move(other.parquetBuilder)),
+          orcBuilder(std::move(other.orcBuilder)) {}
+
+    Builder& operator=(const Builder& other) {
+      if (this != &other) {
+        csvBuilder = other.csvBuilder;
+        parquetBuilder = other.parquetBuilder;
+        orcBuilder = other.orcBuilder;
+      }
+      return *this;
+    }
+
+    Builder& operator=(Builder&& other) noexcept {
+      if (this != &other) {
+        csvBuilder = std::move(other.csvBuilder);
+        parquetBuilder = std::move(other.parquetBuilder);
+        orcBuilder = std::move(other.orcBuilder);
+      }
+      return *this;
+    }
+
     std::shared_ptr<CSVBuilder> getCsvOptionBuilder();
     std::shared_ptr<ParquetBuilder> getParquetOptionBuilder();
     std::shared_ptr<OrcBuilder> getOrcOptionBuilder();


### PR DESCRIPTION
### Reason for this PR

This PR resolves issue #108  by providing a WriterOption API to support different file types.

### What changes are included in this PR?

I've added a `WriterOption` class that provides different options for each file type.
To improve clarity and usability, I've separated the options for the three supported file types into three distinct classes, so users can clearly see what configurations are available for each format.
Additionally, I've created a `Builder` class to help users construct these options in a more intuitive and structured way. 

### Are these changes tested?

yes

### Are there any user-facing changes?

yes, users can use `WriterOptions` to customize the `writer option` for each file type.

