### PR TITLE
feat(java,info): refactor `EdgeInfo` creation using access-level compliant builder, a…

### DIFF
--- a/maven-projects/info/src/test/java/org/apache/graphar/info/EdgeInfoTest.java
+++ b/maven-projects/info/src/test/java/org/apache/graphar/info/EdgeInfoTest.java
@@ -19,27 +19,25 @@
 
 package org.apache.graphar.info;
 
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
-
-import java.util.List;
-
 public class EdgeInfoTest {
 
-    private EdgeInfo.EdgeInfoBuilder e = EdgeInfo.builder()
-            .srcType("person")
-            .edgeType("knows")
-            .chunkSize(1024)
-            .srcChunkSize(100)
-            .dstChunkSize(100)
-            .directed(false)
-            .prefix("edge/person_knows_person/")
-            .version("gar/v1");
-
+    private EdgeInfo.EdgeInfoBuilder e =
+            EdgeInfo.builder()
+                    .srcType("person")
+                    .edgeType("knows")
+                    .chunkSize(1024)
+                    .srcChunkSize(100)
+                    .dstChunkSize(100)
+                    .directed(false)
+                    .prefix("edge/person_knows_person/")
+                    .version("gar/v1");
 
     @Test
-    public void erroneousTripletEdgeBuilderTest(){
+    public void erroneousTripletEdgeBuilderTest() {
         try {
             e.adjacentLists(List.of(TestUtil.orderedBySource, TestUtil.orderedByDest))
                     .addPropertyGroups(List.of(TestUtil.pg3))
@@ -50,18 +48,16 @@ public class EdgeInfoTest {
     }
 
     @Test
-    public void emptyAdjacentListEdgeBuilderTest(){
+    public void emptyAdjacentListEdgeBuilderTest() {
         try {
-            e.dstType("person")
-                    .addPropertyGroups(List.of(TestUtil.pg3))
-                    .build();
+            e.dstType("person").addPropertyGroups(List.of(TestUtil.pg3)).build();
         } catch (IllegalArgumentException e) {
             System.err.println(e.getMessage());
         }
     }
 
     @Test
-    public void emptyPropertyGroupsEdgeBuilderTest(){
+    public void emptyPropertyGroupsEdgeBuilderTest() {
         try {
             e.adjacentLists(List.of(TestUtil.orderedBySource, TestUtil.orderedByDest))
                     .dstType("person")
@@ -72,31 +68,30 @@ public class EdgeInfoTest {
     }
 
     @Test
-    public void addMethodsTest(){
+    public void addMethodsTest() {
 
-        EdgeInfo edgeInfo = e.addPropertyGroup(TestUtil.pg3)
-                .addAdjacentList(TestUtil.orderedBySource)
-                .addAdjacentList(TestUtil.orderedByDest)
-                .dstType("person")
-                .build();
+        EdgeInfo edgeInfo =
+                e.addPropertyGroup(TestUtil.pg3)
+                        .addAdjacentList(TestUtil.orderedBySource)
+                        .addAdjacentList(TestUtil.orderedByDest)
+                        .dstType("person")
+                        .build();
 
         Assert.assertEquals(2, edgeInfo.getAdjacentLists().size());
-        Assert.assertEquals(1,edgeInfo.getPropertyGroups().size());
+        Assert.assertEquals(1, edgeInfo.getPropertyGroups().size());
     }
 
     @Test
-    public void appendMethodsTest(){
-        EdgeInfo edgeInfo = e.propertyGroups(new PropertyGroups(List.of(TestUtil.pg3)))
-                .adjacentLists(List.of(TestUtil.orderedBySource))
-                .addAdjacentList(TestUtil.orderedByDest)
-                .addPropertyGroups(List.of(TestUtil.pg2))
-                .dstType("person")
-                .build();
+    public void appendMethodsTest() {
+        EdgeInfo edgeInfo =
+                e.propertyGroups(new PropertyGroups(List.of(TestUtil.pg3)))
+                        .adjacentLists(List.of(TestUtil.orderedBySource))
+                        .addAdjacentList(TestUtil.orderedByDest)
+                        .addPropertyGroups(List.of(TestUtil.pg2))
+                        .dstType("person")
+                        .build();
 
         Assert.assertEquals(2, edgeInfo.getAdjacentLists().size());
-        Assert.assertEquals(2,edgeInfo.getPropertyGroups().size());
+        Assert.assertEquals(2, edgeInfo.getPropertyGroups().size());
     }
-
-
-
 }

--- a/maven-projects/info/src/test/java/org/apache/graphar/info/TestUtil.java
+++ b/maven-projects/info/src/test/java/org/apache/graphar/info/TestUtil.java
@@ -44,11 +44,14 @@ public class TestUtil {
             new AdjacentList(AdjListType.ordered_by_source, FileType.CSV, "ordered_by_source/");
     public static final AdjacentList orderedByDest =
             new AdjacentList(AdjListType.ordered_by_dest, FileType.CSV, "ordered_by_dest/");
-    public static final Property creationDate = new Property("creationDate", DataType.STRING, false, false);
-    public static final PropertyGroup pg3 = new PropertyGroup(List.of(creationDate), FileType.CSV, "creationDate/");
+    public static final Property creationDate =
+            new Property("creationDate", DataType.STRING, false, false);
+    public static final PropertyGroup pg3 =
+            new PropertyGroup(List.of(creationDate), FileType.CSV, "creationDate/");
 
     public static final Property id = new Property("id", DataType.INT64, true, false);
-    public static final Property firstName = new Property("firstName", DataType.STRING, false, false);
+    public static final Property firstName =
+            new Property("firstName", DataType.STRING, false, false);
     public static final Property lastName = new Property("lastName", DataType.STRING, false, false);
     public static final Property gender = new Property("gender", DataType.STRING, false, true);
     public static final PropertyGroup pg1 = new PropertyGroup(List.of(id), FileType.CSV, "id/");
@@ -86,8 +89,6 @@ public class TestUtil {
         //    file_type: csv
         // version: gar/v1
 
-
-
         // create edge info of yaml:
         // src_type: person
         // edge_type: knows
@@ -114,7 +115,6 @@ public class TestUtil {
         //        data_type: string
         //        is_primary: false
         // version: gar/v1
-
 
         EdgeInfo knows =
                 EdgeInfo.builder()


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR

Boiler plate heavy telescoping constructor inside `EdgeInfo` #740 
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->


### What changes are included in this PR?

Refactor of telescoping constructor to builder pattern while keeping API access levels and compatibility.

### Are these changes tested?

Yes, using the new builder in `TestUtil` and running the dependent `GraphSaverTest`

### Are there any user-facing changes?

No


