### PR TITLE
feat(c++): support build multi-properties in high-level API

### DIFF
--- a/cpp/examples/high_level_writer_example.cc
+++ b/cpp/examples/high_level_writer_example.cc
@@ -40,7 +40,7 @@ void vertices_builder() {
   builder.SetWriterOptions(parquetOptionBuilder.build());
 
   // set validate level
-  builder.SetValidateLevel(graphar::ValidateLevel::weak_validate);
+  builder.SetValidateLevel(graphar::ValidateLevel::strong_validate);
 
   // prepare vertex data
   int vertex_count = 3;

--- a/cpp/examples/high_level_writer_example.cc
+++ b/cpp/examples/high_level_writer_example.cc
@@ -29,7 +29,7 @@
 void vertices_builder() {
   // construct vertices builder
   std::string vertex_meta_file =
-      GetTestingResourceRoot() + "/ldbc_sample/parquet/" + "person.vertex.yml";
+      GetTestingResourceRoot() + "/ldbc/parquet/" + "person.vertex.yml";
   auto vertex_meta = graphar::Yaml::LoadFile(vertex_meta_file).value();
   auto vertex_info = graphar::VertexInfo::Load(vertex_meta).value();
   graphar::IdType start_index = 0;
@@ -45,11 +45,16 @@ void vertices_builder() {
   // prepare vertex data
   int vertex_count = 3;
   std::vector<std::string> property_names = {"id", "firstName", "lastName",
-                                             "gender"};
+                                             "gender", "emails"};
   std::vector<int64_t> id = {0, 1, 2};
   std::vector<std::string> firstName = {"John", "Jane", "Alice"};
   std::vector<std::string> lastName = {"Smith", "Doe", "Wonderland"};
   std::vector<std::string> gender = {"male", "famale", "famale"};
+  std::vector<std::vector<std::string>> emails = {
+      {"john@example.com", "john.work@example.com"},
+      {"jane@example.com"},
+      {"alice@example.com", "alice123@example.com",
+       "a.wonderland@example.com"}};
 
   // add vertices
   for (int i = 0; i < vertex_count; i++) {
@@ -58,6 +63,10 @@ void vertices_builder() {
     v.AddProperty(property_names[1], firstName[i]);
     v.AddProperty(property_names[2], lastName[i]);
     v.AddProperty(property_names[3], gender[i]);
+    // for (const auto& email : emails[i]) {
+    //   v.AddProperty(graphar::Cardinality::LIST, property_names[4],
+    //                 email);  // Multi-property
+    // }
     ASSERT(builder.AddVertex(v).ok());
   }
 

--- a/cpp/examples/high_level_writer_example.cc
+++ b/cpp/examples/high_level_writer_example.cc
@@ -40,7 +40,7 @@ void vertices_builder() {
   builder.SetWriterOptions(parquetOptionBuilder.build());
 
   // set validate level
-  builder.SetValidateLevel(graphar::ValidateLevel::strong_validate);
+  builder.SetValidateLevel(graphar::ValidateLevel::weak_validate);
 
   // prepare vertex data
   int vertex_count = 3;
@@ -63,10 +63,10 @@ void vertices_builder() {
     v.AddProperty(property_names[1], firstName[i]);
     v.AddProperty(property_names[2], lastName[i]);
     v.AddProperty(property_names[3], gender[i]);
-    // for (const auto& email : emails[i]) {
-    //   v.AddProperty(graphar::Cardinality::LIST, property_names[4],
-    //                 email);  // Multi-property
-    // }
+    for (const auto& email : emails[i]) {
+      v.AddProperty(graphar::Cardinality::LIST, property_names[4],
+                    email);  // Multi-property
+    }
     ASSERT(builder.AddVertex(v).ok());
   }
 

--- a/cpp/src/graphar/arrow/chunk_writer.cc
+++ b/cpp/src/graphar/arrow/chunk_writer.cc
@@ -23,6 +23,7 @@
 
 #include "arrow/api.h"
 #include "arrow/compute/api.h"
+#include "graphar/fwd.h"
 #include "graphar/writer_util.h"
 #if defined(ARROW_VERSION) && ARROW_VERSION >= 12000000
 #include "arrow/acero/exec_plan.h"
@@ -193,10 +194,15 @@ Status VertexPropertyWriter::validate(
                                " does not exist in the input table.");
       }
       auto field = schema->field(indice);
-      if (DataType::ArrowDataTypeToDataType(field->type()) != property.type) {
+      auto schema_data_type = DataType::DataTypeToArrowDataType(property.type);
+      if (property.cardinality != Cardinality::SINGLE) {
+        schema_data_type = arrow::list(schema_data_type);
+      }
+      if (!field->type()->Equals(schema_data_type)) {
         return Status::TypeError(
             "The data type of property: ", property.name, " is ",
-            property.type->ToTypeName(), ", but got ",
+            DataType::ArrowDataTypeToDataType(schema_data_type)->ToTypeName(),
+            ", but got ",
             DataType::ArrowDataTypeToDataType(field->type())->ToTypeName(),
             ".");
       }

--- a/cpp/src/graphar/arrow/chunk_writer.cc
+++ b/cpp/src/graphar/arrow/chunk_writer.cc
@@ -198,7 +198,8 @@ Status VertexPropertyWriter::validate(
       if (property.cardinality != Cardinality::SINGLE) {
         schema_data_type = arrow::list(schema_data_type);
       }
-      if (!field->type()->Equals(schema_data_type)) {
+      if (!DataType::ArrowDataTypeToDataType(field->type())
+               ->Equals(DataType::ArrowDataTypeToDataType(schema_data_type))) {
         return Status::TypeError(
             "The data type of property: ", property.name, " is ",
             DataType::ArrowDataTypeToDataType(schema_data_type)->ToTypeName(),

--- a/cpp/src/graphar/high-level/vertices_builder.cc
+++ b/cpp/src/graphar/high-level/vertices_builder.cc
@@ -128,7 +128,6 @@ Status VerticesBuilder::validate(const Vertex& v, IdType index,
       if (invalid_type &&
           Cardinality::SINGLE ==
               vertex_info_->GetPropertyCardinality(property.first).value()) {
-        // TODO(yangxk) validate multi property type
         return Status::TypeError(
             "Invalid data type for property ", property.first + ", defined as ",
             type->ToTypeName(), ", but got ", property.second.type().name());

--- a/cpp/src/graphar/high-level/vertices_builder.cc
+++ b/cpp/src/graphar/high-level/vertices_builder.cc
@@ -150,6 +150,8 @@ Status VerticesBuilder::tryToAppend(
   if (cardinality != Cardinality::SINGLE) {
     arrow::ListBuilder list_builder(pool, builder);
     for (auto& v : vertices_) {
+      GAR_RETURN_NOT_OK(
+          v.ValidateMultiProperty<CType>(property_name, cardinality));
       RETURN_NOT_ARROW_OK(list_builder.Append());
       if (v.Empty() || !v.ContainProperty(property_name)) {
         RETURN_NOT_ARROW_OK(builder->AppendNull());
@@ -264,7 +266,7 @@ Result<std::shared_ptr<arrow::Table>> VerticesBuilder::convertToTable() {
       }
       // add a column to data
       std::shared_ptr<arrow::Array> array;
-      appendToArray(property.type, property.name, array);
+      GAR_RETURN_NOT_OK(appendToArray(property.type, property.name, array));
       arrays.push_back(array);
     }
   }

--- a/cpp/src/graphar/high-level/vertices_builder.cc
+++ b/cpp/src/graphar/high-level/vertices_builder.cc
@@ -109,17 +109,18 @@ Status VerticesBuilder::validate(const Vertex& v, IdType index,
         break;
       case Type::DATE:
         // date is stored as int32_t
-        GAR_RETURN_NOT_OK(
-            v.ValidatePropertyType<typename TypeToArrowType<Type::DATE>::CType::c_type>(
-                property.first,
-                vertex_info_->GetPropertyCardinality(property.first).value()));
+        GAR_RETURN_NOT_OK(v.ValidatePropertyType<
+                          typename TypeToArrowType<Type::DATE>::CType::c_type>(
+            property.first,
+            vertex_info_->GetPropertyCardinality(property.first).value()));
         break;
       case Type::TIMESTAMP:
         // timestamp is stored as int64_t
-        GAR_RETURN_NOT_OK(v.ValidatePropertyType<
-                          typename TypeToArrowType<Type::TIMESTAMP>::CType::c_type>(
-            property.first,
-            vertex_info_->GetPropertyCardinality(property.first).value()));
+        GAR_RETURN_NOT_OK(
+            v.ValidatePropertyType<
+                typename TypeToArrowType<Type::TIMESTAMP>::CType::c_type>(
+                property.first,
+                vertex_info_->GetPropertyCardinality(property.first).value()));
         break;
       default:
         return Status::TypeError("Unsupported property type.");

--- a/cpp/src/graphar/high-level/vertices_builder.cc
+++ b/cpp/src/graphar/high-level/vertices_builder.cc
@@ -72,54 +72,54 @@ Status VerticesBuilder::validate(const Vertex& v, IdType index,
       bool invalid_type = false;
       switch (type->id()) {
       case Type::BOOL:
-        if (property.second.type() !=
-            typeid(typename TypeToArrowType<Type::BOOL>::CType)) {
-          invalid_type = true;
-        }
+        GAR_RETURN_NOT_OK(
+            v.ValidatePropertyType<typename TypeToArrowType<Type::BOOL>::CType>(
+                property.first,
+                vertex_info_->GetPropertyCardinality(property.first).value()));
         break;
       case Type::INT32:
-        if (property.second.type() !=
-            typeid(typename TypeToArrowType<Type::INT32>::CType)) {
-          invalid_type = true;
-        }
+        GAR_RETURN_NOT_OK(v.ValidatePropertyType<
+                          typename TypeToArrowType<Type::INT32>::CType>(
+            property.first,
+            vertex_info_->GetPropertyCardinality(property.first).value()));
         break;
       case Type::INT64:
-        if (property.second.type() !=
-            typeid(typename TypeToArrowType<Type::INT64>::CType)) {
-          invalid_type = true;
-        }
+        GAR_RETURN_NOT_OK(v.ValidatePropertyType<
+                          typename TypeToArrowType<Type::INT64>::CType>(
+            property.first,
+            vertex_info_->GetPropertyCardinality(property.first).value()));
         break;
       case Type::FLOAT:
-        if (property.second.type() !=
-            typeid(typename TypeToArrowType<Type::FLOAT>::CType)) {
-          invalid_type = true;
-        }
+        GAR_RETURN_NOT_OK(v.ValidatePropertyType<
+                          typename TypeToArrowType<Type::FLOAT>::CType>(
+            property.first,
+            vertex_info_->GetPropertyCardinality(property.first).value()));
         break;
       case Type::DOUBLE:
-        if (property.second.type() !=
-            typeid(typename TypeToArrowType<Type::DOUBLE>::CType)) {
-          invalid_type = true;
-        }
+        GAR_RETURN_NOT_OK(v.ValidatePropertyType<
+                          typename TypeToArrowType<Type::DOUBLE>::CType>(
+            property.first,
+            vertex_info_->GetPropertyCardinality(property.first).value()));
         break;
       case Type::STRING:
-        if (property.second.type() !=
-            typeid(typename TypeToArrowType<Type::STRING>::CType)) {
-          invalid_type = true;
-        }
+        GAR_RETURN_NOT_OK(v.ValidatePropertyType<
+                          typename TypeToArrowType<Type::STRING>::CType>(
+            property.first,
+            vertex_info_->GetPropertyCardinality(property.first).value()));
         break;
       case Type::DATE:
         // date is stored as int32_t
-        if (property.second.type() !=
-            typeid(typename TypeToArrowType<Type::DATE>::CType::c_type)) {
-          invalid_type = true;
-        }
+        GAR_RETURN_NOT_OK(
+            v.ValidatePropertyType<typename TypeToArrowType<Type::DATE>::CType::c_type>(
+                property.first,
+                vertex_info_->GetPropertyCardinality(property.first).value()));
         break;
       case Type::TIMESTAMP:
         // timestamp is stored as int64_t
-        if (property.second.type() !=
-            typeid(typename TypeToArrowType<Type::TIMESTAMP>::CType::c_type)) {
-          invalid_type = true;
-        }
+        GAR_RETURN_NOT_OK(v.ValidatePropertyType<
+                          typename TypeToArrowType<Type::TIMESTAMP>::CType::c_type>(
+            property.first,
+            vertex_info_->GetPropertyCardinality(property.first).value()));
         break;
       default:
         return Status::TypeError("Unsupported property type.");
@@ -127,7 +127,7 @@ Status VerticesBuilder::validate(const Vertex& v, IdType index,
       if (invalid_type &&
           Cardinality::SINGLE ==
               vertex_info_->GetPropertyCardinality(property.first).value()) {
-        // TODO validate multi property type
+        // TODO(yangxk) validate multi property type
         return Status::TypeError(
             "Invalid data type for property ", property.first + ", defined as ",
             type->ToTypeName(), ", but got ", property.second.type().name());
@@ -150,8 +150,6 @@ Status VerticesBuilder::tryToAppend(
   if (cardinality != Cardinality::SINGLE) {
     arrow::ListBuilder list_builder(pool, builder);
     for (auto& v : vertices_) {
-      GAR_RETURN_NOT_OK(
-          v.ValidateMultiProperty<CType>(property_name, cardinality));
       RETURN_NOT_ARROW_OK(list_builder.Append());
       if (v.Empty() || !v.ContainProperty(property_name)) {
         RETURN_NOT_ARROW_OK(builder->AppendNull());

--- a/cpp/src/graphar/high-level/vertices_builder.h
+++ b/cpp/src/graphar/high-level/vertices_builder.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -159,8 +160,9 @@ class Vertex {
           ", defined as SINGLE but got ",
           cardinalities_.at(property) == Cardinality::LIST ? "LIST" : "SET");
     }
-    if (cardinality == Cardinality::SET && IsMultiProperty(property)) {
-      // TODO 如果插入的时候是单利，但是需要一个set/list看看是否可以执行成功
+    if (IsMultiProperty(property) &&
+        (cardinality == Cardinality::SET ||
+         cardinalities_.at(property) == Cardinality::SET)) {
       GAR_RETURN_NOT_OK(ValidateMultiPropertySet<T>(property));
     }
     if (IsMultiProperty(property)) {

--- a/cpp/src/graphar/high-level/vertices_builder.h
+++ b/cpp/src/graphar/high-level/vertices_builder.h
@@ -149,21 +149,21 @@ class Vertex {
             cardinalities_.at(property) != Cardinality::SINGLE);
   }
 
+  template <typename T>
   Status ValidateMultiProperty(const std::string& property,
                                const Cardinality cardinality) const {
     if (cardinality == Cardinality::SET) {
-      if (IsMultiProperty(property) &&
-          cardinalities_.at(property) != Cardinality::SET) {
-        // auto vec =
-        //     std::any_cast<std::vector<std::any>>(properties_.at(property));
-        // std::unordered_set<std::any> seen;
-        // for (const auto& item : vec) {
-        //   if (!seen.insert(item).second) {
-        //     return Status::KeyError(
-        //         "Duplicate values exist in set type multi-property: ",
-        //         property);
-        //   }
-        // }
+      if (IsMultiProperty(property)) {
+        auto vec =
+            std::any_cast<std::vector<std::any>>(properties_.at(property));
+        std::unordered_set<T> seen;
+        for (const auto& item : vec) {
+          if (!seen.insert(std::any_cast<T>(item)).second) {
+            return Status::KeyError(
+                "Duplicate values exist in set type multi-property key: ",
+                property," value: ",std::any_cast<T>(item));
+          }
+        }
       }
     }
     return Status::OK();

--- a/cpp/src/graphar/high-level/vertices_builder.h
+++ b/cpp/src/graphar/high-level/vertices_builder.h
@@ -20,8 +20,8 @@
 #pragma once
 
 #include <any>
+#include <cassert>
 #include <cstddef>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -29,7 +29,6 @@
 #include <utility>
 #include <vector>
 
-#include "examples/config.h"
 #include "graphar/arrow/chunk_writer.h"
 #include "graphar/fwd.h"
 #include "graphar/graph_info.h"
@@ -103,7 +102,7 @@ class Vertex {
     }
     empty_ = false;
     if (cardinalities_.find(name) != cardinalities_.end()) {
-      ASSERT(cardinalities_[name] == cardinality);
+      assert(cardinalities_[name] == cardinality);
       auto property_value_list =
           std::any_cast<std::vector<std::any>>(properties_[name]);
       property_value_list.push_back(val);

--- a/cpp/src/graphar/types.h
+++ b/cpp/src/graphar/types.h
@@ -100,8 +100,17 @@ class DataType {
   inline DataType& operator=(const DataType& other) = default;
 
   bool Equals(const DataType& other) const {
-    return id_ == other.id_ &&
-           user_defined_type_name_ == other.user_defined_type_name_;
+    if (id_ != other.id_ ||
+        user_defined_type_name_ != other.user_defined_type_name_) {
+      return false;
+    }
+    if (child_ == nullptr && other.child_ == nullptr) {
+      return true;
+    }
+    if (child_ != nullptr && other.child_ != nullptr) {
+      return child_->Equals(other.child_);
+    }
+    return false;
   }
 
   bool Equals(const std::shared_ptr<DataType>& other) const {


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
Implemented multi-properties in high-level writer (sub-issue of #660).

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Add an API that allows `multi-properties` to be added directly through `v.AddProperty()`, and validate the `Cardinality` and `DataType` at the time of addition. 

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes, in `test_multi_property`
### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
yes
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
