### PR TITLE
feat(c++): Allow setting WriterOptions in high-level writer APIs

### DIFF
--- a/cpp/examples/high_level_writer_example.cc
+++ b/cpp/examples/high_level_writer_example.cc
@@ -86,6 +86,10 @@ void edges_builder() {
   // set validate level
   builder.SetValidateLevel(graphar::ValidateLevel::strong_validate);
 
+  graphar::WriterOptions::ParquetOptionBuilder parquetOptionBuilder;
+  parquetOptionBuilder.compression(arrow::Compression::ZSTD);
+  builder.SetWriterOptions(parquetOptionBuilder.build());
+
   // prepare edge data
   int edge_count = 4;
   std::vector<std::string> property_names = {"creationDate"};

--- a/cpp/examples/high_level_writer_example.cc
+++ b/cpp/examples/high_level_writer_example.cc
@@ -83,6 +83,10 @@ void edges_builder() {
   graphar::builder::EdgesBuilder builder(
       edge_info, "/tmp/", graphar::AdjListType::ordered_by_dest, vertex_count);
 
+  graphar::WriterOptions::ParquetOptionBuilder parquetOptionBuilder;
+  parquetOptionBuilder.compression(arrow::Compression::ZSTD);
+  builder.SetWriterOptions(parquetOptionBuilder.build());
+
   // set validate level
   builder.SetValidateLevel(graphar::ValidateLevel::strong_validate);
 

--- a/cpp/examples/high_level_writer_example.cc
+++ b/cpp/examples/high_level_writer_example.cc
@@ -86,10 +86,6 @@ void edges_builder() {
   // set validate level
   builder.SetValidateLevel(graphar::ValidateLevel::strong_validate);
 
-  graphar::WriterOptions::ParquetOptionBuilder parquetOptionBuilder;
-  parquetOptionBuilder.compression(arrow::Compression::ZSTD);
-  builder.SetWriterOptions(parquetOptionBuilder.build());
-
   // prepare edge data
   int edge_count = 4;
   std::vector<std::string> property_names = {"creationDate"};

--- a/cpp/examples/high_level_writer_example.cc
+++ b/cpp/examples/high_level_writer_example.cc
@@ -24,6 +24,7 @@
 
 #include "./config.h"
 #include "graphar/api/high_level_writer.h"
+#include "graphar/writer_util.h"
 
 void vertices_builder() {
   // construct vertices builder
@@ -33,6 +34,10 @@ void vertices_builder() {
   auto vertex_info = graphar::VertexInfo::Load(vertex_meta).value();
   graphar::IdType start_index = 0;
   graphar::builder::VerticesBuilder builder(vertex_info, "/tmp/", start_index);
+
+  graphar::WriterOptions::ParquetOptionBuilder parquetOptionBuilder;
+  parquetOptionBuilder.compression(arrow::Compression::ZSTD);
+  builder.SetWriterOptions(parquetOptionBuilder.build());
 
   // set validate level
   builder.SetValidateLevel(graphar::ValidateLevel::strong_validate);

--- a/cpp/src/graphar/high-level/edges_builder.cc
+++ b/cpp/src/graphar/high-level/edges_builder.cc
@@ -28,7 +28,7 @@ namespace graphar::builder {
 
 Status EdgesBuilder::Dump() {
   // construct the writer
-  EdgeChunkWriter writer(edge_info_, prefix_, adj_list_type_, nullptr,
+  EdgeChunkWriter writer(edge_info_, prefix_, adj_list_type_, writer_options_,
                          validate_level_);
   // construct empty edge collections for vertex chunks without edges
   IdType num_vertex_chunks =

--- a/cpp/src/graphar/high-level/edges_builder.h
+++ b/cpp/src/graphar/high-level/edges_builder.h
@@ -310,7 +310,7 @@ class EdgesBuilder {
   static Result<std::shared_ptr<EdgesBuilder>> Make(
       const std::shared_ptr<EdgeInfo>& edge_info, const std::string& prefix,
       AdjListType adj_list_type, IdType num_vertices,
-      std::shared_ptr<WriterOptions> writer_options = nullptr,
+      std::shared_ptr<WriterOptions> writer_options,
       const ValidateLevel& validate_level = ValidateLevel::no_validate) {
     if (!edge_info->HasAdjacentListType(adj_list_type)) {
       return Status::KeyError(
@@ -319,6 +319,20 @@ class EdgesBuilder {
     }
     return std::make_shared<EdgesBuilder>(edge_info, prefix, adj_list_type,
                                           num_vertices, writer_options,
+                                          validate_level);
+  }
+
+  static Result<std::shared_ptr<EdgesBuilder>> Make(
+      const std::shared_ptr<EdgeInfo>& edge_info, const std::string& prefix,
+      AdjListType adj_list_type, IdType num_vertices,
+      const ValidateLevel& validate_level = ValidateLevel::no_validate) {
+    if (!edge_info->HasAdjacentListType(adj_list_type)) {
+      return Status::KeyError(
+          "The adjacent list type ", AdjListTypeToString(adj_list_type),
+          " doesn't exist in edge ", edge_info->GetEdgeType(), ".");
+    }
+    return std::make_shared<EdgesBuilder>(edge_info, prefix, adj_list_type,
+                                          num_vertices, nullptr,
                                           validate_level);
   }
 
@@ -338,7 +352,7 @@ class EdgesBuilder {
       const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
       const std::string& edge_type, const std::string& dst_type,
       const AdjListType& adj_list_type, IdType num_vertices,
-      std::shared_ptr<WriterOptions> writer_options = nullptr,
+      std::shared_ptr<WriterOptions> writer_options,
       const ValidateLevel& validate_level = ValidateLevel::no_validate) {
     auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
     if (!edge_info) {
@@ -347,6 +361,20 @@ class EdgesBuilder {
     }
     return Make(edge_info, graph_info->GetPrefix(), adj_list_type, num_vertices,
                 writer_options, validate_level);
+  }
+
+  static Result<std::shared_ptr<EdgesBuilder>> Make(
+      const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
+      const std::string& edge_type, const std::string& dst_type,
+      const AdjListType& adj_list_type, IdType num_vertices,
+      const ValidateLevel& validate_level = ValidateLevel::no_validate) {
+    auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
+    if (!edge_info) {
+      return Status::KeyError("The edge ", src_type, " ", edge_type, " ",
+                              dst_type, " doesn't exist.");
+    }
+    return Make(edge_info, graph_info->GetPrefix(), adj_list_type, num_vertices,
+                nullptr, validate_level);
   }
 
  private:

--- a/cpp/src/graphar/high-level/edges_builder.h
+++ b/cpp/src/graphar/high-level/edges_builder.h
@@ -158,6 +158,8 @@ class EdgesBuilder {
    * @param prefix The absolute prefix.
    * @param adj_list_type The adj list type of the edges.
    * @param num_vertices The total number of vertices for source or destination.
+   * @param writerOptions The writerOptions provides configuration options for
+   * different file format writers.
    * @param validate_level The global validate level for the writer, with no
    * validate by default. It could be ValidateLevel::no_validate,
    * ValidateLevel::weak_validate or ValidateLevel::strong_validate, but could
@@ -166,11 +168,13 @@ class EdgesBuilder {
   explicit EdgesBuilder(
       const std::shared_ptr<EdgeInfo>& edge_info, const std::string& prefix,
       AdjListType adj_list_type, IdType num_vertices,
+      std::shared_ptr<WriterOptions> writerOptions = nullptr,
       const ValidateLevel& validate_level = ValidateLevel::no_validate)
       : edge_info_(std::move(edge_info)),
         prefix_(prefix),
         adj_list_type_(adj_list_type),
         num_vertices_(num_vertices),
+        writer_options_(writerOptions),
         validate_level_(validate_level) {
     if (validate_level_ == ValidateLevel::default_validate) {
       throw std::runtime_error(
@@ -208,6 +212,25 @@ class EdgesBuilder {
       return;
     }
     validate_level_ = validate_level;
+  }
+
+  /**
+   * @brief Set the writerOptions.
+   *
+   * @return The writerOptions provides configuration options for different file
+   * format writers.
+   */
+  inline void SetWriterOptions(std::shared_ptr<WriterOptions> writer_options) {
+    this->writer_options_ = writer_options;
+  }
+  /**
+   * @brief Set the writerOptions.
+   *
+   * @param writerOptions The writerOptions provides configuration options for
+   * different file format writers.
+   */
+  inline std::shared_ptr<WriterOptions> GetWriterOptions() {
+    return this->writer_options_;
   }
 
   /**
@@ -279,12 +302,15 @@ class EdgesBuilder {
    * @param prefix The absolute prefix.
    * @param adj_list_type The adj list type of the edges.
    * @param num_vertices The total number of vertices for source or destination.
+   * @param writerOptions The writerOptions provides configuration options for
+   * different file format writers.
    * @param validate_level The global validate level for the builder, default is
    * no_validate.
    */
   static Result<std::shared_ptr<EdgesBuilder>> Make(
       const std::shared_ptr<EdgeInfo>& edge_info, const std::string& prefix,
       AdjListType adj_list_type, IdType num_vertices,
+      std::shared_ptr<WriterOptions> writer_options = nullptr,
       const ValidateLevel& validate_level = ValidateLevel::no_validate) {
     if (!edge_info->HasAdjacentListType(adj_list_type)) {
       return Status::KeyError(
@@ -292,7 +318,8 @@ class EdgesBuilder {
           " doesn't exist in edge ", edge_info->GetEdgeType(), ".");
     }
     return std::make_shared<EdgesBuilder>(edge_info, prefix, adj_list_type,
-                                          num_vertices, validate_level);
+                                          num_vertices, writer_options,
+                                          validate_level);
   }
 
   /**
@@ -311,6 +338,7 @@ class EdgesBuilder {
       const std::shared_ptr<GraphInfo>& graph_info, const std::string& src_type,
       const std::string& edge_type, const std::string& dst_type,
       const AdjListType& adj_list_type, IdType num_vertices,
+      std::shared_ptr<WriterOptions> writer_options = nullptr,
       const ValidateLevel& validate_level = ValidateLevel::no_validate) {
     auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
     if (!edge_info) {
@@ -318,7 +346,7 @@ class EdgesBuilder {
                               dst_type, " doesn't exist.");
     }
     return Make(edge_info, graph_info->GetPrefix(), adj_list_type, num_vertices,
-                validate_level);
+                writer_options, validate_level);
   }
 
  private:
@@ -421,6 +449,7 @@ class EdgesBuilder {
   IdType num_vertices_;
   IdType num_edges_;
   bool is_saved_;
+  std::shared_ptr<WriterOptions> writer_options_;
   ValidateLevel validate_level_;
 };
 

--- a/cpp/src/graphar/high-level/vertices_builder.h
+++ b/cpp/src/graphar/high-level/vertices_builder.h
@@ -376,7 +376,7 @@ class VerticesBuilder {
   IdType start_vertex_index_;
   IdType num_vertices_;
   bool is_saved_;
-  std::shared_ptr<WriterOptions> writer_options_ = nullptr;
+  std::shared_ptr<WriterOptions> writer_options_;
   ValidateLevel validate_level_;
 };
 

--- a/cpp/src/graphar/high-level/vertices_builder.h
+++ b/cpp/src/graphar/high-level/vertices_builder.h
@@ -294,12 +294,20 @@ class VerticesBuilder {
    */
   static Result<std::shared_ptr<VerticesBuilder>> Make(
       const std::shared_ptr<VertexInfo>& vertex_info, const std::string& prefix,
+      std::shared_ptr<WriterOptions> writer_options,
       IdType start_vertex_index = 0,
-      std::shared_ptr<WriterOptions> writer_options = nullptr,
       const ValidateLevel& validate_level = ValidateLevel::no_validate) {
     return std::make_shared<VerticesBuilder>(vertex_info, prefix,
                                              start_vertex_index, writer_options,
                                              validate_level);
+  }
+
+  static Result<std::shared_ptr<VerticesBuilder>> Make(
+      const std::shared_ptr<VertexInfo>& vertex_info, const std::string& prefix,
+      IdType start_vertex_index = 0,
+      const ValidateLevel& validate_level = ValidateLevel::no_validate) {
+    return std::make_shared<VerticesBuilder>(
+        vertex_info, prefix, start_vertex_index, nullptr, validate_level);
   }
 
   /**
@@ -315,8 +323,8 @@ class VerticesBuilder {
    */
   static Result<std::shared_ptr<VerticesBuilder>> Make(
       const std::shared_ptr<GraphInfo>& graph_info, const std::string& type,
+      std::shared_ptr<WriterOptions> writer_options,
       IdType start_vertex_index = 0,
-      std::shared_ptr<WriterOptions> writer_options = nullptr,
       const ValidateLevel& validate_level = ValidateLevel::no_validate) {
     const auto vertex_info = graph_info->GetVertexInfo(type);
     if (!vertex_info) {
@@ -324,8 +332,22 @@ class VerticesBuilder {
                               " doesn't exist in graph ", graph_info->GetName(),
                               ".");
     }
-    return Make(vertex_info, graph_info->GetPrefix(), start_vertex_index,
-                writer_options, validate_level);
+    return Make(vertex_info, graph_info->GetPrefix(), writer_options,
+                start_vertex_index, validate_level);
+  }
+
+  static Result<std::shared_ptr<VerticesBuilder>> Make(
+      const std::shared_ptr<GraphInfo>& graph_info, const std::string& type,
+      IdType start_vertex_index = 0,
+      const ValidateLevel& validate_level = ValidateLevel::no_validate) {
+    const auto vertex_info = graph_info->GetVertexInfo(type);
+    if (!vertex_info) {
+      return Status::KeyError("The vertex type ", type,
+                              " doesn't exist in graph ", graph_info->GetName(),
+                              ".");
+    }
+    return Make(vertex_info, graph_info->GetPrefix(), nullptr,
+                start_vertex_index, validate_level);
   }
 
  private:

--- a/cpp/src/graphar/writer_util.h
+++ b/cpp/src/graphar/writer_util.h
@@ -179,8 +179,9 @@ class WriterOptions {
       return *this;
     }
     std::shared_ptr<WriterOptions> build() {
-      writerOptions_ =
-          writerOptions_ ? writerOptions_ : std::make_shared<WriterOptions>();
+      if (!writerOptions_) {
+        writerOptions_ = std::make_shared<WriterOptions>();
+      }
       writerOptions_->setCsvOption(option_);
       return writerOptions_;
     }
@@ -327,8 +328,9 @@ class WriterOptions {
       return *this;
     }
     std::shared_ptr<WriterOptions> build() {
-      writerOptions_ =
-          writerOptions_ ? writerOptions_ : std::make_shared<WriterOptions>();
+      if (!writerOptions_) {
+        writerOptions_ = std::make_shared<WriterOptions>();
+      }
       writerOptions_->setParquetOption(option_);
       return writerOptions_;
     }
@@ -394,8 +396,9 @@ class WriterOptions {
     }
 #endif
     std::shared_ptr<WriterOptions> build() {
-      writerOptions_ =
-          writerOptions_ ? writerOptions_ : std::make_shared<WriterOptions>();
+      if (!writerOptions_) {
+        writerOptions_ = std::make_shared<WriterOptions>();
+      }
       writerOptions_->setOrcOption(option_);
       return writerOptions_;
     }

--- a/cpp/src/graphar/writer_util.h
+++ b/cpp/src/graphar/writer_util.h
@@ -45,6 +45,16 @@ namespace graphar {
  *
  * The configuration parameters and their default values are aligned with those
  * in Arrow.
+ *
+ * CSVOptionBuilder, ParquetOptionBuilder, and ORCOptionBuilder are used to
+ * construct format-specific options for CSV, Parquet, and ORC, respectively.
+ * An existing WriterOptions instance can be passed to a builder’s constructor
+ * to incrementally add or combine options across different formats.
+ * Example:
+ * CSVOptionBuilder csvBuilder;
+ * auto wopt = csvBuilder.build();
+ * ParquetOptionBuilder parquetBuilder(wopt);
+ * wopt = parquetBuilder.build();
  */
 class WriterOptions {
  private:
@@ -138,7 +148,8 @@ class WriterOptions {
     CSVOptionBuilder() : option_(std::make_shared<CSVOption>()) {}
     explicit CSVOptionBuilder(std::shared_ptr<WriterOptions> wopt)
         : writerOptions_(wopt),
-          option_(wopt ? wopt->csvOption_ : std::make_shared<CSVOption>()) {}
+          option_(wopt && wopt->csvOption_ ? wopt->csvOption_
+                                           : std::make_shared<CSVOption>()) {}
     CSVOptionBuilder& include_header(bool header) {
       option_->include_header = header;
       return *this;
@@ -168,9 +179,10 @@ class WriterOptions {
       return *this;
     }
     std::shared_ptr<WriterOptions> build() {
-      return writerOptions_
-                 ? writerOptions_
-                 : std::make_shared<WriterOptions>(option_, nullptr, nullptr);
+      writerOptions_ =
+          writerOptions_ ? writerOptions_ : std::make_shared<WriterOptions>();
+      writerOptions_->setCsvOption(option_);
+      return writerOptions_;
     }
 
    private:
@@ -184,8 +196,9 @@ class WriterOptions {
     ParquetOptionBuilder() : option_(std::make_shared<ParquetOption>()) {}
     explicit ParquetOptionBuilder(std::shared_ptr<WriterOptions> wopt)
         : writerOptions_(wopt),
-          option_(wopt ? wopt->parquetOption_
-                       : std::make_shared<ParquetOption>()) {}
+          option_(wopt && wopt->parquetOption_
+                      ? wopt->parquetOption_
+                      : std::make_shared<ParquetOption>()) {}
     ParquetOptionBuilder& enable_dictionary(bool enable) {
       option_->enable_dictionary = enable;
       return *this;
@@ -314,9 +327,10 @@ class WriterOptions {
       return *this;
     }
     std::shared_ptr<WriterOptions> build() {
-      return writerOptions_
-                 ? writerOptions_
-                 : std::make_shared<WriterOptions>(nullptr, option_, nullptr);
+      writerOptions_ =
+          writerOptions_ ? writerOptions_ : std::make_shared<WriterOptions>();
+      writerOptions_->setParquetOption(option_);
+      return writerOptions_;
     }
 
    private:
@@ -330,7 +344,8 @@ class WriterOptions {
     ORCOptionBuilder() : option_(std::make_shared<ORCOption>()) {}
     explicit ORCOptionBuilder(std::shared_ptr<WriterOptions> wopt)
         : writerOptions_(wopt),
-          option_(wopt ? wopt->orcOption_ : std::make_shared<ORCOption>()) {}
+          option_(wopt && wopt->orcOption_ ? wopt->orcOption_
+                                           : std::make_shared<ORCOption>()) {}
 #ifdef ARROW_ORC
     ORCOptionBuilder& batch_size(int64_t bs) {
       option_->batch_size = bs;
@@ -379,9 +394,10 @@ class WriterOptions {
     }
 #endif
     std::shared_ptr<WriterOptions> build() {
-      return writerOptions_
-                 ? writerOptions_
-                 : std::make_shared<WriterOptions>(nullptr, nullptr, option_);
+      writerOptions_ =
+          writerOptions_ ? writerOptions_ : std::make_shared<WriterOptions>();
+      writerOptions_->setOrcOption(option_);
+      return writerOptions_;
     }
 
    private:
@@ -396,6 +412,15 @@ class WriterOptions {
       : csvOption_(csv), parquetOption_(parquet), orcOption_(orc) {}
   static std::shared_ptr<WriterOptions> DefaultWriterOption() {
     return std::make_shared<WriterOptions>();
+  }
+  void setCsvOption(std::shared_ptr<CSVOption> csv_option) {
+    csvOption_ = csv_option;
+  }
+  void setParquetOption(std::shared_ptr<ParquetOption> parquet_option) {
+    parquetOption_ = parquet_option;
+  }
+  void setOrcOption(std::shared_ptr<ORCOption> orc_option) {
+    orcOption_ = orc_option;
   }
   arrow::csv::WriteOptions getCsvOption() const;
   std::shared_ptr<parquet::WriterProperties> getParquetWriterProperties() const;

--- a/cpp/test/test_arrow_chunk_writer.cc
+++ b/cpp/test/test_arrow_chunk_writer.cc
@@ -166,10 +166,11 @@ TEST_CASE_METHOD(GlobalFixture, "TestVertexPropertyWriter") {
     auto vertex_meta_csv = Yaml::LoadFile(vertex_meta_file_csv).value();
     auto vertex_info_csv = VertexInfo::Load(vertex_meta_csv).value();
     auto csv_options = WriterOptions::CSVOptionBuilder();
+    auto wopt = csv_options.build();
     csv_options.include_header(true);
     csv_options.delimiter('|');
-    auto maybe_writer = VertexPropertyWriter::Make(
-        vertex_info_csv, "/tmp/option/", csv_options.build());
+    auto maybe_writer =
+        VertexPropertyWriter::Make(vertex_info_csv, "/tmp/option/", wopt);
     REQUIRE(!maybe_writer.has_error());
     auto writer = maybe_writer.value();
     REQUIRE(writer->WriteTable(table, 0).ok());
@@ -196,7 +197,7 @@ TEST_CASE_METHOD(GlobalFixture, "TestVertexPropertyWriter") {
                                  .size()) +
                 1);
     // type parquet
-    auto options_parquet_Builder = WriterOptions::ParquetOptionBuilder();
+    auto options_parquet_Builder = WriterOptions::ParquetOptionBuilder(wopt);
     options_parquet_Builder.compression(arrow::Compression::type::UNCOMPRESSED);
     options_parquet_Builder.enable_statistics(false);
     parquet::SortingColumn sc;
@@ -205,8 +206,9 @@ TEST_CASE_METHOD(GlobalFixture, "TestVertexPropertyWriter") {
     options_parquet_Builder.sorting_columns(columns)
         .enable_store_decimal_as_integer(true)
         .max_row_group_length(10);
-    maybe_writer = VertexPropertyWriter::Make(
-        vertex_info_parquet, "/tmp/option/", options_parquet_Builder.build());
+    wopt = options_parquet_Builder.build();
+    maybe_writer =
+        VertexPropertyWriter::Make(vertex_info_parquet, "/tmp/option/", wopt);
     REQUIRE(!maybe_writer.has_error());
     writer = maybe_writer.value();
     REQUIRE(writer->WriteTable(table, 0).ok());
@@ -244,10 +246,11 @@ TEST_CASE_METHOD(GlobalFixture, "TestVertexPropertyWriter") {
         test_data_dir + "/ldbc_sample/orc/" + "person.vertex.yml";
     auto vertex_meta_orc = Yaml::LoadFile(vertex_meta_file_orc).value();
     auto vertex_info_orc = VertexInfo::Load(vertex_meta_orc).value();
-    auto optionsOrcBuilder = WriterOptions::ORCOptionBuilder();
+    auto optionsOrcBuilder = WriterOptions::ORCOptionBuilder(wopt);
     optionsOrcBuilder.compression(arrow::Compression::type::ZSTD);
-    maybe_writer = VertexPropertyWriter::Make(vertex_info_orc, "/tmp/option/",
-                                              optionsOrcBuilder.build());
+    wopt = optionsOrcBuilder.build();
+    maybe_writer =
+        VertexPropertyWriter::Make(vertex_info_orc, "/tmp/option/", wopt);
     REQUIRE(!maybe_writer.has_error());
     writer = maybe_writer.value();
     REQUIRE(writer->WriteTable(table, 0).ok());


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
As #715 describe

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- [x] Adds `Get/SetWriterOptions()` and constructor parameters to the `VerticesBuilder/EdgesBuilder`.

- [x] Fixes an NPE issue that occurs when `WriterOptions` contains configurations for different file types.

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes
### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
yes
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
