### PR TITLE
fix(ci): install arrow 20.0.0_1 with brewfile(temporary soluation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
         pushd homebrew-core
         git fetch origin aeedb3fd9d26579140d3e59eab5e61db4bba1699
         git checkout aeedb3fd9d26579140d3e59eab5e61db4bba1699
-        brew install ./Formula/a/apache-arrow.rb
+        brew install --prefix=/opt/homebrew ./Formula/a/apache-arrow.rb
         popd
         git clone https://github.com/apache/incubator-graphar-testing.git $GAR_TEST_DATA --depth 1
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,11 +208,12 @@ jobs:
     - name: Install dependencies
       run: |
         brew bundle --file=cpp/Brewfile
+        sudo chown -R $(whoami) /usr/local/Cellar /usr/local/Homebrew
         git clone https://github.com/Homebrew/homebrew-core.git --depth 1 
         pushd homebrew-core
         git fetch origin aeedb3fd9d26579140d3e59eab5e61db4bba1699
         git checkout aeedb3fd9d26579140d3e59eab5e61db4bba1699
-        brew install --prefix=/opt/homebrew ./Formula/a/apache-arrow.rb
+        brew install ./Formula/a/apache-arrow.rb
         popd
         git clone https://github.com/apache/incubator-graphar-testing.git $GAR_TEST_DATA --depth 1
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
         pushd homebrew-core
         git fetch origin aeedb3fd9d26579140d3e59eab5e61db4bba1699
         git checkout aeedb3fd9d26579140d3e59eab5e61db4bba1699
-        brew install homebrew-core/Formula/a/apache-arrow.rb
+        brew install Formula/a/apache-arrow.rb
         popd
         git clone https://github.com/apache/incubator-graphar-testing.git $GAR_TEST_DATA --depth 1
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,12 @@ jobs:
     - name: Install dependencies
       run: |
         brew bundle --file=cpp/Brewfile
+        git clone https://github.com/Homebrew/homebrew-core.git --depth 1 
+        pushd homebrew-core
+        git fetch origin aeedb3fd9d26579140d3e59eab5e61db4bba1699
+        git checkout aeedb3fd9d26579140d3e59eab5e61db4bba1699
+        brew install homebrew-core/Formula/a/apache-arrow.rb
+        popd
         git clone https://github.com/apache/incubator-graphar-testing.git $GAR_TEST_DATA --depth 1
     
     - name: Build GraphAr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,10 +205,6 @@ jobs:
       with:
           submodules: true
 
-    - name: Setup Debug Session
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 15
-
     - name: Install dependencies
       run: |
         brew bundle --file=cpp/Brewfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,8 +210,8 @@ jobs:
         brew bundle --file=cpp/Brewfile
         git clone https://github.com/Homebrew/homebrew-core.git --depth 1 
         pushd homebrew-core
-        git fetch origin 6f33d6974fe77a38a3efbd44a89ead14a5562589
-        git checkout 6f33d6974fe77a38a3efbd44a89ead14a5562589
+        git fetch origin b76848f98196f6dd9d3c4e6f71d030da84d22ce8
+        git checkout b76848f98196f6dd9d3c4e6f71d030da84d22ce8
         brew install ./Formula/a/apache-arrow.rb
         popd
         git clone https://github.com/apache/incubator-graphar-testing.git $GAR_TEST_DATA --depth 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,10 @@ jobs:
       with:
           submodules: true
 
+    - name: Setup Debug Session
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 15
+
     - name: Install dependencies
       run: |
         brew bundle --file=cpp/Brewfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,6 @@ jobs:
     - name: Install dependencies
       run: |
         brew bundle --file=cpp/Brewfile
-        sudo chown -R $(whoami) /usr/local/Cellar /usr/local/Homebrew
         git clone https://github.com/Homebrew/homebrew-core.git --depth 1 
         pushd homebrew-core
         git fetch origin 6f33d6974fe77a38a3efbd44a89ead14a5562589

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
         pushd homebrew-core
         git fetch origin aeedb3fd9d26579140d3e59eab5e61db4bba1699
         git checkout aeedb3fd9d26579140d3e59eab5e61db4bba1699
-        brew install Formula/a/apache-arrow.rb
+        brew install ./Formula/a/apache-arrow.rb
         popd
         git clone https://github.com/apache/incubator-graphar-testing.git $GAR_TEST_DATA --depth 1
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,8 +215,8 @@ jobs:
         sudo chown -R $(whoami) /usr/local/Cellar /usr/local/Homebrew
         git clone https://github.com/Homebrew/homebrew-core.git --depth 1 
         pushd homebrew-core
-        git fetch origin aeedb3fd9d26579140d3e59eab5e61db4bba1699
-        git checkout aeedb3fd9d26579140d3e59eab5e61db4bba1699
+        git fetch origin 6f33d6974fe77a38a3efbd44a89ead14a5562589
+        git checkout 6f33d6974fe77a38a3efbd44a89ead14a5562589
         brew install ./Formula/a/apache-arrow.rb
         popd
         git clone https://github.com/apache/incubator-graphar-testing.git $GAR_TEST_DATA --depth 1

--- a/cpp/Brewfile
+++ b/cpp/Brewfile
@@ -17,7 +17,6 @@
 
 brew "cmake"
 brew "google-benchmark"
-brew "https://github.com/Homebrew/homebrew-core/blob/aeedb3fd9d26579140d3e59eab5e61db4bba1699/Formula/a/apache-arrow.rb"
 brew "boost"
 brew "doxygen"
 brew "git"

--- a/cpp/Brewfile
+++ b/cpp/Brewfile
@@ -17,7 +17,7 @@
 
 brew "cmake"
 brew "google-benchmark"
-brew "apache-arrow", version: "17.0.0"
+brew "https://github.com/Homebrew/homebrew-core/blob/aeedb3fd9d26579140d3e59eab5e61db4bba1699/Formula/a/apache-arrow.rb"
 brew "boost"
 brew "doxygen"
 brew "git"

--- a/cpp/Brewfile
+++ b/cpp/Brewfile
@@ -17,7 +17,7 @@
 
 brew "cmake"
 brew "google-benchmark"
-brew "apache-arrow"
+brew "apache-arrow", version: "17.0.0"
 brew "boost"
 brew "doxygen"
 brew "git"

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -56,6 +56,15 @@ On macOS, you can use [Homebrew](https://brew.sh) to install the required packag
 ```bash
 brew update && brew bundle --file=cpp/Brewfile
 ```
+and run the following command to install the Arrow 20.0.0_1 C++ libraries:
+```bash
+git clone https://github.com/Homebrew/homebrew-core.git --depth 1 
+cd homebrew-core
+git fetch origin b76848f98196f6dd9d3c4e6f71d030da84d22ce8
+git checkout b76848f98196f6dd9d3c4e6f71d030da84d22ce8
+brew install ./Formula/a/apache-arrow.rb
+```
+
 > [!NOTE]
 > Currently, the Arrow C++ library has [disabled ARROW_ORC](https://github.com/Homebrew/homebrew-core/blob/4588359b7248b07379094de5310ee7ff89afa17e/Formula/a/apache-arrow.rb#L53) in the brew formula, so you need to build and install the Arrow C++ library manually (with `-DARROW_ORC=True`).
 


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
description in #724 

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Since Homebrew does not support direct installation of older versions of `apache-arrow`, modifying the Brewfile won't solve the issue. However, we can install a specific version using the following steps:
```bash
git clone https://github.com/Homebrew/homebrew-core.git --depth 1 
cd homebrew-core
git fetch origin b76848f98196f6dd9d3c4e6f71d030da84d22ce8
git checkout b76848f98196f6dd9d3c4e6f71d030da84d22ce8
brew install ./Formula/a/apache-arrow.rb
```
This command can install `apache-arrow 20.0.0_1`, which is the most recent version known to be compatible with the current codebase.
**This is a temporary solution**. Later, we need to find a more elegant way to manage Arrow version, or upgrade the codebase to be compatible with the latest Arrow version.