### PR TITLE
func(c++): make the c++ code compatible with both Arrow 17.0.0 and Arrow 21.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,12 +208,6 @@ jobs:
     - name: Install dependencies
       run: |
         brew bundle --file=cpp/Brewfile
-        git clone https://github.com/Homebrew/homebrew-core.git --depth 1 
-        pushd homebrew-core
-        git fetch origin b76848f98196f6dd9d3c4e6f71d030da84d22ce8
-        git checkout b76848f98196f6dd9d3c4e6f71d030da84d22ce8
-        brew install ./Formula/a/apache-arrow.rb
-        popd
         git clone https://github.com/apache/incubator-graphar-testing.git $GAR_TEST_DATA --depth 1
     
     - name: Build GraphAr

--- a/cli/src/util.h
+++ b/cli/src/util.h
@@ -76,14 +76,10 @@ std::shared_ptr<arrow::Table> SelectColumns(
 std::shared_ptr<arrow::Table> GetDataFromParquetFile(
     const std::string& path, const std::vector<std::string>& column_names) {
   // Open the Parquet file
-  auto infile =
-      arrow::io::ReadableFile::Open(path, arrow::default_memory_pool())
-          .ValueOrDie();
-
   // Create a Parquet FileReader
   std::unique_ptr<parquet::arrow::FileReader> parquet_reader;
-  auto status = parquet::arrow::OpenFile(infile, arrow::default_memory_pool(),
-                                         &parquet_reader);
+  auto status = graphar::util::OpenParquetArrowReader(
+      path, arrow::default_memory_pool(), parquet_reader);
   if (!status.ok()) {
     throw std::runtime_error("Failed to create Parquet FileReader: " +
                              status.ToString());

--- a/cpp/Brewfile
+++ b/cpp/Brewfile
@@ -17,6 +17,7 @@
 
 brew "cmake"
 brew "google-benchmark"
+brew "apache-arrow"
 brew "boost"
 brew "doxygen"
 brew "git"

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -56,14 +56,6 @@ On macOS, you can use [Homebrew](https://brew.sh) to install the required packag
 ```bash
 brew update && brew bundle --file=cpp/Brewfile
 ```
-and run the following command to install the Arrow 20.0.0_1 C++ libraries:
-```bash
-git clone https://github.com/Homebrew/homebrew-core.git --depth 1 
-cd homebrew-core
-git fetch origin b76848f98196f6dd9d3c4e6f71d030da84d22ce8
-git checkout b76848f98196f6dd9d3c4e6f71d030da84d22ce8
-brew install ./Formula/a/apache-arrow.rb
-```
 
 > [!NOTE]
 > Currently, the Arrow C++ library has [disabled ARROW_ORC](https://github.com/Homebrew/homebrew-core/blob/4588359b7248b07379094de5310ee7ff89afa17e/Formula/a/apache-arrow.rb#L53) in the brew formula, so you need to build and install the Arrow C++ library manually (with `-DARROW_ORC=True`).

--- a/cpp/src/graphar/arrow/chunk_writer.cc
+++ b/cpp/src/graphar/arrow/chunk_writer.cc
@@ -18,9 +18,10 @@
  */
 
 #include <cstddef>
+#include <iostream>
 #include <unordered_map>
 #include <utility>
-
+#include <arrow/acero/api.h>
 #include "arrow/api.h"
 #include "arrow/compute/api.h"
 #include "graphar/fwd.h"
@@ -1005,6 +1006,9 @@ Result<std::shared_ptr<arrow::Table>> EdgeChunkWriter::getOffsetTable(
 Result<std::shared_ptr<arrow::Table>> EdgeChunkWriter::sortTable(
     const std::shared_ptr<arrow::Table>& input_table,
     const std::string& column_name) {
+#if ARROW_VERSION >= 21000000
+  RETURN_NOT_ARROW_OK(arrow::compute::Initialize());
+#endif
   auto exec_context = arrow::compute::default_exec_context();
   auto plan = arrow_acero_namespace::ExecPlan::Make(exec_context).ValueOrDie();
   auto table_source_options =

--- a/cpp/src/graphar/filesystem.cc
+++ b/cpp/src/graphar/filesystem.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <iostream>
 #include <memory>
 #include "graphar/writer_util.h"
 #ifdef ARROW_ORC
@@ -24,6 +25,7 @@
 #endif
 #include "arrow/api.h"
 #include "arrow/csv/api.h"
+#include <arrow/compute/api.h>
 #include "arrow/dataset/api.h"
 #include "parquet/arrow/reader.h"
 #if defined(ARROW_VERSION) && ARROW_VERSION <= 12000000
@@ -147,7 +149,9 @@ Result<std::shared_ptr<arrow::Table>> FileSystem::ReadFileToTable(
                         arrow::dataset::FileSystemFactoryOptions()));
   GAR_RETURN_ON_ARROW_ERROR_AND_ASSIGN(auto dataset, factory->Finish());
   GAR_RETURN_ON_ARROW_ERROR_AND_ASSIGN(auto scan_builder, dataset->NewScan());
-
+#if ARROW_VERSION >= 21000000
+  RETURN_NOT_ARROW_OK(arrow::compute::Initialize());
+#endif
   // Apply the row filter and select the specified columns
   if (options.filter) {
     GAR_ASSIGN_OR_RAISE(auto filter, options.filter->Evaluate());

--- a/cpp/test/test_builder.cc
+++ b/cpp/test/test_builder.cc
@@ -30,6 +30,7 @@
 #include "arrow/io/api.h"
 #include "arrow/stl.h"
 #include "arrow/util/uri.h"
+#include "graphar/util.h"
 #include "parquet/arrow/reader.h"
 #include "parquet/arrow/writer.h"
 
@@ -131,13 +132,9 @@ TEST_CASE_METHOD(GlobalFixture, "Test_vertices_builder") {
   REQUIRE((*ptr) == start_index + builder->GetNum());
   // check parquet file compression
   auto parquet_file = "/tmp/vertex/person/id/chunk0";
-  auto parquet_fs =
-      arrow::fs::FileSystemFromUriOrPath(parquet_file).ValueOrDie();
-  std::shared_ptr<arrow::io::RandomAccessFile> parquet_input =
-      parquet_fs->OpenInputFile(parquet_file).ValueOrDie();
   std::unique_ptr<parquet::arrow::FileReader> parquet_reader;
-  REQUIRE(parquet::arrow::OpenFile(parquet_input, arrow::default_memory_pool(),
-                                   &parquet_reader)
+  REQUIRE(graphar::util::OpenParquetArrowReader(
+              parquet_file, arrow::default_memory_pool(), parquet_reader)
               .ok());
   std::shared_ptr<arrow::Table> parquet_table;
   REQUIRE(parquet_reader->ReadTable(&parquet_table).ok());
@@ -238,14 +235,9 @@ TEST_CASE_METHOD(GlobalFixture, "test_edges_builder") {
   // check parquet file compression
   auto parquet_file =
       "/tmp/edge/person_knows_person/ordered_by_dest/creationDate/part0/chunk0";
-  auto parquet_fs =
-      arrow::fs::FileSystemFromUriOrPath(parquet_file).ValueOrDie();
-  std::shared_ptr<arrow::io::RandomAccessFile> parquet_input =
-      parquet_fs->OpenInputFile(parquet_file).ValueOrDie();
   std::unique_ptr<parquet::arrow::FileReader> parquet_reader;
-  REQUIRE(parquet::arrow::OpenFile(parquet_input, arrow::default_memory_pool(),
-                                   &parquet_reader)
-              .ok());
+  REQUIRE(graphar::util::OpenParquetArrowReader(parquet_file, arrow::default_memory_pool(),
+                                     parquet_reader).ok());
   std::shared_ptr<arrow::Table> parquet_table;
   REQUIRE(parquet_reader->ReadTable(&parquet_table).ok());
   auto parquet_metadata = parquet_reader->parquet_reader()->metadata();


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
description in https://github.com/apache/incubator-graphar/issues/724 and #725
The arrow downloaded by homebrew is the latest version(21.0.0), while the arrow used in ubuntu is 17.0.0.

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

use `#ifdef` to make the c++ code compatible with both Arrow 17.0.0 and Arrow 21.0.0 

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

yes
### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->
no
<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
