### PR TITLE
fix(c++): replace all `assert` and `ASSERT` with `REQUIRE`

### DIFF
--- a/cpp/test/test_multi_label.cc
+++ b/cpp/test/test_multi_label.cc
@@ -88,10 +88,10 @@ TEST_CASE_METHOD(GlobalFixture, "test_multi_label_builder") {
   // read label chunk as arrow table
   auto maybe_reader = VertexPropertyArrowChunkReader::Make(
       vertex_info, labels, "/tmp/ldbc/parquet/");
-  assert(maybe_reader.status().ok());
+  REQUIRE(maybe_reader.status().ok());
   auto reader = maybe_reader.value();
-  assert(reader->seek(0).ok());
-  assert(reader->GetLabelChunk().status().ok());
-  assert(reader->next_chunk().ok());
+  REQUIRE(reader->seek(0).ok());
+  REQUIRE(reader->GetLabelChunk().status().ok());
+  REQUIRE(reader->next_chunk().ok());
 }
 }  // namespace graphar


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
#789 

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
`cpp/tests`
- replace `assert` with `REQUIRE` for avoiding side effects
- replace `ASSERT` with `REQUIRE` for consistency
- remove unnecessary code

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes
### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
no
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
