### PR TITLE
feat(c++): specify underlying types for enums in fwd.h

### DIFF
--- a/cpp/src/graphar/fwd.h
+++ b/cpp/src/graphar/fwd.h
@@ -72,13 +72,13 @@ class FileSystem;
 using IdType = int64_t;
 class DataType;
 /** Defines how multiple values are handled for a given property key */
-enum Cardinality { SINGLE, LIST, SET };
+enum Cardinality : int32_t { SINGLE, LIST, SET };
 /** Type of file format */
-enum FileType { CSV = 0, PARQUET = 1, ORC = 2, JSON = 3 };
-enum SelectType { PROPERTIES = 0, LABELS = 1 };
+enum FileType : int32_t { CSV = 0, PARQUET = 1, ORC = 2, JSON = 3 };
+enum SelectType : int32_t { PROPERTIES = 0, LABELS = 1 };
 /** GetChunkVersion: V1 use scanner, V2 use FileReader */
-enum GetChunkVersion { AUTO = 0, V1 = 1, V2 = 2 };
-enum class AdjListType : uint8_t;
+enum GetChunkVersion : int32_t { AUTO = 0, V1 = 1, V2 = 2 };
+enum class AdjListType : int32_t;
 
 template <typename T>
 class Array;

--- a/cpp/src/graphar/types.h
+++ b/cpp/src/graphar/types.h
@@ -170,7 +170,7 @@ class Date {
 };
 
 /** Adj list type enumeration for adjacency list of graph. */
-enum class AdjListType : std::uint8_t {
+enum class AdjListType : std::int32_t {
   /// collection of edges by source, but unordered, can represent COO format
   unordered_by_source = 0b00000001,
   /// collection of edges by destination, but unordered, can represent COO


### PR DESCRIPTION
Fixes #809 

### Reason for this PR

The `graphar::Type` enum is part of public APIs and is also used in
serialization / layout-sensitive code paths. Previously, its underlying
type was implicit, which makes the width platform-dependent.

This PR makes the underlying type explicit so that it is stable and
well-defined across platforms.

### What changes are included in this PR?

- Update `graphar::Type` to use an explicit `int32_t` underlying type
- Align the forward declaration in `fwd.h` with the enum definition

No behavior changes are intended.

### Testing

- Code review and static inspection
- Local CMake configure succeeded
- Full build was not completed locally due to Arrow Acero/ORC header
  availability issues in the conda-forge Arrow version
- Relying on CI for full build and integration testing

### Are there any user-facing changes?

No. This change is internal and does not affect file formats or API behavior.
