### PR TITLE
[C++][CMake] Fix install/export targets and Windows runtime handling

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -277,7 +277,7 @@ macro(build_graphar)
     else()
         add_library(graphar SHARED ${CORE_SRC_FILES})
     endif()
-    install_graphar_target(graphar)
+   # install_graphar_target(graphar)
     target_compile_features(graphar PRIVATE cxx_std_17)
     target_include_directories(graphar PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty)
     target_link_libraries(graphar PRIVATE ${CMAKE_DL_LIBS})
@@ -334,7 +334,7 @@ macro(build_graphar_with_arrow_bundled)
     else()
         add_library(graphar SHARED ${CORE_SRC_FILES})
     endif()
-    install_graphar_target(graphar)
+    #install_graphar_target(graphar)
     target_compile_features(graphar PRIVATE cxx_std_17)
     target_include_directories(graphar PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty)
     target_include_directories(graphar SYSTEM BEFORE PRIVATE ${GAR_ARROW_INCLUDE_DIR})
@@ -497,6 +497,14 @@ endif()
 # ------------------------------------------------------------------------------
 # Install
 # ------------------------------------------------------------------------------
+install(TARGETS graphar
+  EXPORT graphar-targets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}   # .lib / .a
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}   # .so / .dylib
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL  # .dll / executables
+)
+
+
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/src/graphar
         DESTINATION include
         FILES_MATCHING


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->
Fixes #810

### Reason for this PR

The current CMake installation logic in GraphAr does not reliably support
library distribution and downstream consumption, especially on Windows.

This PR addresses the CMake install and export issues discussed in #810
and makes runtime installation behavior consistent across platforms.


### What changes are included in this PR?

- Remove duplicate and conflicting install logic for the `graphar` target
- Define a single canonical `install(TARGETS graphar ...)` rule
- Ensure headers and CMake package config files are installed correctly
- Fix Windows runtime (DLL) installation issues during `cmake --install`
- Validate installation with MSVC + vcpkg + Apache Arrow

### Are these changes tested?

- Windows 11
- MSVC (Visual Studio 2026)
- CMake + vcpkg
- Apache Arrow installed via vcpkg (arrow[dataset,parquet])
- Verified:
  - `cmake --build . --config Release`
  - `cmake --install . --config Release`
  - Generated headers and CMake config files

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No. This change affects CMake install and packaging behavior only and does not
modify GraphAr APIs or runtime behavior.
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
