### PR TITLE
chore(c++): reduce copies in graph_reader.h and remove unnecessary `std::move`

### DIFF
--- a/cpp/src/graphar/high-level/graph_reader.cc
+++ b/cpp/src/graphar/high-level/graph_reader.cc
@@ -150,7 +150,7 @@ static inline bool IsValid(bool* state, int column_number) {
 }
 
 Result<std::vector<IdType>> VerticesCollection::filter(
-    std::vector<std::string> filter_labels,
+    const std::vector<std::string>& filter_labels,
     std::vector<IdType>* new_valid_chunk) {
   std::vector<int> indices;
   const int TOT_ROWS_NUM = vertex_num_;
@@ -214,7 +214,7 @@ Result<std::vector<IdType>> VerticesCollection::filter(
 }
 
 Result<std::vector<IdType>> VerticesCollection::filter_by_acero(
-    std::vector<std::string> filter_labels) const {
+    const std::vector<std::string>& filter_labels) const {
   std::vector<int> indices;
   const int TOT_ROWS_NUM = vertex_num_;
   const int CHUNK_SIZE = vertex_info_->GetChunkSize();
@@ -265,7 +265,8 @@ Result<std::vector<IdType>> VerticesCollection::filter_by_acero(
 }
 
 Result<std::vector<IdType>> VerticesCollection::filter(
-    std::string property_name, std::shared_ptr<Expression> filter_expression,
+    const std::string& property_name,
+    std::shared_ptr<Expression> filter_expression,
     std::vector<IdType>* new_valid_chunk) {
   std::vector<int> indices;
   const int TOT_ROWS_NUM = vertex_num_;

--- a/cpp/src/graphar/high-level/graph_reader.h
+++ b/cpp/src/graphar/high-level/graph_reader.h
@@ -330,12 +330,12 @@ class VerticesCollection {
   explicit VerticesCollection(const std::shared_ptr<VertexInfo>& vertex_info,
                               const std::string& prefix,
                               const bool is_filtered = false,
-                              const std::vector<IdType> filtered_ids = {})
-      : vertex_info_(std::move(vertex_info)),
+                              std::vector<IdType> filtered_ids = {})
+      : vertex_info_(vertex_info),
         prefix_(prefix),
         labels_(vertex_info->GetLabels()),
         is_filtered_(is_filtered),
-        filtered_ids_(filtered_ids) {
+        filtered_ids_(std::move(filtered_ids)) {
     // get the vertex num
     std::string base_dir;
     GAR_ASSIGN_OR_RAISE_ERROR(auto fs,
@@ -377,14 +377,15 @@ class VerticesCollection {
 
   /** The vertex id list that satisfies the label filter condition. */
   Result<std::vector<IdType>> filter(
-      std::vector<std::string> filter_labels,
+      const std::vector<std::string>& filter_labels,
       std::vector<IdType>* new_valid_chunk = nullptr);
 
   Result<std::vector<IdType>> filter_by_acero(
-      std::vector<std::string> filter_labels) const;
+      const std::vector<std::string>& filter_labels) const;
 
   Result<std::vector<IdType>> filter(
-      std::string property_name, std::shared_ptr<Expression> filter_expression,
+      const std::string& property_name,
+      std::shared_ptr<Expression> filter_expression,
       std::vector<IdType>* new_valid_chunk = nullptr);
 
   /**
@@ -905,9 +906,7 @@ class EdgesCollection {
   explicit EdgesCollection(const std::shared_ptr<EdgeInfo>& edge_info,
                            const std::string& prefix, IdType vertex_chunk_begin,
                            IdType vertex_chunk_end, AdjListType adj_list_type)
-      : edge_info_(std::move(edge_info)),
-        prefix_(prefix),
-        adj_list_type_(adj_list_type) {
+      : edge_info_(edge_info), prefix_(prefix), adj_list_type_(adj_list_type) {
     GAR_ASSIGN_OR_RAISE_ERROR(
         auto vertex_chunk_num,
         util::GetVertexChunkNum(prefix_, edge_info_, adj_list_type_));


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
related to #774 
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->


### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. using `const &` and `std::move` to reduce copies
2. remove unnecessary `std::move`

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
no
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
