### PR TITLE
feat(c++): Add support for the date/timestamp property types in iter

### DIFF
--- a/cpp/src/graphar/util.cc
+++ b/cpp/src/graphar/util.cc
@@ -89,6 +89,12 @@ Result<const void*> GetArrowArrayData(
   } else if (array->type()->Equals(arrow::boolean())) {
     return reinterpret_cast<const void*>(
         std::dynamic_pointer_cast<arrow::BooleanArray>(array).get());
+  } else if (array->type()->Equals(arrow::date32())) {
+    return reinterpret_cast<const void*>(
+        std::dynamic_pointer_cast<arrow::Date32Array>(array)->raw_values());
+  } else if (array->type()->Equals(arrow::timestamp(arrow::TimeUnit::MILLI))) {
+    return reinterpret_cast<const void*>(
+        std::dynamic_pointer_cast<arrow::TimestampArray>(array)->raw_values());
   } else {
     return Status::TypeError("Array type - ", array->type()->ToString(),
                              " is not supported yet...");


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
Previously, `vertexIter` and `edgeIter` did not properly support `date32` and `timestamp(MILLI)` property types. 

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
* Added explicit handling for `arrow::date32` and `arrow::timestamp(MILLI)` types in `GetArrowArrayData`.
* Kept the existing default branch to raise a `Status::TypeError` if the array type is unsupported.

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->
Yes, user-facing improvement:  Users can now reliably access `date32` and `timestamp(MILLI)` properties through iterators (`vertexIter` / `edgeIter`). No breaking changes introduced; unsupported types still return a `TypeError` as before.
```c++
// sample code for timestamp type
it.property<int64_t>("creationDate").value();
// sample code for date type
it.property<int32_t>("creationDate").value();
```

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
