### PR TITLE
feat(c++): kuzu extension to import/export graphar data

### DIFF
--- a/cpp/extensions/kuzu-extension/CMakeLists.txt
+++ b/cpp/extensions/kuzu-extension/CMakeLists.txt
@@ -1,0 +1,36 @@
+if (WIN32 OR BUILD_STATIC_EXTENSION)
+    set(GraphAr_USE_STATIC_LIBS   ON)
+    set(Arrow_USE_STATIC_LIBS     ON)
+else()
+    set(GraphAr_USE_STATIC_LIBS   OFF)
+    set(Arrow_USE_STATIC_LIBS     OFF)
+endif()
+
+find_package(graphar REQUIRED)
+find_package(Arrow REQUIRED)
+
+message(STATUS "Found GraphAr  : ${graphar_VERSION}")
+message(STATUS "Found Arrow   : ${Arrow_VERSION}")
+
+include_directories(
+    ${PROJECT_SOURCE_DIR}/src/include
+    ${CMAKE_BINARY_DIR}/src/include
+    ${PROJECT_SOURCE_DIR}/extension/graphar/src/include
+    src/include
+)
+
+add_subdirectory(src/function)
+add_subdirectory(src/main)
+
+build_extension_lib(${BUILD_STATIC_EXTENSION} "graphar")
+
+target_link_libraries(
+    kuzu_${EXTENSION_LIB_NAME}_extension
+    PUBLIC
+      graphar
+    #   Arrow::arrow_shared
+)
+
+if (APPLE AND NOT BUILD_STATIC_EXTENSION)
+    set_apple_dynamic_lookup(kuzu_${EXTENSION_LIB_NAME}_extension)
+endif()

--- a/cpp/extensions/kuzu-extension/README.md
+++ b/cpp/extensions/kuzu-extension/README.md
@@ -1,0 +1,68 @@
+# Kuzu — GraphAr Extension
+
+**API:** C++
+**Status:** read-only ingestion, first-cut
+**Repository branch:** [https://github.com/gary-cloud/kuzu/tree/graphar-extension](https://github.com/gary-cloud/kuzu/tree/graphar-extension)
+
+---
+
+## TL;DR
+
+A minimal GraphAr extension for Kuzu implemented in C++ (relying on GraphAr + Arrow C++ SDKs). It parses GraphAr YAML schema and parallel-reads data into Kuzu’s internal node/edge representations so GraphAr datasets can be consumed directly via `LOAD` / `COPY` workflows.
+
+---
+
+## Context
+
+GraphAr ([https://graphar.apache.org/](https://graphar.apache.org/)) is a property-graph interchange/storage format that exposes YAML metadata and stores columnar data using Arrow / Parquet and similar formats. The extension demonstrates a pragmatic approach to supporting GraphAr in Kuzu by translating GraphAr schema/columns into Kuzu types and ingesting record batches in parallel using Arrow readers.
+
+---
+
+## What this extension implements
+
+* GraphAr YAML schema parsing (node/edge tables, property columns and types).
+* Mapping of GraphAr/Arrow column types to Kuzu primitive types.
+* Parallel chunk/record-batch readers that convert GraphAr data → Kuzu insert streams.
+* A non-invasive extension layer that translates GraphAr into Kuzu types without changing Kuzu core where possible.
+
+---
+
+## Usage examples
+
+```sql
+-- read and return rows (demo)
+LOAD FROM ".../ldbc_sample.graph.yml" (file_format="graphar", table_name="person") RETURN *;
+
+-- create a target table in Kuzu
+CREATE NODE TABLE Person(id INT64, firstName STRING, lastName STRING, gender STRING, PRIMARY KEY (id));
+
+-- copy GraphAr dataset into an existing Kuzu table
+COPY Person FROM ".../ldbc_sample.graph.yml" (file_format="graphar", table_name="person");
+```
+
+Parameters:
+
+* `file_format="graphar"`: instructs Kuzu to use this GraphAr reader extension.
+* `table_name`: must match the node/edge table name declared in the GraphAr YAML.
+
+---
+
+## Design choices
+
+* **Non-invasive architecture:** the extension lives as a translation layer to avoid touching Kuzu core.
+* **Reuse of GraphAr + Arrow SDKs:** avoids reimplementing low-level IO and schema logic.
+* **Parallel RecordBatch conversion:** increases ingestion throughput in many workloads.
+* **Scope limitation:** read-only ingestion (LOAD/COPY). Export/write path not implemented in this branch.
+
+---
+
+## Forward-looking improvements
+
+1. **Export/write path**: enable Kuzu → GraphAr export with schema & metadata generation.
+2. **Comprehensive tests & benchmarks**: unit/integration tests, stress tests, and performance baselines.
+
+---
+
+## Expected outcome
+
+* Users can `LOAD` or `COPY` GraphAr datasets into Kuzu without a manual pre-conversion step.

--- a/cpp/extensions/kuzu-extension/src/function/CMakeLists.txt
+++ b/cpp/extensions/kuzu-extension/src/function/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(kuzu_graphar_function
+        OBJECT
+        graphar_scan.cpp
+        graphar_bindfunc.cpp)
+
+set(GRAPHAR_EXTENSION_OBJECT_FILES
+        ${GRAPHAR_EXTENSION_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_graphar_function>
+        PARENT_SCOPE)

--- a/cpp/extensions/kuzu-extension/src/function/graphar_bindfunc.cpp
+++ b/cpp/extensions/kuzu-extension/src/function/graphar_bindfunc.cpp
@@ -1,0 +1,370 @@
+#include "function/graphar_scan.h"
+
+#include "common/exception/not_implemented.h"
+
+namespace kuzu {
+namespace graphar_extension {
+
+using namespace function;
+using namespace common;
+
+// Vertex setter maker for properties
+template<typename T>
+VertexColumnSetter makeTypedVertexSetter(uint64_t fieldIdx, std::string colName) {
+    return [fieldIdx, colName = std::move(colName)](graphar::VertexIter& it, function::TableFuncOutput& output, kuzu::common::idx_t row) {
+        auto res = it.property<T>(colName);
+        auto &vec = output.dataChunk.getValueVectorMutable(fieldIdx);
+        vec.setValue(row, res.value());
+    };
+}
+
+template<>
+VertexColumnSetter makeTypedVertexSetter<list_entry_t>(uint64_t fieldIdx, std::string colName) {
+    throw NotImplementedException("List type is not supported in graphar scan.");
+}
+
+// Edge setter maker for properties
+template<typename T>
+EdgeColumnSetter makeTypedEdgeSetter(uint64_t fieldIdx, std::string colName) {
+    return [fieldIdx, colName = std::move(colName)](graphar::EdgeIter& it, function::TableFuncOutput& output, kuzu::common::idx_t row, [[maybe_unused]] std::shared_ptr<graphar::VerticesCollection> unused) {
+        auto res = it.property<T>(colName);
+        auto &vec = output.dataChunk.getValueVectorMutable(fieldIdx);
+        vec.setValue(row, res.value());
+    };
+}
+
+template<>
+EdgeColumnSetter makeTypedEdgeSetter<list_entry_t>(uint64_t fieldIdx, std::string colName) {
+    throw NotImplementedException("List type is not supported in graphar scan.");
+}
+
+// Edge setter for "from" (source) and "to" (destination)
+template<typename T>
+EdgeColumnSetter makeFromSetter(uint64_t fieldIdx, std::string colName) {
+    return [fieldIdx, colName = std::move(colName)](graphar::EdgeIter& it, function::TableFuncOutput& output, kuzu::common::idx_t row, std::shared_ptr<graphar::VerticesCollection> from_vertices) {
+        graphar::IdType src = it.source();
+        auto vertex_it = from_vertices->find(src);
+        auto res = vertex_it.property<T>(colName);
+        auto &vec = output.dataChunk.getValueVectorMutable(fieldIdx);
+        vec.setValue(row, res.value());
+    };
+}
+
+template<typename T>
+EdgeColumnSetter makeToSetter(uint64_t fieldIdx, std::string colName) {
+    return [fieldIdx, colName = std::move(colName)](graphar::EdgeIter& it, function::TableFuncOutput& output, kuzu::common::idx_t row, std::shared_ptr<graphar::VerticesCollection> to_vertices) {
+        graphar::IdType dst = it.destination();
+        auto vertex_it = to_vertices->find(dst);
+        auto res = vertex_it.property<T>(colName);
+        auto &vec = output.dataChunk.getValueVectorMutable(fieldIdx);
+        vec.setValue(row, res.value());
+    };
+}
+
+static const std::unordered_map<LogicalTypeID, std::function<VertexColumnSetter(uint64_t, std::string)>> vertexSetterFactory = {
+    { LogicalTypeID::INT64,   [](uint64_t idx, std::string col){ return makeTypedVertexSetter<int64_t>(idx, std::move(col)); } },
+    { LogicalTypeID::INT32,   [](uint64_t idx, std::string col){ return makeTypedVertexSetter<int32_t>(idx, std::move(col)); } },
+    { LogicalTypeID::DOUBLE,  [](uint64_t idx, std::string col){ return makeTypedVertexSetter<double>(idx, std::move(col)); } },
+    { LogicalTypeID::FLOAT,   [](uint64_t idx, std::string col){ return makeTypedVertexSetter<float>(idx, std::move(col)); } },
+    { LogicalTypeID::STRING,  [](uint64_t idx, std::string col){ return makeTypedVertexSetter<std::string>(idx, std::move(col)); } },
+    { LogicalTypeID::BOOL,    [](uint64_t idx, std::string col){ return makeTypedVertexSetter<bool>(idx, std::move(col)); } },
+    { LogicalTypeID::DATE,    [](uint64_t idx, std::string col){ return makeTypedVertexSetter<date_t>(idx, std::move(col)); } },
+    { LogicalTypeID::TIMESTAMP, [](uint64_t idx, std::string col){ return makeTypedVertexSetter<timestamp_t>(idx, std::move(col)); } },
+    { LogicalTypeID::LIST,    [](uint64_t idx, std::string col){ return makeTypedVertexSetter<list_entry_t>(idx, std::move(col)); } },
+};
+
+static const std::unordered_map<LogicalTypeID, std::function<EdgeColumnSetter(uint64_t, std::string)>> edgeSetterFactory = {
+    { LogicalTypeID::INT64,   [](uint64_t idx, std::string col){ return makeTypedEdgeSetter<int64_t>(idx, std::move(col)); } },
+    { LogicalTypeID::INT32,   [](uint64_t idx, std::string col){ return makeTypedEdgeSetter<int32_t>(idx, std::move(col)); } },
+    { LogicalTypeID::DOUBLE,  [](uint64_t idx, std::string col){ return makeTypedEdgeSetter<double>(idx, std::move(col)); } },
+    { LogicalTypeID::FLOAT,   [](uint64_t idx, std::string col){ return makeTypedEdgeSetter<float>(idx, std::move(col)); } },
+    { LogicalTypeID::STRING,  [](uint64_t idx, std::string col){ return makeTypedEdgeSetter<std::string>(idx, std::move(col)); } },
+    { LogicalTypeID::BOOL,    [](uint64_t idx, std::string col){ return makeTypedEdgeSetter<bool>(idx, std::move(col)); } },
+    { LogicalTypeID::DATE,    [](uint64_t idx, std::string col){ return makeTypedEdgeSetter<date_t>(idx, std::move(col)); } },
+    { LogicalTypeID::TIMESTAMP, [](uint64_t idx, std::string col){ return makeTypedEdgeSetter<timestamp_t>(idx, std::move(col)); } },
+    { LogicalTypeID::LIST,    [](uint64_t idx, std::string col){ return makeTypedEdgeSetter<list_entry_t>(idx, std::move(col)); } },
+};
+
+static const std::unordered_map<LogicalTypeID, std::function<EdgeColumnSetter(uint64_t, std::string)>> fromSetterFactory = {
+    { LogicalTypeID::INT64,   [](uint64_t idx, std::string col){ return makeFromSetter<int64_t>(idx, std::move(col)); } },
+    { LogicalTypeID::INT32,   [](uint64_t idx, std::string col){ return makeFromSetter<int32_t>(idx, std::move(col)); } },
+    { LogicalTypeID::DOUBLE,  [](uint64_t idx, std::string col){ return makeFromSetter<double>(idx, std::move(col)); } },
+    { LogicalTypeID::FLOAT,   [](uint64_t idx, std::string col){ return makeFromSetter<float>(idx, std::move(col)); } },
+    { LogicalTypeID::STRING,  [](uint64_t idx, std::string col){ return makeFromSetter<std::string>(idx, std::move(col)); } },
+};
+
+static const std::unordered_map<LogicalTypeID, std::function<EdgeColumnSetter(uint64_t, std::string)>> toSetterFactory = {
+    { LogicalTypeID::INT64,   [](uint64_t idx, std::string col){ return makeToSetter<int64_t>(idx, std::move(col)); } },
+    { LogicalTypeID::INT32,   [](uint64_t idx, std::string col){ return makeToSetter<int32_t>(idx, std::move(col)); } },
+    { LogicalTypeID::DOUBLE,  [](uint64_t idx, std::string col){ return makeToSetter<double>(idx, std::move(col)); } },
+    { LogicalTypeID::FLOAT,   [](uint64_t idx, std::string col){ return makeToSetter<float>(idx, std::move(col)); } },
+    { LogicalTypeID::STRING,  [](uint64_t idx, std::string col){ return makeToSetter<std::string>(idx, std::move(col)); } },
+};
+
+static LogicalType GrapharTypeToKuzuTypeFunc(std::shared_ptr<graphar::DataType> type) {
+    graphar::Type type_id = type->id();
+    switch (type_id) {
+        case graphar::Type::BOOL:
+            return LogicalType::BOOL();
+        case graphar::Type::INT64:
+            return LogicalType::INT64();
+        case graphar::Type::INT32:
+            return LogicalType::INT32();
+        case graphar::Type::FLOAT:
+            return LogicalType::FLOAT();
+        case graphar::Type::STRING:
+            return LogicalType::STRING();
+        case graphar::Type::DOUBLE:
+            return LogicalType::DOUBLE();
+        case graphar::Type::DATE:
+            return LogicalType::DATE();
+        case graphar::Type::TIMESTAMP:
+            return LogicalType::TIMESTAMP();
+        case graphar::Type::LIST: {
+            auto value_type_id = type->value_type()->id();
+            switch (value_type_id) {
+                case graphar::Type::BOOL:
+                    return LogicalType::LIST(LogicalType::BOOL());
+                case graphar::Type::INT64:
+                    return LogicalType::LIST(LogicalType::INT64());
+                case graphar::Type::INT32:
+                    return LogicalType::LIST(LogicalType::INT32());
+                case graphar::Type::FLOAT:
+                    return LogicalType::LIST(LogicalType::FLOAT());
+                case graphar::Type::STRING:
+                    return LogicalType::LIST(LogicalType::STRING());
+                case graphar::Type::DOUBLE:
+                    return LogicalType::LIST(LogicalType::DOUBLE());
+                case graphar::Type::DATE:
+                    return LogicalType::LIST(LogicalType::DATE());
+                case graphar::Type::TIMESTAMP:
+                    return LogicalType::LIST(LogicalType::TIMESTAMP());
+                default:
+                    throw NotImplementedException{"GraphAr's List Type with value type " + std::to_string(static_cast<int>(value_type_id)) + " is not implemented."};
+            }
+        }
+        default:
+            throw NotImplementedException{"GraphAr's Type " + std::to_string(static_cast<int>(type_id)) + " is not implemented."};
+    }
+}
+
+static void autoDetectVertexSchema([[maybe_unused]] main::ClientContext* context, std::shared_ptr<graphar::GraphInfo> graph_info, std::string table_name,
+    std::vector<LogicalType>& types, std::vector<std::string>& names) {
+    auto vertex_info = graph_info->GetVertexInfo(table_name);
+    if (!vertex_info) {
+        throw BinderException("GraphAr's Type " + table_name + " does not exist as vertex.");
+    }
+
+    // Construct the types and names from the vertex info.
+    for (auto& property_group : vertex_info->GetPropertyGroups()) {
+        for (const auto& property : property_group->GetProperties()) {
+            names.push_back(property.name);
+            types.push_back(GrapharTypeToKuzuTypeFunc(property.type));
+        }
+    }
+}
+
+static bool tryParseEdgeTableName(const std::string &table_name, std::string &src, std::string &edge, std::string &dst) {
+    // Try '.' then ':' then '_'
+    std::vector<char> seps = {'.', ':', '_'};
+    for (char sep : seps) {
+        std::vector<std::string> parts;
+        size_t start = 0;
+        for (size_t i = 0; i <= table_name.size(); ++i) {
+            if (i == table_name.size() || table_name[i] == sep) {
+                parts.push_back(table_name.substr(start, i - start));
+                start = i + 1;
+            }
+        }
+        if (parts.size() == 3 && !parts[0].empty() && !parts[1].empty() && !parts[2].empty()) {
+            src = parts[0];
+            edge = parts[1];
+            dst = parts[2];
+            return true;
+        }
+    }
+    return false;
+}
+
+static void autoDetectEdgeSchema([[maybe_unused]] main::ClientContext* context, std::shared_ptr<graphar::GraphInfo> graph_info, const std::string &table_name,
+    std::vector<LogicalType>& types, std::vector<std::string>& names, std::unordered_map<std::string, std::string>& edges_from_to_mapping) {
+    std::string src_type, edge_type, dst_type;
+    if (!tryParseEdgeTableName(table_name, src_type, edge_type, dst_type)) {
+        throw BinderException("Edge table_name must be specified in `src.edge.dst` format (supported separators: '.', ':', '_'). Given: " + table_name);
+    }
+
+    // Use GraphInfo to get EdgeInfo
+    auto edge_info = graph_info->GetEdgeInfo(src_type, edge_type, dst_type);
+    if (!edge_info) {
+        throw BinderException("GraphAr's EdgeInfo does not exist for " + table_name +
+                            " (parsed as " + src_type + "." + edge_type + "." + dst_type + ").");
+    }
+
+    auto from_vertex_info = graph_info->GetVertexInfo(src_type);
+    auto to_vertex_info = graph_info->GetVertexInfo(dst_type);
+    if (!from_vertex_info) {
+        throw BinderException("GraphAr's VertexInfo does not exist for edge source type " + src_type + ".");
+    }
+    if (!to_vertex_info) {
+        throw BinderException("GraphAr's VertexInfo does not exist for edge destination type " + dst_type + ".");
+    }
+
+    // Prepend from/to columns
+    names.push_back("from");
+    // Find from column mapping name in the from_vertex_info's primary keys
+    for (const auto& propertyGroup : from_vertex_info->GetPropertyGroups()) {
+        for (const auto& property : propertyGroup->GetProperties()) {
+            if (property.is_primary) {
+                edges_from_to_mapping.insert({"from", property.name});
+                break;
+            }
+        }
+    }
+    types.push_back(LogicalType::INT64());
+
+    names.push_back("to");
+    // Find to column mapping name in the to_vertex_info's primary keys
+    for (const auto& propertyGroup : to_vertex_info->GetPropertyGroups()) {
+        for (const auto& property : propertyGroup->GetProperties()) {
+            if (property.is_primary) {
+                edges_from_to_mapping.insert({"to", property.name});
+                break;
+            }
+        }
+    }
+    types.push_back(LogicalType::INT64());
+
+    // Add the edge properties except from/to
+    for (auto& property_group : edge_info->GetPropertyGroups()) {
+        for (const auto& property : property_group->GetProperties()) {
+            names.push_back(property.name);
+            types.push_back(GrapharTypeToKuzuTypeFunc(property.type));
+        }
+    }
+}
+
+GrapharScanBindData::GrapharScanBindData(binder::expression_vector columns, common::FileScanInfo fileScanInfo, main::ClientContext* context,
+    std::shared_ptr<graphar::GraphInfo> graph_info, std::string table_name, std::vector<std::string> column_names, std::vector<kuzu::common::LogicalType> column_types, bool is_edge)
+    : ScanFileBindData{std::move(columns), 0 /* numRows */, std::move(fileScanInfo), context},
+        graph_info{std::move(graph_info)}, column_info{std::make_shared<KuzuColumnInfo>(column_names)},
+        table_name{std::move(table_name)}, column_names{std::move(column_names)}, column_types{std::move(column_types)}, is_edge(is_edge) {
+            if (!is_edge) {
+                this->vertex_column_setters.reserve(this->column_names.size());
+                for (size_t i = 0; i < this->column_names.size(); ++i) {
+                    auto typeID = this->column_types[i].getLogicalTypeID();
+                    uint64_t fieldIdx = getFieldIdx(this->column_names[i]);
+                    KU_ASSERT(fieldIdx != UINT64_MAX);
+                    auto it = vertexSetterFactory.find(typeID);
+                    if (it == vertexSetterFactory.end()) {
+                        throw NotImplementedException{"Unsupported column type in GrapharScan bind (vertex): " + std::to_string((int)typeID)};
+                    }
+                    this->vertex_column_setters.push_back(it->second(fieldIdx, this->column_names[i]));
+                }
+            } else {
+                this->edge_column_setters.reserve(this->column_names.size());
+                for (size_t i = 0; i < this->column_names.size(); ++i) {
+                    uint64_t fieldIdx = getFieldIdx(this->column_names[i]);
+                    KU_ASSERT(fieldIdx != UINT64_MAX);
+                    // special-case from/to
+                    if (StringUtils::caseInsensitiveEquals(this->column_names[i], "from")) {
+                        LogicalTypeID typeID = this->column_types[i].getLogicalTypeID();
+                        auto it = fromSetterFactory.find(typeID);
+                        if (it == fromSetterFactory.end()) {
+                            throw NotImplementedException{"Unsupported column type in GrapharScan bind (from edge): " + std::to_string((int)typeID)};
+                        }
+                        this->edge_column_setters.push_back(it->second(fieldIdx, "id"));
+                        continue;
+                    } else if (StringUtils::caseInsensitiveEquals(this->column_names[i], "to")) {
+                        LogicalTypeID typeID = this->column_types[i].getLogicalTypeID();
+                        auto it = toSetterFactory.find(typeID);
+                        if (it == toSetterFactory.end()) {
+                            throw NotImplementedException{"Unsupported column type in GrapharScan bind (to edge): " + std::to_string((int)typeID)};
+                        }
+                        this->edge_column_setters.push_back(it->second(fieldIdx, "id"));
+                        continue;
+                    }
+                    LogicalTypeID typeID = this->column_types[i].getLogicalTypeID();
+                    auto it = edgeSetterFactory.find(typeID);
+                    if (it == edgeSetterFactory.end()) {
+                        throw NotImplementedException{"Unsupported column type in GrapharScan bind (edge): " + std::to_string((int)typeID)};
+                    }
+                    this->edge_column_setters.push_back(it->second(fieldIdx, this->column_names[i]));
+                }
+            }
+            this->max_threads = context->getMaxNumThreadForExec();
+        }
+
+KuzuColumnInfo::KuzuColumnInfo(std::vector<std::string> column_names) {
+    this->colNames = std::move(column_names);
+    idx_t colIdx = 0;
+    for (auto& colName : this->colNames) {
+        colNameToIdx.insert({colName, colIdx++});
+    }
+}
+
+uint64_t KuzuColumnInfo::getFieldIdx(std::string fieldName) const {
+    // For a small number of keys, probing a vector is faster than lookups in an unordered_map.
+    if (colNames.size() < 24) {
+        auto iter = std::find(colNames.begin(), colNames.end(), fieldName);
+        if (iter != colNames.end()) {
+            return iter - colNames.begin();
+        }
+    } else {
+        auto itr = colNameToIdx.find(fieldName);
+        if (itr != colNameToIdx.end()) {
+            return itr->second;
+        }
+    }
+    // From and to are case-insensitive for backward compatibility.
+    if (StringUtils::caseInsensitiveEquals(fieldName, "from")) {
+        return colNameToIdx.at("from");
+    } else if (StringUtils::caseInsensitiveEquals(fieldName, "to")) {
+        return colNameToIdx.at("to");
+    }
+    return UINT64_MAX;
+}
+
+std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
+    const TableFuncBindInput* input) {
+    auto scanInput = ku_dynamic_cast<ExtraScanTableFuncBindInput*>(input->extraInput.get());
+    std::string absolute_path = scanInput->fileScanInfo.getFilePath(0);
+    if (absolute_path.empty()) {
+        throw BinderException("GraphAr scan requires a valid file path.");
+    }
+    std::string table_name = scanInput->fileScanInfo.options.at("table_name").strVal;
+
+    // Load graph info from the file path
+    auto graph_info = graphar::GraphInfo::Load(absolute_path).value();
+    if (!graph_info) {
+        throw BinderException("GraphAr's GraphInfo could not be loaded from " + absolute_path);
+    }
+
+    std::vector<LogicalType> column_types;
+    std::vector<std::string> column_names;
+    std::unordered_map<std::string, std::string> edges_from_to_mapping;
+    bool is_edge = false;
+
+    // Try vertex first
+    try {
+        autoDetectVertexSchema(context, graph_info, table_name, column_types, column_names);
+        is_edge = false;
+    } catch (BinderException&) {
+        // not a vertex, try edge
+        column_types.clear();
+        column_names.clear();
+        edges_from_to_mapping.clear();
+        autoDetectEdgeSchema(context, graph_info, table_name, column_types, column_names, edges_from_to_mapping);
+        is_edge = true;
+    }
+
+    KU_ASSERT(column_types.size() == column_names.size());
+    
+    column_names =
+        TableFunction::extractYieldVariables(column_names, input->yieldVariables);
+    auto columns = input->binder->createVariables(column_names, column_types);
+    return std::make_unique<GrapharScanBindData>(std::move(columns), scanInput->fileScanInfo.copy(), context,
+        std::move(graph_info), std::move(table_name), std::move(column_names), std::move(column_types), is_edge);
+}
+
+} // namespace graphar_extension
+} // namespace kuzu

--- a/cpp/extensions/kuzu-extension/src/function/graphar_scan.cpp
+++ b/cpp/extensions/kuzu-extension/src/function/graphar_scan.cpp
@@ -1,0 +1,180 @@
+#include "function/graphar_scan.h"
+
+#include <iostream>
+
+namespace kuzu {
+namespace graphar_extension {
+
+using namespace function;
+using namespace common;
+
+GrapharScanSharedState::GrapharScanSharedState(
+    graphar::Result<std::shared_ptr<graphar::VerticesCollection>> maybeVerticesCollection,
+    graphar::Result<std::shared_ptr<graphar::EdgesCollection>> maybeEdgesCollection,
+    graphar::Result<std::shared_ptr<graphar::VerticesCollection>> maybeFromVerticesCollection,
+    graphar::Result<std::shared_ptr<graphar::VerticesCollection>> maybeToVerticesCollection,
+    uint64_t max_threads, bool is_edge)
+    : maybe_vertices_collection{std::move(maybeVerticesCollection)},
+      maybe_edges_collection{std::move(maybeEdgesCollection)},
+      maybe_from_vertices_collection{std::move(maybeFromVerticesCollection)},
+      maybe_to_vertices_collection{std::move(maybeToVerticesCollection)} {
+        if (!is_edge) {
+            collection_count = maybe_vertices_collection.value()->size();
+        } else {
+            collection_count = maybe_edges_collection.value()->size();
+        }
+        KU_ASSERT(collection_count != 0);
+        batch_size = max_threads % collection_count == 0 ?
+            std::max<size_t>(1, collection_count / max_threads) : std::max<size_t>(1, collection_count / max_threads + 1);
+        batch_size = batch_size > DEFAULT_VECTOR_CAPACITY ? DEFAULT_VECTOR_CAPACITY : batch_size;
+        next_index.store(0);
+
+        // If it is edge, pre-compute the starting point of each batch's EdgeIter in the init stage.
+        if (is_edge && maybe_edges_collection.has_value()) {
+            auto edges = maybe_edges_collection.value();
+            size_t num_batches = (collection_count + batch_size - 1) / batch_size;
+            edge_batch_iters.reserve(num_batches);
+
+            // Single sequential scan: Walk from begin() to end(), and push_back a copy at the first index of each batch.
+            auto iter = edges->begin();
+            for (size_t idx = 0; idx < collection_count; ++idx) {
+                if (idx % batch_size == 0) {
+                    edge_batch_iters.emplace_back(iter); // copy constructor
+                }
+                ++iter;
+            }
+        }
+}
+
+std::unique_ptr<TableFuncSharedState> initGrapharScanSharedState(
+    const TableFuncInitSharedStateInput& input) {
+    auto grapharScanBindData = input.bindData->constPtrCast<GrapharScanBindData>();
+    graphar::Result<std::shared_ptr<graphar::VerticesCollection>> maybe_vertices_collection = {};
+    graphar::Result<std::shared_ptr<graphar::EdgesCollection>> maybe_edges_collection = {};
+    graphar::Result<std::shared_ptr<graphar::VerticesCollection>> maybe_from_vertices_collection = {};
+    graphar::Result<std::shared_ptr<graphar::VerticesCollection>> maybe_to_vertices_collection = {};
+
+    if (!grapharScanBindData->is_edge) {
+        maybe_vertices_collection = graphar::VerticesCollection::Make(grapharScanBindData->graph_info, grapharScanBindData->table_name);
+    } else {
+        // parse table_name into src.edge.dst
+        std::string src, edge, dst;
+        auto tryParse = [&](const std::string &tn) {
+            std::vector<char> seps = {'.', ':', '_'};
+            for (char sep : seps) {
+                std::vector<std::string> parts;
+                size_t start = 0;
+                for (size_t i = 0; i <= tn.size(); ++i) {
+                    if (i == tn.size() || tn[i] == sep) {
+                        parts.push_back(tn.substr(start, i - start));
+                        start = i + 1;
+                    }
+                }
+                if (parts.size() == 3) {
+                    src = parts[0]; edge = parts[1]; dst = parts[2];
+                    return true;
+                }
+            }
+            return false;
+        };
+        if (tryParse(grapharScanBindData->table_name)) {
+            maybe_edges_collection = graphar::EdgesCollection::Make(grapharScanBindData->graph_info, src, edge, dst, graphar::AdjListType::ordered_by_source);
+            maybe_from_vertices_collection = graphar::VerticesCollection::Make(grapharScanBindData->graph_info, src);
+            maybe_to_vertices_collection = graphar::VerticesCollection::Make(grapharScanBindData->graph_info, dst);
+        }
+    }
+    return std::make_unique<graphar_extension::GrapharScanSharedState>(std::move(maybe_vertices_collection), std::move(maybe_edges_collection), 
+                                                                       std::move(maybe_from_vertices_collection), std::move(maybe_to_vertices_collection),
+                                                                       grapharScanBindData->max_threads, grapharScanBindData->is_edge);
+}
+
+offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) {
+    auto grapharSharedState = input.sharedState->ptrCast<graphar_extension::GrapharScanSharedState>();
+    auto grapharScanBindData = input.bindData->constPtrCast<graphar_extension::GrapharScanBindData>();
+
+    if (!grapharScanBindData->is_edge) {
+        auto& column_setters = grapharScanBindData->vertex_column_setters;
+        auto vertices = grapharSharedState->maybe_vertices_collection.value();
+        size_t vertices_count = grapharSharedState->collection_count;
+        size_t batch_size = grapharSharedState->batch_size;
+
+        // Reserve a batch of indices atomically
+        size_t start = grapharSharedState->next_index.fetch_add(batch_size, std::memory_order_relaxed);
+        if (start >= vertices_count) {
+            // no more rows
+            output.dataChunk.state->getSelVectorUnsafe().setSelSize(0);
+            return 0;
+        }
+        size_t end = std::min(start + batch_size, vertices_count);
+
+        idx_t count = 0;
+        // create a local iterator for this index (each worker/thread has its own local iterator)
+        auto it = vertices->begin() + start;
+        for (size_t idx = start; idx < end; ++idx) {
+            // Complete all column writes using the setter generated in the bind stage (without switch)
+            for (size_t ci = 0; ci < column_setters.size(); ++ci) {
+                column_setters[ci](it, output, count);
+            }
+            ++it;
+            count++;
+        }
+        
+        output.dataChunk.state->getSelVectorUnsafe().setSelSize(count);
+        return output.dataChunk.state->getSelVector().getSelSize();
+    } else {
+        auto& column_names = grapharScanBindData->column_names;
+        auto& column_setters = grapharScanBindData->edge_column_setters;
+        auto edges = grapharSharedState->maybe_edges_collection.value();
+        size_t edges_count = grapharSharedState->collection_count;
+        size_t batch_size = grapharSharedState->batch_size;
+
+        // Reserve a batch of indices atomically
+        size_t start = grapharSharedState->next_index.fetch_add(batch_size, std::memory_order_relaxed);
+        if (start >= edges_count) {
+            // no more rows
+            output.dataChunk.state->getSelVectorUnsafe().setSelSize(0);
+            return 0;
+        }
+        size_t end = std::min(start + batch_size, edges_count);
+
+        // Use the pre-computed batch start iter in SharedState to avoid advancing from the beginning each time.
+        size_t batch_id = start / batch_size;
+        KU_ASSERT(batch_id < grapharSharedState->edge_batch_iters.size());
+
+        idx_t count = 0; 
+        auto from_vertices = grapharSharedState->maybe_from_vertices_collection.value();
+        auto to_vertices = grapharSharedState->maybe_to_vertices_collection.value();
+
+        auto it = grapharSharedState->edge_batch_iters[batch_id];
+        for (size_t idx = start; idx < end; ++idx) {
+            for (size_t ci = 0; ci < column_setters.size(); ++ci) {
+                if (column_names[ci] == "from") {
+                    column_setters[ci](it, output, count, from_vertices); // from setter
+                } else if (column_names[ci] == "to") {
+                    column_setters[ci](it, output, count, to_vertices); // to setter
+                } else {
+                    column_setters[ci](it, output, count, nullptr); // other setter
+                }
+            }
+            ++it;
+            count++;
+        }
+
+        output.dataChunk.state->getSelVectorUnsafe().setSelSize(count);
+        return output.dataChunk.state->getSelVector().getSelSize();
+    }
+}
+
+function_set GrapharScanFunction::getFunctionSet() {
+    function_set functionSet;
+    auto function = std::make_unique<TableFunction>(name, std::vector{LogicalTypeID::STRING});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initGrapharScanSharedState;
+    function->initLocalStateFunc = TableFunction::initEmptyLocalState;
+    functionSet.push_back(std::move(function));
+    return functionSet;
+}
+
+} // namespace graphar_extension
+} // namespace kuzu

--- a/cpp/extensions/kuzu-extension/src/include/function/graphar_scan.h
+++ b/cpp/extensions/kuzu-extension/src/include/function/graphar_scan.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <functional>
+#include <atomic> 
+
+#include "main/client_context.h"
+#include "binder/binder.h"
+#include "common/types/types.h"
+#include "common/case_insensitive_map.h"
+#include "common/copy_constructors.h"
+#include "common/exception/binder.h"
+#include "common/exception/runtime.h"
+#include "common/string_utils.h"
+#include "function/table/bind_data.h"
+#include "function/table/bind_input.h"
+#include "function/table/table_function.h"
+#include "function/table/scan_file_function.h"
+
+// #include "arrow/api.h"
+// #include "arrow/filesystem/api.h"
+
+#include "graphar/api/high_level_reader.h"
+
+namespace kuzu {
+namespace graphar_extension {
+
+struct GrapharScanFunction {
+    static constexpr const char* name = "GRAPHAR_SCAN";
+
+    static function::function_set getFunctionSet();
+};
+
+// Setter for vertex iterator
+using VertexColumnSetter = std::function<void(graphar::VertexIter&, function::TableFuncOutput&, kuzu::common::idx_t)>;
+
+// Setter for edge iterator
+using EdgeColumnSetter = std::function<void(graphar::EdgeIter&, function::TableFuncOutput&, kuzu::common::idx_t, 
+                         std::shared_ptr<graphar::VerticesCollection>)>;
+
+using column_name_idx_map_t = std::unordered_map<std::string, uint64_t>;
+
+class KuzuColumnInfo {
+public:
+    explicit KuzuColumnInfo(std::vector<std::string> columnNames);
+    DELETE_COPY_DEFAULT_MOVE(KuzuColumnInfo);
+
+    uint64_t getFieldIdx(std::string fieldName) const;
+
+private:
+    column_name_idx_map_t colNameToIdx;
+    std::vector<std::string> colNames;
+};
+
+struct GrapharScanBindData final : function::ScanFileBindData {
+    std::shared_ptr<graphar::GraphInfo> graph_info;
+    std::shared_ptr<KuzuColumnInfo> column_info;
+    std::string table_name;
+    std::vector<std::string> column_names;
+    std::vector<kuzu::common::LogicalType> column_types;
+    std::vector<VertexColumnSetter> vertex_column_setters;
+    std::vector<EdgeColumnSetter> edge_column_setters;
+    bool is_edge = false;
+    uint64_t max_threads;
+    std::unordered_map<std::string, std::string> edges_from_to_mapping;
+    
+    uint64_t getFieldIdx(std::string fieldName) const { return column_info->getFieldIdx(fieldName); }
+
+    GrapharScanBindData(binder::expression_vector columns, common::FileScanInfo fileScanInfo, main::ClientContext* context,
+        std::shared_ptr<graphar::GraphInfo> graph_info, std::string table_name, std::vector<std::string> column_names,
+        std::vector<kuzu::common::LogicalType> column_types, bool is_edge);
+
+    GrapharScanBindData(const GrapharScanBindData& other) 
+        : ScanFileBindData(other),
+          graph_info(other.graph_info),
+          column_info(other.column_info),
+          table_name(other.table_name), 
+          column_names(other.column_names),
+          column_types(copyVector(other.column_types)),
+          vertex_column_setters(other.vertex_column_setters),
+          edge_column_setters(other.edge_column_setters),
+          is_edge(other.is_edge),
+          max_threads(other.max_threads) {}
+
+    std::unique_ptr<TableFuncBindData> copy() const override {
+        return std::make_unique<GrapharScanBindData>(*this);
+    }
+};
+
+struct GrapharScanSharedState : public function::TableFuncSharedState {
+    graphar::Result<std::shared_ptr<graphar::VerticesCollection>> maybe_vertices_collection;
+    graphar::Result<std::shared_ptr<graphar::EdgesCollection>> maybe_edges_collection;
+    graphar::Result<std::shared_ptr<graphar::VerticesCollection>> maybe_from_vertices_collection;
+    graphar::Result<std::shared_ptr<graphar::VerticesCollection>> maybe_to_vertices_collection;
+    std::atomic<size_t> next_index{0};
+    size_t collection_count;
+    size_t batch_size;
+    std::vector<graphar::EdgeIter> edge_batch_iters; // if is_edge, store batch start iterators
+
+    GrapharScanSharedState(graphar::Result<std::shared_ptr<graphar::VerticesCollection>> maybeVerticesCollection,
+        graphar::Result<std::shared_ptr<graphar::EdgesCollection>> maybeEdgesCollection,
+        graphar::Result<std::shared_ptr<graphar::VerticesCollection>> maybe_from_vertices_collection,
+        graphar::Result<std::shared_ptr<graphar::VerticesCollection>> maybe_to_vertices_collection,
+        uint64_t max_threads, bool is_edge);
+};
+
+// Functions and structs exposed for use
+std::unique_ptr<function::TableFuncSharedState> initGrapharScanSharedState(
+    const function::TableFuncInitSharedStateInput& input);
+
+std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext* context,
+    const function::TableFuncBindInput* input);
+
+common::offset_t tableFunc(const function::TableFuncInput& input,
+    function::TableFuncOutput& output);
+
+} // namespace graphar_extension
+} // namespace kuzu

--- a/cpp/extensions/kuzu-extension/src/include/main/graphar_extension.h
+++ b/cpp/extensions/kuzu-extension/src/include/main/graphar_extension.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "extension/extension.h"
+
+namespace kuzu {
+namespace graphar_extension {
+
+class GrapharExtension final : public extension::Extension {
+public:
+    static constexpr char EXTENSION_NAME[] = "GRAPHAR";
+
+public:
+    static void load(main::ClientContext* context);
+};
+
+} // namespace graphar_extension
+} // namespace kuzu

--- a/cpp/extensions/kuzu-extension/src/main/CMakeLists.txt
+++ b/cpp/extensions/kuzu-extension/src/main/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(kuzu_graphar_main
+        OBJECT
+        graphar_extension.cpp)
+
+set(GRAPHAR_EXTENSION_OBJECT_FILES
+        ${GRAPHAR_EXTENSION_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_graphar_main>
+        PARENT_SCOPE)

--- a/cpp/extensions/kuzu-extension/src/main/graphar_extension.cpp
+++ b/cpp/extensions/kuzu-extension/src/main/graphar_extension.cpp
@@ -1,0 +1,35 @@
+#include "main/graphar_extension.h"
+
+#include "function/graphar_scan.h"
+#include "main/client_context.h"
+#include "main/database.h"
+
+namespace kuzu {
+namespace graphar_extension {
+
+void GrapharExtension::load(main::ClientContext* context) {
+    auto& db = *context->getDatabase();
+    extension::ExtensionUtils::addTableFunc<GrapharScanFunction>(db);
+}
+
+} // namespace graphar_extension
+} // namespace kuzu
+
+#if defined(BUILD_DYNAMIC_LOAD)
+extern "C" {
+// Because we link against the static library on windows, we implicitly inherit KUZU_STATIC_DEFINE,
+// which cancels out any exporting, so we can't use KUZU_API.
+#if defined(_WIN32)
+#define INIT_EXPORT __declspec(dllexport)
+#else
+#define INIT_EXPORT __attribute__((visibility("default")))
+#endif
+INIT_EXPORT void init(kuzu::main::ClientContext* context) {
+    kuzu::graphar_extension::GrapharExtension::load(context);
+}
+
+INIT_EXPORT const char* name() {
+    return kuzu::graphar_extension::GrapharExtension::EXTENSION_NAME;
+}
+}
+#endif

--- a/cpp/extensions/kuzu-extension/test/README.md
+++ b/cpp/extensions/kuzu-extension/test/README.md
@@ -1,0 +1,11 @@
+## Test cases/examples
+
+```shell
+# test for copy clause
+g++ graphar_extension_copy_test.cpp -std=c++20 -ggdb -lkuzu -lpthread -o graphar_extension_copy_test
+./graphar_extension_copy_test
+
+# test for load clause
+g++ graphar_extension_load_test.cpp -std=c++20 -ggdb -lkuzu -lpthread -o graphar_extension_load_test
+./graphar_extension_load_test
+```

--- a/cpp/extensions/kuzu-extension/test/graphar_extension_copy_test.cpp
+++ b/cpp/extensions/kuzu-extension/test/graphar_extension_copy_test.cpp
@@ -1,0 +1,120 @@
+#include <iostream>
+#include <filesystem>
+#include "kuzu.hpp"
+
+using namespace kuzu::main;
+using namespace std;
+
+int main()
+{
+    // Create an empty on-disk database and connect to it
+    SystemConfig systemConfig(
+        /*bufferPoolSize=*/-1u,
+        /*maxNumThreads=*/16,
+        /*enableCompression=*/true,
+        /*readOnly=*/false);
+    auto database = make_unique<Database>("test", systemConfig);
+
+    // Connect to the database.
+    auto connection = make_unique<Connection>(database.get());
+
+    // auto loadResult = connection->query("LOAD graphar;");
+    auto loadResult = connection->query("LOAD EXTENSION \"/home/gary/.kuzu/extension/0.10.0/linux_amd64/graphar/libgraphar.kuzu_extension\";");
+    if (!loadResult->isSuccess())
+    {
+        std::cerr << loadResult->getErrorMessage() << std::endl;
+        std::filesystem::remove_all("test");
+        return -1;
+    }
+
+    // Create the schema.
+    auto createTableResult = connection->query("CREATE NODE TABLE Person(id INT64, firstName STRING, lastName STRING, gender STRING, PRIMARY KEY (id))");
+    if (!createTableResult->isSuccess())
+    {
+        std::cerr << createTableResult->getErrorMessage() << std::endl;
+        std::filesystem::remove_all("test");
+        return -1;
+    }
+
+    // Copy explain
+    // auto copyExplainResult = connection->query("EXPLAIN COPY Person FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample_timestamp/parquet/ldbc_sample_timestamp.graph.yml\" (file_format=\"graphar\", table_name=\"person\")");
+    auto copyExplainResult = connection->query("EXPLAIN COPY Person FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample/parquet/ldbc_sample.graph.yml\" (file_format=\"graphar\", table_name=\"person\")");
+    // auto copyExplainResult = connection->query("EXPLAIN COPY Person FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample/json/LdbcSample.graph.yml\" (file_format=\"graphar\", table_name=\"Person\")");
+    if (!copyExplainResult->isSuccess())
+    {
+        std::cerr << copyExplainResult->getErrorMessage() << std::endl;
+        std::filesystem::remove_all("test");
+        return -1;
+    }
+
+    while (copyExplainResult->hasNext())
+    {
+        auto row = copyExplainResult->getNext();
+        std::cout << row->getValue(0)->getValue<string>() << std::endl;
+    }
+
+    // Load data.
+    auto copyResult = connection->query("COPY Person FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample/parquet/ldbc_sample.graph.yml\" (file_format=\"graphar\", table_name=\"person\")");
+    // auto copyResult = connection->query("COPY Person FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample_timestamp/parquet/ldbc_sample_timestamp.graph.yml\" (file_format=\"graphar\", table_name=\"person\")");
+    // auto copyResult = connection->query("COPY Person FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample/json/LdbcSample.graph.yml\" (file_format=\"graphar\", table_name=\"Person\")");
+    if (!copyResult->isSuccess())
+    {
+        std::cerr << copyResult->getErrorMessage() << std::endl;
+        std::filesystem::remove_all("test");
+        return -1;
+    }
+
+    // Execute a simple query.
+    auto result =
+        connection->query("MATCH (p:Person) RETURN p.id, p.firstName, p.lastName, p.gender;");
+
+    // Output query result.
+    while (result->hasNext())
+    {
+        auto row = result->getNext();
+        std::cout << row->getValue(0)->getValue<int64_t>() << " "
+                  << row->getValue(1)->getValue<string>() << " "
+                  << row->getValue(2)->getValue<string>() << " "
+                  << row->getValue(3)->getValue<string>() << std::endl;
+    }
+
+    /* EDGE */
+    // connection->query("CREATE REL TABLE KNOWS(FROM Person TO Person, creationDate STRING)");
+    connection->query("CREATE REL TABLE KNOWS(FROM Person TO Person, creationDate TIMESTAMP)");
+
+    // Copy edge explain
+    auto copyEdgeExplainResult = connection->query("EXPLAIN COPY KNOWS FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample_timestamp/parquet/ldbc_sample_timestamp.graph.yml\" (file_format=\"graphar\", table_name=\"person_knows_person\")");
+    // auto copyEdgeExplainResult = connection->query("EXPLAIN COPY KNOWS FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample/parquet/ldbc_sample.graph.yml\" (file_format=\"graphar\", table_name=\"person_knows_person\")");
+    // auto copyEdgeExplainResult = connection->query("EXPLAIN COPY KNOWS FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample/json/LdbcSample.graph.yml\" (file_format=\"graphar\", table_name=\"Person_Knows_Person\")");
+    if (!copyEdgeExplainResult->isSuccess())
+    {
+        std::cerr << copyEdgeExplainResult->getErrorMessage() << std::endl;
+        std::filesystem::remove_all("test");
+        return -1;
+    }
+
+    auto copyEdgeResult = connection->query("COPY KNOWS FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample_timestamp/parquet/ldbc_sample_timestamp.graph.yml\" (file_format=\"graphar\", table_name=\"person_knows_person\")");
+    // auto copyEdgeResult = connection->query("COPY KNOWS FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample/parquet/ldbc_sample.graph.yml\" (file_format=\"graphar\", table_name=\"person_knows_person\")");
+    // auto copyEdgeResult = connection->query("COPY KNOWS FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample/json/LdbcSample.graph.yml\" (file_format=\"graphar\", table_name=\"Person_Knows_Person\")");
+    if (!copyEdgeResult->isSuccess())
+    {
+        std::cerr << copyEdgeResult->getErrorMessage() << std::endl;
+        std::filesystem::remove_all("test");
+        return -1;
+    }
+
+    auto edgeResult =
+        connection->query("MATCH (a:Person)-[k:KNOWS]->(b:Person) RETURN a.id, k.creationDate, b.id;");
+    while (edgeResult->hasNext())
+    {
+        auto row = edgeResult->getNext();
+        std::cout << row->getValue(0)->getValue<int64_t>() << " "
+                //   << row->getValue(1)->getValue<string>() << " "
+                  << row->getValue(1)->getValue<int64_t>() << " "
+                  << row->getValue(2)->getValue<int64_t>() << std::endl;
+    }
+
+    std::filesystem::remove_all("test");
+
+    return 0;
+}

--- a/cpp/extensions/kuzu-extension/test/graphar_extension_load_test.cpp
+++ b/cpp/extensions/kuzu-extension/test/graphar_extension_load_test.cpp
@@ -1,0 +1,67 @@
+#include <iostream>
+#include <filesystem>
+#include "kuzu.hpp"
+
+using namespace kuzu::main;
+using namespace std;
+
+int main()
+{
+    // Create an empty on-disk database and connect to it
+    SystemConfig systemConfig(
+        /*bufferPoolSize=*/-1u,
+        /*maxNumThreads=*/16,
+        /*enableCompression=*/true,
+        /*readOnly=*/false);
+    auto database = make_unique<Database>("test", systemConfig);
+
+    // Connect to the database.
+    auto connection = make_unique<Connection>(database.get());
+
+    // auto loadResult = connection->query("LOAD graphar;");
+    auto result = connection->query("LOAD EXTENSION \"/home/gary/.kuzu/extension/0.10.0/linux_amd64/graphar/libgraphar.kuzu_extension\";");
+    if (!result->isSuccess())
+    {
+        std::cerr << result->getErrorMessage() << std::endl;
+        std::filesystem::remove_all("test");
+        return -1;
+    }
+
+    // Load explain
+    auto loadExplainResult = connection->query("EXPLAIN LOAD FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample/parquet/ldbc_sample.graph.yml\" (file_format=\"graphar\", table_name=\"person\") RETURN *");
+    // auto copyExplainResult = connection->query("EXPLAIN COPY Person FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample/json/LdbcSample.graph.yml\" (file_format=\"graphar\", table_name=\"Person\")");
+    if (!loadExplainResult->isSuccess())
+    {
+        std::cerr << loadExplainResult->getErrorMessage() << std::endl;
+        std::filesystem::remove_all("test");
+        return -1;
+    }
+
+    while (loadExplainResult->hasNext())
+    {
+        auto row = loadExplainResult->getNext();
+        std::cout << row->getValue(0)->getValue<string>() << std::endl;
+    }
+
+    // Load data.
+    auto loadResult = connection->query("LOAD FROM \"/home/gary/incubator-graphar/cpp/build-debug/testing/ldbc_sample/parquet/ldbc_sample.graph.yml\" (file_format=\"graphar\", table_name=\"person\") RETURN *");
+    if (!loadResult->isSuccess())
+    {
+        std::cerr << loadResult->getErrorMessage() << std::endl;
+        std::filesystem::remove_all("test");
+        return -1;
+    }
+
+    while (loadResult->hasNext())
+    {
+        auto row = loadResult->getNext();
+        std::cout << row->getValue(0)->getValue<int64_t>() << " "
+                  << row->getValue(1)->getValue<string>() << " "
+                  << row->getValue(2)->getValue<string>() << " "
+                  << row->getValue(3)->getValue<string>() << std::endl;
+    }
+
+    std::filesystem::remove_all("test");
+
+    return 0;
+}


### PR DESCRIPTION
### Reason for this PR

Provide a minimal GraphAr reader extension for Kuzu to enable direct `LOAD`/`COPY` of GraphAr datasets (tracks: GraphAr #679 ). Branch: `https://github.com/gary-cloud/kuzu/tree/graphar-extension`.

### What changes are included in this PR?

* Extension layer parsing GraphAr YAML and mapping GraphAr columns → Kuzu types via Arrow/GraphAr C++ SDKs.
* Parallel Arrow `RecordBatch` readers converting batches into Kuzu node/edge insert streams.
* `file_format="graphar"` support for `LOAD`/`COPY`.
* Demo + minimal example ingesting an LDBC GraphAr sample.

### Are these changes tested?

Yes

### Are there any user-facing changes?

* Additive: users can `LOAD`/`COPY` GraphAr files using `file_format="graphar"` and `table_name`.
* No changes to Kuzu core public APIs.
