### PR TITLE
feat(Rust): add `EdgeInfo` support

### DIFF
--- a/rust/include/graphar_rs.h
+++ b/rust/include/graphar_rs.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -32,13 +33,15 @@
 
 namespace graphar {
 using SharedPropertyGroup = std::shared_ptr<PropertyGroup>;
+using SharedAdjacentList = std::shared_ptr<AdjacentList>;
 using ConstInfoVersion = const InfoVersion;
-}
+} // namespace graphar
 
 namespace graphar_rs {
 rust::String to_type_name(const graphar::DataType &type);
 
-std::shared_ptr<graphar::ConstInfoVersion> new_const_info_version(int32_t version);
+std::shared_ptr<graphar::ConstInfoVersion>
+new_const_info_version(int32_t version);
 
 std::unique_ptr<graphar::Property>
 new_property(const std::string &name, std::shared_ptr<graphar::DataType> type,
@@ -72,13 +75,31 @@ std::unique_ptr<std::vector<graphar::SharedPropertyGroup>>
 property_group_vec_clone(
     const std::vector<graphar::SharedPropertyGroup> &property_groups);
 
-std::shared_ptr<graphar::VertexInfo>
-create_vertex_info(const std::string &type, graphar::IdType chunk_size,
-                   const std::vector<graphar::SharedPropertyGroup> &property_groups,
-                   const rust::Vec<rust::String> &labels,
-                   const std::string &prefix,
-                   std::shared_ptr<graphar::ConstInfoVersion> version);
+std::shared_ptr<graphar::VertexInfo> create_vertex_info(
+    const std::string &type, graphar::IdType chunk_size,
+    const std::vector<graphar::SharedPropertyGroup> &property_groups,
+    const rust::Vec<rust::String> &labels, const std::string &prefix,
+    std::shared_ptr<graphar::ConstInfoVersion> version);
 
-void vertex_info_save(const graphar::VertexInfo &vertex_info, const std::string &path);
-std::unique_ptr<std::string> vertex_info_dump(const graphar::VertexInfo &vertex_info);
+std::shared_ptr<graphar::EdgeInfo> create_edge_info(
+    const std::string &src_type, const std::string &edge_type,
+    const std::string &dst_type, graphar::IdType chunk_size,
+    graphar::IdType src_chunk_size, graphar::IdType dst_chunk_size,
+    bool directed, const graphar::AdjacentListVector &adjacent_lists,
+    const std::vector<graphar::SharedPropertyGroup> &property_groups,
+    const std::string &prefix,
+    std::shared_ptr<graphar::ConstInfoVersion> version);
+
+void vertex_info_save(const graphar::VertexInfo &vertex_info,
+                      const std::string &path);
+std::unique_ptr<std::string>
+vertex_info_dump(const graphar::VertexInfo &vertex_info);
+
+std::unique_ptr<graphar::AdjacentListVector> new_adjacent_list_vec();
+void push_adjacent_list(graphar::AdjacentListVector &v,
+                        std::shared_ptr<graphar::AdjacentList> adjacent_list);
+
+void edge_info_save(const graphar::EdgeInfo &edge_info,
+                    const std::string &path);
+std::unique_ptr<std::string> edge_info_dump(const graphar::EdgeInfo &edge_info);
 } // namespace graphar_rs

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Error types for this crate.
+
+use std::fmt;
+use std::path::PathBuf;
+
+/// A result type for this crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// An error returned by this crate.
+#[derive(Debug)]
+pub enum Error {
+    /// An exception raised from the C++ GraphAr implementation and propagated via `cxx`.
+    Cxx(cxx::Exception),
+    /// A filesystem path is not valid UTF-8.
+    NonUtf8Path(PathBuf),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cxx(e) => write!(f, "C++ exception: {e}"),
+            Self::NonUtf8Path(path) => write!(f, "path is not valid UTF-8: {}", path.display()),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Cxx(e) => Some(e),
+            Self::NonUtf8Path(_) => None,
+        }
+    }
+}
+
+impl From<cxx::Exception> for Error {
+    fn from(value: cxx::Exception) -> Self {
+        Self::Cxx(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::info::VertexInfo;
+    use crate::property::PropertyGroupVector;
+    use std::error::Error as StdError;
+
+    #[test]
+    fn test_non_utf8_path_display_and_source() {
+        let err = Error::NonUtf8Path(std::path::PathBuf::from("not_utf8_checked_here"));
+        let msg = err.to_string();
+        assert!(msg.contains("path is not valid UTF-8"), "msg={msg:?}");
+        assert!(StdError::source(&err).is_none());
+    }
+
+    #[test]
+    fn test_cxx_error_display_source_and_from() {
+        let groups = PropertyGroupVector::new();
+        let err = match VertexInfo::try_new("", 1, groups, vec![], "", None) {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+
+        let cxx_exc = match err {
+            Error::Cxx(e) => e,
+            other => panic!("expected Error::Cxx, got {other:?}"),
+        };
+
+        let err = Error::from(cxx_exc);
+        let msg = err.to_string();
+        assert!(msg.contains("C++ exception:"), "msg={msg:?}");
+        assert!(StdError::source(&err).is_some());
+    }
+}

--- a/rust/src/info/adjacent_list.rs
+++ b/rust/src/info/adjacent_list.rs
@@ -1,0 +1,156 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! GraphAr adjacent list metadata.
+
+use std::ops::Deref;
+
+use cxx::{CxxVector, SharedPtr, UniquePtr, let_cxx_string};
+
+use crate::ffi;
+use crate::info::AdjListType;
+use crate::types::FileType;
+
+/// An adjacency list definition in GraphAr metadata.
+pub type AdjacentList = ffi::SharedAdjacentList;
+
+impl AdjacentList {
+    /// Construct a `AdjacentList` from a raw C++ shared pointer.
+    pub(crate) fn from_inner(inner: SharedPtr<ffi::graphar::AdjacentList>) -> Self {
+        Self(inner)
+    }
+
+    /// Create a new adjacency list definition.
+    ///
+    /// If `path_prefix` is `None`, GraphAr will use a default prefix derived
+    /// from `ty` (e.g. `ordered_by_source/`).
+    pub fn new<P: AsRef<str>>(
+        ty: AdjListType,
+        file_type: FileType,
+        path_prefix: Option<P>,
+    ) -> Self {
+        let prefix = path_prefix.as_ref().map(|p| p.as_ref()).unwrap_or("");
+        let_cxx_string!(prefix = prefix);
+        let inner = ffi::graphar::CreateAdjacentList(ty, file_type, &prefix);
+        Self(inner)
+    }
+
+    /// Returns the adjacency list type.
+    pub fn ty(&self) -> AdjListType {
+        self.0.GetType()
+    }
+
+    /// Returns the chunk file type for this adjacency list.
+    pub fn file_type(&self) -> FileType {
+        self.0.GetFileType()
+    }
+
+    /// Returns the logical prefix for this adjacency list.
+    pub fn prefix(&self) -> String {
+        self.0.GetPrefix().to_string()
+    }
+}
+
+/// A vector of adjacency lists.
+///
+/// This is a wrapper around a C++ `graphar::AdjacentListVector`.
+pub struct AdjacentListVector(UniquePtr<CxxVector<AdjacentList>>);
+
+impl Default for AdjacentListVector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Deref for AdjacentListVector {
+    type Target = CxxVector<AdjacentList>;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl AdjacentListVector {
+    /// Create an empty adjacency list vector.
+    pub fn new() -> Self {
+        Self(ffi::graphar::new_adjacent_list_vec())
+    }
+
+    /// Push an adjacency list into the vector.
+    pub fn push(&mut self, adjacent_list: AdjacentList) {
+        ffi::graphar::push_adjacent_list(self.0.pin_mut(), adjacent_list.0);
+    }
+
+    /// Borrow the underlying C++ adjacency list vector.
+    pub(crate) fn as_ref(&self) -> &CxxVector<AdjacentList> {
+        self.0
+            .as_ref()
+            .expect("adjacent list vector should be valid")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::FileType;
+
+    #[test]
+    fn test_adjacent_list_roundtrip_getters() {
+        let list = AdjacentList::new(AdjListType::OrderedBySource, FileType::Csv, Some("adj/"));
+        assert_eq!(list.ty(), AdjListType::OrderedBySource);
+        assert_eq!(list.file_type(), FileType::Csv);
+        assert_eq!(list.prefix(), "adj/");
+    }
+
+    #[test]
+    fn test_adjacent_list_default_prefix() {
+        let list = AdjacentList::new(
+            AdjListType::OrderedBySource,
+            FileType::Parquet,
+            None::<&str>,
+        );
+        assert_eq!(list.prefix(), "ordered_by_source/");
+    }
+
+    #[test]
+    fn test_adjacent_list_vector_push_and_borrow() {
+        let mut v = AdjacentListVector::new();
+        let _ = v.as_ref();
+        assert!(v.is_empty());
+
+        v.push(AdjacentList::new(
+            AdjListType::UnorderedBySource,
+            FileType::Parquet,
+            Some("u/"),
+        ));
+        let _ = v.as_ref();
+        assert_eq!(v.len(), 1);
+    }
+
+    #[test]
+    fn test_adjacent_list_vector_default() {
+        let mut v = AdjacentListVector::default();
+        assert_eq!(v.len(), 0);
+        v.push(AdjacentList::new(
+            AdjListType::OrderedByDest,
+            FileType::Parquet,
+            None::<&str>,
+        ));
+        assert_eq!(v.len(), 1);
+        let _ = v.as_ref();
+    }
+}

--- a/rust/src/info/edge_info.rs
+++ b/rust/src/info/edge_info.rs
@@ -1,0 +1,717 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! GraphAr edge metadata.
+
+use std::path::Path;
+
+use cxx::{CxxVector, SharedPtr, UniquePtr, let_cxx_string};
+
+use crate::ffi;
+use crate::info::{AdjListType, AdjacentList, AdjacentListVector, InfoVersion};
+use crate::property::{PropertyGroup, PropertyGroupVector};
+
+/// An edge definition in the GraphAr metadata.
+#[derive(Clone)]
+pub struct EdgeInfo(pub(crate) SharedPtr<ffi::graphar::EdgeInfo>);
+
+impl EdgeInfo {
+    /// Create a builder for [`EdgeInfo`].
+    ///
+    /// This is the preferred API when constructing `EdgeInfo` in Rust, since
+    /// the raw constructor has many parameters.
+    pub fn builder(
+        src_type: impl Into<String>,
+        edge_type: impl Into<String>,
+        dst_type: impl Into<String>,
+        chunk_size: i64,
+        src_chunk_size: i64,
+        dst_chunk_size: i64,
+    ) -> EdgeInfoBuilder {
+        EdgeInfoBuilder::new(
+            src_type,
+            edge_type,
+            dst_type,
+            chunk_size,
+            src_chunk_size,
+            dst_chunk_size,
+        )
+    }
+
+    /// Create a new edge definition.
+    ///
+    /// The `prefix` is a logical prefix string used by GraphAr (it is not a filesystem path).
+    ///
+    /// Panics if GraphAr rejects the inputs (including, but not limited to,
+    /// empty type names, non-positive chunk sizes, or empty adjacency list
+    /// vector). Prefer [`EdgeInfo::try_new`] if you want to handle errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new<P: AsRef<str>>(
+        src_type: &str,
+        edge_type: &str,
+        dst_type: &str,
+        chunk_size: i64,
+        src_chunk_size: i64,
+        dst_chunk_size: i64,
+        directed: bool,
+        adjacent_lists: AdjacentListVector,
+        property_groups: PropertyGroupVector,
+        prefix: P,
+        version: Option<InfoVersion>,
+    ) -> Self {
+        Self::try_new(
+            src_type,
+            edge_type,
+            dst_type,
+            chunk_size,
+            src_chunk_size,
+            dst_chunk_size,
+            directed,
+            adjacent_lists,
+            property_groups,
+            prefix,
+            version,
+        )
+        .unwrap()
+    }
+
+    /// Try to create a new edge definition.
+    ///
+    /// This returns an error if any required field is invalid (e.g. empty type
+    /// names, non-positive chunk sizes, or empty adjacency list vector), or if
+    /// the upstream GraphAr implementation rejects the inputs.
+    #[allow(clippy::too_many_arguments)]
+    pub fn try_new<P: AsRef<str>>(
+        src_type: &str,
+        edge_type: &str,
+        dst_type: &str,
+        chunk_size: i64,
+        src_chunk_size: i64,
+        dst_chunk_size: i64,
+        directed: bool,
+        adjacent_lists: AdjacentListVector,
+        property_groups: PropertyGroupVector,
+        prefix: P,
+        version: Option<InfoVersion>,
+    ) -> crate::Result<Self> {
+        let_cxx_string!(src = src_type);
+        let_cxx_string!(edge = edge_type);
+        let_cxx_string!(dst = dst_type);
+        let_cxx_string!(prefix = prefix.as_ref());
+
+        let prop_groups = property_groups.as_ref();
+        let version = version.map(|v| v.0).unwrap_or_else(SharedPtr::null);
+
+        let inner = ffi::graphar::create_edge_info(
+            &src,
+            &edge,
+            &dst,
+            chunk_size,
+            src_chunk_size,
+            dst_chunk_size,
+            directed,
+            adjacent_lists.as_ref(),
+            prop_groups,
+            &prefix,
+            version,
+        )?;
+        Ok(Self(inner))
+    }
+
+    /// Return the source vertex type.
+    pub fn src_type(&self) -> String {
+        self.0.GetSrcType().to_string()
+    }
+
+    /// Return the edge type.
+    pub fn edge_type(&self) -> String {
+        self.0.GetEdgeType().to_string()
+    }
+
+    /// Return the destination vertex type.
+    pub fn dst_type(&self) -> String {
+        self.0.GetDstType().to_string()
+    }
+
+    /// Return the global chunk size.
+    pub fn chunk_size(&self) -> i64 {
+        self.0.GetChunkSize()
+    }
+
+    /// Return the chunk size for the source vertex type.
+    pub fn src_chunk_size(&self) -> i64 {
+        self.0.GetSrcChunkSize()
+    }
+
+    /// Return the chunk size for the destination vertex type.
+    pub fn dst_chunk_size(&self) -> i64 {
+        self.0.GetDstChunkSize()
+    }
+
+    /// Return the logical prefix.
+    pub fn prefix(&self) -> String {
+        self.0.GetPrefix().to_string()
+    }
+
+    /// Return whether this edge is directed.
+    pub fn is_directed(&self) -> bool {
+        self.0.IsDirected()
+    }
+
+    /// Return the optional info version.
+    pub fn version(&self) -> Option<InfoVersion> {
+        let sp = self.0.version();
+        if sp.is_null() {
+            None
+        } else {
+            Some(InfoVersion(sp.clone()))
+        }
+    }
+
+    /// Return whether this edge has the given adjacency list type.
+    pub fn has_adjacent_list_type(&self, adj_list_type: AdjListType) -> bool {
+        self.0.HasAdjacentListType(adj_list_type)
+    }
+
+    /// Return the adjacency list definition of the given type.
+    ///
+    /// Returns `None` if the adjacency list type is not found.
+    pub fn adjacent_list(&self, adj_list_type: AdjListType) -> Option<AdjacentList> {
+        let sp = self.0.GetAdjacentList(adj_list_type);
+        if sp.is_null() {
+            None
+        } else {
+            Some(AdjacentList::from_inner(sp))
+        }
+    }
+
+    /// Return the number of property groups.
+    ///
+    /// TODO: upstream C++ uses `int` for this return type; prefer fixed-width.
+    pub fn property_group_num(&self) -> i32 {
+        self.0.PropertyGroupNum()
+    }
+
+    /// Return property groups.
+    ///
+    /// This is an advanced API that exposes `cxx` types and ties the returned
+    /// reference to the lifetime of `self`.
+    pub fn property_groups_cxx(&self) -> &CxxVector<PropertyGroup> {
+        self.0.GetPropertyGroups()
+    }
+
+    /// Return property groups.
+    ///
+    /// This allocates a new `Vec`. Prefer [`EdgeInfo::property_groups_iter`]
+    /// if you only need to iterate.
+    pub fn property_groups(&self) -> Vec<PropertyGroup> {
+        self.property_groups_iter().collect()
+    }
+
+    /// Iterate over property groups without allocating a `Vec`.
+    pub fn property_groups_iter(&self) -> impl Iterator<Item = PropertyGroup> + '_ {
+        self.0.GetPropertyGroups().iter().cloned()
+    }
+
+    /// Return the property group containing the given property name.
+    ///
+    /// Returns `None` if the property is not found.
+    pub fn property_group<S: AsRef<str>>(&self, property_name: S) -> Option<PropertyGroup> {
+        let_cxx_string!(name = property_name.as_ref());
+        let sp = self.0.GetPropertyGroup(&name);
+        if sp.is_null() {
+            None
+        } else {
+            Some(PropertyGroup::from_inner(sp))
+        }
+    }
+
+    /// Return the property group at the given index.
+    ///
+    /// Returns `None` if the index is out of range.
+    ///
+    /// TODO: upstream C++ uses `int` for this parameter; prefer fixed-width.
+    pub fn property_group_by_index(&self, index: i32) -> Option<PropertyGroup> {
+        let sp = self.0.GetPropertyGroupByIndex(index);
+        if sp.is_null() {
+            None
+        } else {
+            Some(PropertyGroup::from_inner(sp))
+        }
+    }
+
+    /// Save this edge definition as a YAML file.
+    ///
+    /// Note: `path` must be valid UTF-8. On Unix, paths can contain arbitrary
+    /// bytes; such non-UTF8 paths return [`crate::Error::NonUtf8Path`].
+    pub fn save<P: AsRef<Path>>(&self, path: P) -> crate::Result<()> {
+        let path_str = crate::path_to_utf8_str(path.as_ref())?;
+        let_cxx_string!(p = path_str);
+        ffi::graphar::edge_info_save(&self.0, &p)?;
+        Ok(())
+    }
+
+    /// Dump this edge definition to a YAML string.
+    pub fn dump(&self) -> crate::Result<String> {
+        let dumped: UniquePtr<cxx::CxxString> = ffi::graphar::edge_info_dump(&self.0)?;
+        let dumped = dumped.as_ref().expect("edge info dump should be valid");
+        Ok(dumped.to_string())
+    }
+}
+
+/// A builder for constructing an [`EdgeInfo`].
+///
+/// This builder is intended to reduce the argument noise of [`EdgeInfo::new`],
+/// while keeping the resulting `EdgeInfo` construction explicit and readable.
+///
+/// Note: You must supply at least one adjacent list (via
+/// [`EdgeInfoBuilder::push_adjacent_list`] or [`EdgeInfoBuilder::adjacent_lists`])
+/// before calling [`EdgeInfoBuilder::build`] / [`EdgeInfoBuilder::try_build`].
+/// If the adjacent list vector is empty, GraphAr will reject the inputs:
+/// `try_build` returns an error and `build` panics.
+///
+/// Defaults:
+/// - `directed = false`
+/// - `adjacent_lists = []` (must be non-empty before `build` / `try_build`)
+/// - `property_groups = []`
+/// - `prefix = ""` (GraphAr may set a default prefix based on type names)
+/// - `version = None`
+pub struct EdgeInfoBuilder {
+    src_type: String,
+    edge_type: String,
+    dst_type: String,
+    chunk_size: i64,
+    src_chunk_size: i64,
+    dst_chunk_size: i64,
+    directed: bool,
+    adjacent_lists: AdjacentListVector,
+    property_groups: PropertyGroupVector,
+    prefix: String,
+    version: Option<InfoVersion>,
+}
+
+impl EdgeInfoBuilder {
+    /// Create a new builder with required fields.
+    pub fn new(
+        src_type: impl Into<String>,
+        edge_type: impl Into<String>,
+        dst_type: impl Into<String>,
+        chunk_size: i64,
+        src_chunk_size: i64,
+        dst_chunk_size: i64,
+    ) -> Self {
+        Self {
+            src_type: src_type.into(),
+            edge_type: edge_type.into(),
+            dst_type: dst_type.into(),
+            chunk_size,
+            src_chunk_size,
+            dst_chunk_size,
+            directed: false,
+            adjacent_lists: AdjacentListVector::new(),
+            property_groups: PropertyGroupVector::new(),
+            prefix: String::new(),
+            version: None,
+        }
+    }
+
+    /// Set whether this edge is directed.
+    pub fn directed(mut self, directed: bool) -> Self {
+        self.directed = directed;
+        self
+    }
+
+    /// Set the logical prefix.
+    ///
+    /// This is a logical prefix string used by GraphAr (it is not a filesystem path).
+    pub fn prefix<P: AsRef<str>>(mut self, prefix: P) -> Self {
+        self.prefix = prefix.as_ref().to_owned();
+        self
+    }
+
+    /// Set the info format version.
+    pub fn version(mut self, version: InfoVersion) -> Self {
+        self.version = Some(version);
+        self
+    }
+
+    /// Set the optional info format version.
+    pub fn version_opt(mut self, version: Option<InfoVersion>) -> Self {
+        self.version = version;
+        self
+    }
+
+    /// Push an adjacent list definition.
+    pub fn push_adjacent_list(mut self, adjacent_list: AdjacentList) -> Self {
+        self.adjacent_lists.push(adjacent_list);
+        self
+    }
+
+    /// Replace adjacent lists with the given vector.
+    pub fn adjacent_lists(mut self, adjacent_lists: AdjacentListVector) -> Self {
+        self.adjacent_lists = adjacent_lists;
+        self
+    }
+
+    /// Push a property group definition.
+    pub fn push_property_group(mut self, property_group: PropertyGroup) -> Self {
+        self.property_groups.push(property_group);
+        self
+    }
+
+    /// Replace property groups with the given vector.
+    pub fn property_groups(mut self, property_groups: PropertyGroupVector) -> Self {
+        self.property_groups = property_groups;
+        self
+    }
+
+    /// Build an [`EdgeInfo`].
+    ///
+    /// Panics if GraphAr rejects the builder inputs. Prefer
+    /// [`EdgeInfoBuilder::try_build`] if you want to handle errors.
+    pub fn build(self) -> EdgeInfo {
+        self.try_build().unwrap()
+    }
+
+    /// Try to build an [`EdgeInfo`].
+    pub fn try_build(self) -> crate::Result<EdgeInfo> {
+        let Self {
+            src_type,
+            edge_type,
+            dst_type,
+            chunk_size,
+            src_chunk_size,
+            dst_chunk_size,
+            directed,
+            adjacent_lists,
+            property_groups,
+            prefix,
+            version,
+        } = self;
+
+        EdgeInfo::try_new(
+            &src_type,
+            &edge_type,
+            &dst_type,
+            chunk_size,
+            src_chunk_size,
+            dst_chunk_size,
+            directed,
+            adjacent_lists,
+            property_groups,
+            prefix.as_str(),
+            version,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::property::{PropertyBuilder, PropertyGroup, PropertyGroupVector, PropertyVec};
+    use crate::types::{DataType, FileType};
+    use tempfile::tempdir;
+
+    fn make_adjacent_lists() -> AdjacentListVector {
+        let mut lists = AdjacentListVector::new();
+        lists.push(AdjacentList::new(
+            AdjListType::UnorderedBySource,
+            FileType::Parquet,
+            Some("adj/"),
+        ));
+        lists
+    }
+
+    fn make_property_groups() -> PropertyGroupVector {
+        let mut props = PropertyVec::new();
+        props.emplace(PropertyBuilder::new("id", DataType::int64()).primary_key(true));
+        props.emplace(PropertyBuilder::new("weight", DataType::float64()));
+
+        let pg = PropertyGroup::new(props, FileType::Parquet, "props/");
+        let mut groups = PropertyGroupVector::new();
+        groups.push(pg);
+        groups
+    }
+
+    #[test]
+    fn test_edge_info_clone_and_lookup_inputs() {
+        let edge_info = EdgeInfoBuilder::new("person", "knows", "person", 1024, 100, 100)
+            .adjacent_lists(make_adjacent_lists())
+            .property_groups(make_property_groups())
+            .prefix("edge/person_knows_person/")
+            .build();
+
+        let cloned = edge_info.clone();
+        assert_eq!(cloned.src_type(), "person");
+        assert_eq!(cloned.edge_type(), "knows");
+        assert_eq!(cloned.dst_type(), "person");
+        assert_eq!(cloned.prefix(), "edge/person_knows_person/");
+
+        assert!(cloned.property_group(String::from("id")).is_some());
+        assert!(cloned.property_group(String::from("missing")).is_none());
+    }
+
+    #[test]
+    fn test_edge_info_builder_basic() {
+        let edge_info = EdgeInfoBuilder::new("person", "knows", "person", 1024, 100, 100)
+            .directed(true)
+            .prefix("knows/")
+            .version(InfoVersion::new(1).unwrap())
+            .adjacent_lists(make_adjacent_lists())
+            .property_groups(make_property_groups())
+            .build();
+
+        assert_eq!(edge_info.src_type(), "person");
+        assert_eq!(edge_info.edge_type(), "knows");
+        assert_eq!(edge_info.dst_type(), "person");
+        assert_eq!(edge_info.chunk_size(), 1024);
+        assert_eq!(edge_info.src_chunk_size(), 100);
+        assert_eq!(edge_info.dst_chunk_size(), 100);
+        assert!(edge_info.is_directed());
+        assert_eq!(edge_info.prefix(), "knows/");
+        assert!(edge_info.version().is_some());
+        assert!(edge_info.has_adjacent_list_type(AdjListType::UnorderedBySource));
+        assert!(
+            edge_info
+                .adjacent_list(AdjListType::UnorderedBySource)
+                .is_some()
+        );
+        assert!(
+            edge_info
+                .adjacent_list(AdjListType::OrderedBySource)
+                .is_none()
+        );
+        assert_eq!(edge_info.property_group_num(), 1);
+        assert!(edge_info.property_group("id").is_some());
+        assert!(edge_info.property_group("missing").is_none());
+        assert!(edge_info.property_group_by_index(0).is_some());
+        assert!(edge_info.property_group_by_index(1).is_none());
+        assert!(edge_info.property_group_by_index(-1).is_none());
+    }
+
+    #[test]
+    fn test_edge_info_builder_aliases_and_push_helpers() {
+        let version = InfoVersion::new(1).unwrap();
+        let pg_vec = make_property_groups();
+        let pg = pg_vec.get(0).unwrap().clone();
+
+        let mut adj = AdjacentListVector::new();
+        adj.push(AdjacentList::new(
+            AdjListType::OrderedBySource,
+            FileType::Parquet,
+            None::<&str>,
+        ));
+        let list = AdjacentList::new(
+            AdjListType::UnorderedBySource,
+            FileType::Parquet,
+            Some("u/"),
+        );
+
+        let edge_info = EdgeInfo::builder("person", "knows", "person", 1024, 100, 100)
+            .directed(false)
+            .prefix("edge/person_knows_person/")
+            .version_opt(Some(version))
+            .push_adjacent_list(list)
+            .adjacent_lists(adj)
+            .push_property_group(pg)
+            .property_groups(pg_vec)
+            .build();
+
+        assert_eq!(edge_info.prefix(), "edge/person_knows_person/");
+
+        // Covered API that exposes cxx types.
+        let groups_cxx = edge_info.property_groups_cxx();
+        assert_eq!(groups_cxx.len(), 1);
+        assert!(groups_cxx.get(0).unwrap().has_property("id"));
+    }
+
+    #[test]
+    fn test_edge_info_builder_try_build_error_paths() {
+        // adjacent_lists cannot be empty
+        let err = EdgeInfoBuilder::new("person", "knows", "person", 1024, 100, 100)
+            .property_groups(make_property_groups())
+            .try_build()
+            .err()
+            .unwrap();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("CreateEdgeInfo") && msg.contains("adjacent_lists must not be empty"),
+            "unexpected error message: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn test_edge_info_property_groups_roundtrip() {
+        let edge_info = EdgeInfoBuilder::new("person", "knows", "person", 1024, 100, 100)
+            .adjacent_lists(make_adjacent_lists())
+            .property_groups(make_property_groups())
+            .build();
+
+        assert!(edge_info.version().is_none());
+
+        let groups = edge_info.property_groups();
+        assert_eq!(groups.len(), 1);
+        assert!(groups[0].has_property("id"));
+        assert!(groups[0].has_property("weight"));
+    }
+
+    #[test]
+    fn test_edge_info_dump_and_save() {
+        let edge_info = EdgeInfoBuilder::new("person", "knows", "person", 1024, 100, 100)
+            .directed(true)
+            .adjacent_lists(make_adjacent_lists())
+            .property_groups(make_property_groups())
+            .prefix("edge/person_knows_person/")
+            .build();
+
+        let dumped = edge_info.dump().unwrap();
+        assert!(!dumped.trim().is_empty(), "dumped={dumped:?}");
+        assert!(dumped.contains("person"), "dumped={dumped:?}");
+        assert!(dumped.contains("knows"), "dumped={dumped:?}");
+        assert!(
+            dumped.contains("edge/person_knows_person/"),
+            "dumped={dumped:?}"
+        );
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("edge_info.yaml");
+        edge_info.save(&path).unwrap();
+
+        let metadata = std::fs::metadata(&path).unwrap();
+        assert!(metadata.is_file());
+        assert!(metadata.len() > 0);
+
+        let saved = std::fs::read_to_string(&path).unwrap();
+        assert!(!saved.trim().is_empty(), "saved={saved:?}");
+        assert!(saved.contains("person"), "saved={saved:?}");
+        assert!(saved.contains("knows"), "saved={saved:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_edge_info_save_non_utf8_path() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let edge_info = EdgeInfoBuilder::new("person", "knows", "person", 1024, 100, 100)
+            .adjacent_lists(make_adjacent_lists())
+            .property_groups(make_property_groups())
+            .build();
+
+        let dir = tempdir().unwrap();
+        let mut path = dir.path().to_path_buf();
+        path.push(std::ffi::OsString::from_vec(
+            b"edge_info_\xFF.yaml".to_vec(),
+        ));
+
+        let err = edge_info.save(&path).err().unwrap();
+        assert!(
+            matches!(err, crate::Error::NonUtf8Path(_)),
+            "unexpected error: {err:?}"
+        );
+        assert!(std::fs::metadata(&path).is_err());
+    }
+
+    #[test]
+    fn test_edge_info_try_new_error_paths() {
+        let version = InfoVersion::new(1).unwrap();
+
+        // src_type cannot be empty
+        let msg = EdgeInfo::try_new(
+            "",
+            "knows",
+            "person",
+            1,
+            1,
+            1,
+            true,
+            make_adjacent_lists(),
+            make_property_groups(),
+            "",
+            Some(version.clone()),
+        )
+        .err()
+        .unwrap()
+        .to_string();
+        assert!(
+            msg.contains("CreateEdgeInfo") && msg.contains("src_type must not be empty"),
+            "unexpected error message: {msg:?}"
+        );
+
+        // `chunk_size` cannot be less than 1
+        let msg = EdgeInfo::try_new(
+            "person",
+            "knows",
+            "person",
+            0,
+            1,
+            1,
+            true,
+            make_adjacent_lists(),
+            make_property_groups(),
+            "",
+            Some(version.clone()),
+        )
+        .err()
+        .unwrap()
+        .to_string();
+        assert!(
+            msg.contains("CreateEdgeInfo") && msg.contains("chunk_size must be > 0"),
+            "unexpected error message: {msg:?}"
+        );
+
+        // adjacent_lists cannot be empty
+        let msg = EdgeInfo::try_new(
+            "person",
+            "knows",
+            "person",
+            1,
+            1,
+            1,
+            true,
+            AdjacentListVector::new(),
+            make_property_groups(),
+            "",
+            Some(version),
+        )
+        .err()
+        .unwrap()
+        .to_string();
+        assert!(
+            msg.contains("CreateEdgeInfo") && msg.contains("adjacent_lists must not be empty"),
+            "unexpected error message: {msg:?}"
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_edge_info_new_panics_on_invalid_args() {
+        let version = InfoVersion::new(1).unwrap();
+        let _ = EdgeInfo::new(
+            "",
+            "knows",
+            "person",
+            1,
+            1,
+            1,
+            true,
+            make_adjacent_lists(),
+            make_property_groups(),
+            "",
+            Some(version),
+        );
+    }
+}

--- a/rust/src/info/mod.rs
+++ b/rust/src/info/mod.rs
@@ -15,10 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Graph metadata bindings.
+//! GraphAr metadata information types.
 
+mod adjacent_list;
+mod edge_info;
 mod version;
 mod vertex_info;
 
+/// Re-export of the C++ `graphar::AdjListType`.
+pub use crate::ffi::graphar::AdjListType;
+
+pub use adjacent_list::{AdjacentList, AdjacentListVector};
+pub use edge_info::{EdgeInfo, EdgeInfoBuilder};
 pub use version::InfoVersion;
 pub use vertex_info::{VertexInfo, VertexInfoBuilder};

--- a/rust/src/info/version.rs
+++ b/rust/src/info/version.rs
@@ -20,7 +20,7 @@
 use crate::ffi;
 use cxx::SharedPtr;
 
-/// A GraphAr `InfoVersion` value.
+/// A GraphAr info version.
 ///
 /// This is a thin wrapper around `std::shared_ptr<const graphar::InfoVersion>`.
 #[derive(Clone)]
@@ -30,7 +30,7 @@ impl InfoVersion {
     /// Create a new `InfoVersion` by version number.
     ///
     /// TODO: upstream C++ constructor takes `int`; prefer fixed-width integer types.
-    pub fn new(version: i32) -> Result<Self, cxx::Exception> {
+    pub fn new(version: i32) -> crate::Result<Self> {
         Ok(Self(ffi::graphar::new_const_info_version(version)?))
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -19,17 +19,22 @@
 
 #![deny(missing_docs)]
 
-use cxx::CxxString;
+use std::path::Path;
 
 mod ffi;
 
-/// GraphAr metadata.
+/// Error types for this crate.
+pub mod error;
+/// GraphAr metadata information types.
 pub mod info;
 /// GraphAr property.
 pub mod property;
 /// GraphAr logical data types.
 pub mod types;
 
-fn cxx_string_to_string(value: &CxxString) -> String {
-    String::from_utf8_lossy(value.as_bytes()).into_owned()
+pub use error::{Error, Result};
+
+fn path_to_utf8_str(path: &Path) -> Result<&str> {
+    path.to_str()
+        .ok_or_else(|| Error::NonUtf8Path(path.to_owned()))
 }


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->

#832 implement `EdgeInfo` binding for Rust
 
### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
This PR extends the Rust bindings to cover GraphAr edge metadata (`EdgeInfo`) and adjacency list metadata, and introduces a crate-wide error type to improve ergonomics and error propagation.
(following details are generated by AI )
#### `rust/include/graphar_rs.h`
- Adds C++ API surface for edge metadata and adjacency lists:
  - `create_edge_info`, `edge_info_save`, `edge_info_dump`
  - `new_adjacent_list_vec`, `push_adjacent_list`
- Introduces `graphar::SharedAdjacentList` and includes `<cstddef>` for completeness.

#### `rust/src/error.rs` (new)
- Introduces `crate::Error` and `crate::Result<T>`:
  - `Error::Cxx(cxx::Exception)` for propagated C++ exceptions
  - `Error::NonUtf8Path(PathBuf)` for rejecting non-UTF8 filesystem paths
- Adds unit tests for display/source behavior and conversion.

#### `rust/src/lib.rs`
- Exposes `pub mod error` and re-exports `Error`/`Result` at the crate root.
- Adds `path_to_utf8_str(&Path) -> crate::Result<&str>` used by `save` APIs.
- Removes the previous `cxx_string_to_string` helper in favor of `.to_string()`.

#### `rust/src/ffi.rs`
- Adds `SharedAdjacentList` as an opaque `cxx::ExternType`.
- Extends the `cxx::bridge` with:
  - `AdjListType` (GraphAr `AdjListType` bit flags)
  - `AdjacentList` bindings (`CreateAdjacentList`, getters)
  - `AdjacentListVector` helpers (`new_adjacent_list_vec`, `push_adjacent_list`)
  - `EdgeInfo` bindings (getters, property group accessors, `create_edge_info`, `save`, `dump`)

#### `rust/src/graphar_rs.cc`
- Implements `create_edge_info` with explicit validation and null checks.
- Adds `AdjacentListVector` constructor/push helpers exposed to Rust via `cxx`.
- Implements `edge_info_save` and `edge_info_dump` with error propagation via exceptions.

#### `rust/src/info/mod.rs`
- Registers new modules: `adjacent_list`, `edge_info`.
- Re-exports:
  - `AdjListType`
  - `AdjacentList`, `AdjacentListVector`
  - `EdgeInfo`, `EdgeInfoBuilder`

#### `rust/src/info/adjacent_list.rs` (new)
- Adds Rust-side wrappers for adjacency list metadata:
  - `AdjacentList::new`, getters (`ty`, `file_type`, `prefix`)
  - `AdjacentListVector` wrapper with `new`, `push`, and borrowing helpers
- Includes unit tests for roundtrip getters, default prefix behavior, and vector push.

#### `rust/src/info/edge_info.rs` (new)
- Adds Rust-side wrappers for edge metadata:
  - `EdgeInfo` getters (types, chunk sizes, prefix, directed, version)
  - adjacency list queries (`has_adjacent_list_type`, `adjacent_list`)
  - property group APIs (count, C++-borrowed view, iterator, lookups)
  - `save`/`dump`
- Introduces `EdgeInfoBuilder` to reduce constructor argument noise.
- Includes extensive unit tests for:
  - builder ergonomics and helper methods
  - error paths (invalid args, empty adjacency list vector)
  - `dump`/`save` behavior and non-UTF8 path rejection

#### `rust/src/info/version.rs`
- Changes `InfoVersion::new` to return `crate::Result<Self>` to align with the new crate-wide error type.
- Minor doc wording update.

#### `rust/src/info/vertex_info.rs`
- Builder API adjustments:
  - `VertexInfo::builder(type, chunk_size)` no longer takes `property_groups` as a required argument.
  - Adds builder setters/helpers: `push_property_group` and `property_groups`.
- Tightens several APIs from `AsRef<[u8]>` to `AsRef<str>` for type/prefix/property name inputs.
- Changes `save` to require a UTF-8 path (returns `Error::NonUtf8Path` for non-UTF8 paths on Unix).
- Updates and expands unit tests to reflect new builder behavior and path semantics.

#### `rust/src/property.rs`
- Refactors `PropertyVec` and `PropertyGroupVector` wrappers:
  - Removes `DerefMut` usage and introduces explicit borrowing helpers (`as_ref`, `pin_mut`) for mutating C++ vectors.
- Changes `PropertyGroup::new` prefix input from bytes to `AsRef<str>`.
- Updates unit tests to match the new borrowing patterns and APIs.


### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes
### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
