### PR TITLE
fix(format): add clang-format to check all c++ files and fix exist fo…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,38 +87,15 @@ jobs:
         cd build
         cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DBUILD_BENCHMARKS=ON  -DCMAKE_CXX_FLAGS="--coverage" -DCMAKE_C_FLAGS="--coverage"
 
-    - name: Cpp Format and lint
+    - name: clang-format
+      run: |
+        pip install pre-commit
+        pre-commit install
+        pre-commit run clang-format -a
+
+    - name: cpplint
       working-directory: "cpp/build"
       run: |
-        # install clang-format
-        sudo curl -L https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-22538c65/clang-format-8_linux-amd64 --output /usr/bin/clang-format
-        sudo chmod +x /usr/bin/clang-format
-
-        # validate format
-        function prepend() { while read line; do echo "${1}${line}"; done; }
-
-        make graphar-clformat
-        GIT_DIFF=$(git diff --ignore-submodules)
-        if [[ -n $GIT_DIFF ]]; then
-            echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-            echo "| clang-format failures found!"
-            echo "|"
-            echo "$GIT_DIFF" | prepend "| "
-            echo "|"
-            echo "| Run: "
-            echo "|"
-            echo "|    make graphar-clformat"
-            echo "|"
-            echo "| to fix this error."
-            echo "|"
-            echo "| Ensure you are working with clang-format-8, which can be obtained from"
-            echo "|"
-            echo "|    https://github.com/muttleyxd/clang-tools-static-binaries/releases"
-            echo "|"
-            echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-            exit -1
-        fi
-
         function ec() { [[ "$1" == "-h" ]] && { shift && eval $* > /dev/null 2>&1; ec=$?; echo $ec; } || eval $*; ec=$?; }
 
         ec make graphar-cpplint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,11 @@ repos:
     rev: v21.1.2
     hooks:
     - id: clang-format
-      files: ^python/
+      files: \.(cc|cpp|h|hpp)$
       types_or: [c++]
       args: [--style=file, --verbose]
-
+      exclude: ^cpp/thirdparty/
+      
   - repo: local
     hooks:
       - id: spotless-java-info

--- a/cpp/src/graphar/filesystem.cc
+++ b/cpp/src/graphar/filesystem.cc
@@ -215,8 +215,8 @@ Result<T> FileSystem::ReadFileToValue(const std::string& path) const noexcept {
 }
 
 template <>
-Result<std::string> FileSystem::ReadFileToValue(const std::string& path) const
-    noexcept {
+Result<std::string> FileSystem::ReadFileToValue(
+    const std::string& path) const noexcept {
   GAR_RETURN_ON_ARROW_ERROR_AND_ASSIGN(auto access_file,
                                        arrow_fs_->OpenInputFile(path));
   GAR_RETURN_ON_ARROW_ERROR_AND_ASSIGN(auto bytes, access_file->GetSize());
@@ -293,8 +293,8 @@ Status FileSystem::WriteTableToFile(
 }
 
 Status FileSystem::WriteLabelTableToFile(
-    const std::shared_ptr<arrow::Table>& table, const std::string& path) const
-    noexcept {
+    const std::shared_ptr<arrow::Table>& table,
+    const std::string& path) const noexcept {
   // try to create the directory, oss filesystem may not support this, ignore
   ARROW_UNUSED(arrow_fs_->CreateDir(path.substr(0, path.find_last_of("/"))));
   GAR_RETURN_ON_ARROW_ERROR_AND_ASSIGN(auto output_stream,
@@ -397,7 +397,6 @@ Status FinalizeS3() {
 template Result<IdType> FileSystem::ReadFileToValue<IdType>(
     const std::string&) const noexcept;
 /// template specialization for std::string
-template Status FileSystem::WriteValueToFile<IdType>(const IdType&,
-                                                     const std::string&) const
-    noexcept;
+template Status FileSystem::WriteValueToFile<IdType>(
+    const IdType&, const std::string&) const noexcept;
 }  // namespace graphar

--- a/cpp/src/graphar/filesystem.h
+++ b/cpp/src/graphar/filesystem.h
@@ -104,8 +104,8 @@ class FileSystem {
    * @return A Status indicating OK if successful, or an error if unsuccessful.
    */
   template <typename T>
-  Status WriteValueToFile(const T& value, const std::string& path) const
-      noexcept;
+  Status WriteValueToFile(const T& value,
+                          const std::string& path) const noexcept;
 
   /**
    * @brief Write a table to a file with a specific type.
@@ -115,10 +115,10 @@ class FileSystem {
    * @param options Options for writing the table, such as compression.
    * @return A Status indicating OK if successful, or an error if unsuccessful.
    */
-  Status WriteTableToFile(const std::shared_ptr<arrow::Table>& table,
-                          FileType file_type, const std::string& path,
-                          const std::shared_ptr<WriterOptions>& options) const
-      noexcept;
+  Status WriteTableToFile(
+      const std::shared_ptr<arrow::Table>& table, FileType file_type,
+      const std::string& path,
+      const std::shared_ptr<WriterOptions>& options) const noexcept;
 
   /**
    * @brief Write a label table to a file with parquet type.

--- a/maven-projects/java/src/main/cpp/ffi/jni_org_apache_graphar_arrow_ArrowTableStatic.cc
+++ b/maven-projects/java/src/main/cpp/ffi/jni_org_apache_graphar_arrow_ArrowTableStatic.cc
@@ -17,11 +17,11 @@
  * under the License.
  */
 
-#include <jni.h>
-#include <new>
-#include <iostream>
 #include "arrow/api.h"
 #include "arrow/c/bridge.h"
+#include <iostream>
+#include <jni.h>
+#include <new>
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,10 +30,16 @@ extern "C" {
 // Common Stubs
 
 JNIEXPORT
-jlong JNICALL Java_org_apache_graphar_arrow_ArrowTable_1Static_1cxx_10x58c7409_nativeFromArrowArrayAndArrowSchema(JNIEnv*, jclass, jlong rv_base, jlong arg0 /* arrayAddress0 */, jlong arg1 /* schemaAddress1 */) {
-    auto maybeRecordBatch = arrow::ImportRecordBatch(reinterpret_cast<struct ArrowArray*>(arg0), reinterpret_cast<struct ArrowSchema*>(arg1));
-    auto table = arrow::Table::FromRecordBatches({maybeRecordBatch.ValueOrDie()});
-	return reinterpret_cast<jlong>(new((void*)rv_base) arrow::Result<std::shared_ptr<arrow::Table>>(table));
+jlong JNICALL
+Java_org_apache_graphar_arrow_ArrowTable_1Static_1cxx_10x58c7409_nativeFromArrowArrayAndArrowSchema(
+    JNIEnv *, jclass, jlong rv_base, jlong arg0 /* arrayAddress0 */,
+    jlong arg1 /* schemaAddress1 */) {
+  auto maybeRecordBatch =
+      arrow::ImportRecordBatch(reinterpret_cast<struct ArrowArray *>(arg0),
+                               reinterpret_cast<struct ArrowSchema *>(arg1));
+  auto table = arrow::Table::FromRecordBatches({maybeRecordBatch.ValueOrDie()});
+  return reinterpret_cast<jlong>(new (
+      (void *)rv_base) arrow::Result<std::shared_ptr<arrow::Table>>(table));
 }
 
 #ifdef __cplusplus

--- a/python/src/bindings/high_level_binding.cc
+++ b/python/src/bindings/high_level_binding.cc
@@ -34,288 +34,385 @@ namespace py = pybind11;
 
 // Changed from PYBIND11_MODULE to a regular function
 extern "C" void bind_high_level_api(pybind11::module_& m) {
-    // Bind Vertex class
-    auto vertex = py::class_<graphar::Vertex, std::shared_ptr<graphar::Vertex>>(m, "Vertex");
-    vertex.def("id", &graphar::Vertex::id)
-        .def("property", [](const graphar::Vertex& self, const std::string& property) {
-            // We need to handle different property types
-            // For now, let's support common types used in examples
-            try {
-                return py::cast(self.property<int64_t>(property).value());
-            } catch (...) {
-                try {
-                    return py::cast(self.property<std::string>(property).value());
-                } catch (...) {
-                    throw std::runtime_error("Unsupported property type or property not found");
-                }
-            }
-        })
-        .def("IsValid", &graphar::Vertex::IsValid);
+  // Bind Vertex class
+  auto vertex = py::class_<graphar::Vertex, std::shared_ptr<graphar::Vertex>>(
+      m, "Vertex");
+  vertex.def("id", &graphar::Vertex::id)
+      .def("property",
+           [](const graphar::Vertex& self, const std::string& property) {
+             // We need to handle different property types
+             // For now, let's support common types used in examples
+             try {
+               return py::cast(self.property<int64_t>(property).value());
+             } catch (...) {
+               try {
+                 return py::cast(self.property<std::string>(property).value());
+               } catch (...) {
+                 throw std::runtime_error(
+                     "Unsupported property type or property not found");
+               }
+             }
+           })
+      .def("IsValid", &graphar::Vertex::IsValid);
 
-    // Bind Edge class
-    auto edge = py::class_<graphar::Edge, std::shared_ptr<graphar::Edge>>(m, "Edge");
-    edge.def("source", &graphar::Edge::source)
-        .def("destination", &graphar::Edge::destination)
-        .def("property", [](const graphar::Edge& self, const std::string& property) {
-            // We need to handle different property types
-            // For now, let's support common types used in examples
-            try {
-                return py::cast(self.property<std::string>(property).value());
-            } catch (...) {
-                try {
-                    return py::cast(self.property<int64_t>(property).value());
-                } catch (...) {
-                    throw std::runtime_error("Unsupported property type or property not found");
-                }
-            }
-        })
-        .def("IsValid", &graphar::Edge::IsValid);
+  // Bind Edge class
+  auto edge =
+      py::class_<graphar::Edge, std::shared_ptr<graphar::Edge>>(m, "Edge");
+  edge.def("source", &graphar::Edge::source)
+      .def("destination", &graphar::Edge::destination)
+      .def("property",
+           [](const graphar::Edge& self, const std::string& property) {
+             // We need to handle different property types
+             // For now, let's support common types used in examples
+             try {
+               return py::cast(self.property<std::string>(property).value());
+             } catch (...) {
+               try {
+                 return py::cast(self.property<int64_t>(property).value());
+               } catch (...) {
+                 throw std::runtime_error(
+                     "Unsupported property type or property not found");
+               }
+             }
+           })
+      .def("IsValid", &graphar::Edge::IsValid);
 
-    // Bind VertexIter class
-    auto vertex_iter = py::class_<graphar::VertexIter, std::shared_ptr<graphar::VertexIter>>(m, "VertexIter");
-    vertex_iter.def("__iter__", [](graphar::VertexIter& it) -> graphar::VertexIter& { return it; })
-        .def("__next__", [](graphar::VertexIter& it) {
-            // TODO: Implement proper end checking
-            auto vertex = *it;
-            ++it;
-            return vertex;
-        })
-        .def("id", &graphar::VertexIter::id)
-        .def("property", [](graphar::VertexIter& self, const std::string& property) {
-            // We need to handle different property types
-            // For now, let's support common types used in examples
-            try {
-                return py::cast(self.property<int64_t>(property).value());
-            } catch (...) {
-                try {
-                    return py::cast(self.property<std::string>(property).value());
-                } catch (...) {
-                    throw std::runtime_error("Unsupported property type or property not found");
-                }
-            }
-        });
+  // Bind VertexIter class
+  auto vertex_iter =
+      py::class_<graphar::VertexIter, std::shared_ptr<graphar::VertexIter>>(
+          m, "VertexIter");
+  vertex_iter
+      .def("__iter__",
+           [](graphar::VertexIter& it) -> graphar::VertexIter& { return it; })
+      .def("__next__",
+           [](graphar::VertexIter& it) {
+             // TODO: Implement proper end checking
+             auto vertex = *it;
+             ++it;
+             return vertex;
+           })
+      .def("id", &graphar::VertexIter::id)
+      .def("property",
+           [](graphar::VertexIter& self, const std::string& property) {
+             // We need to handle different property types
+             // For now, let's support common types used in examples
+             try {
+               return py::cast(self.property<int64_t>(property).value());
+             } catch (...) {
+               try {
+                 return py::cast(self.property<std::string>(property).value());
+               } catch (...) {
+                 throw std::runtime_error(
+                     "Unsupported property type or property not found");
+               }
+             }
+           });
 
-    // Bind VerticesCollection class
-    auto vertices_collection = py::class_<graphar::VerticesCollection,
-                                     std::shared_ptr<graphar::VerticesCollection>>(m, "VerticesCollection");
-    vertices_collection.def("__iter__", [](graphar::VerticesCollection& self) {
+  // Bind VerticesCollection class
+  auto vertices_collection =
+      py::class_<graphar::VerticesCollection,
+                 std::shared_ptr<graphar::VerticesCollection>>(
+          m, "VerticesCollection");
+  vertices_collection
+      .def(
+          "__iter__",
+          [](graphar::VerticesCollection& self) {
             return py::make_iterator(self.begin(), self.end());
-        }, py::keep_alive<0, 1>()) // Keep collection alive while iterator is used
-        .def("begin", &graphar::VerticesCollection::begin)
-        .def("end", &graphar::VerticesCollection::end)
-        .def("find", &graphar::VerticesCollection::find)
-        .def("size", &graphar::VerticesCollection::size)
-        .def_static("Make", [](const std::shared_ptr<graphar::GraphInfo>& graph_info, const std::string& type) {
+          },
+          py::keep_alive<0,
+                         1>())  // Keep collection alive while iterator is used
+      .def("begin", &graphar::VerticesCollection::begin)
+      .def("end", &graphar::VerticesCollection::end)
+      .def("find", &graphar::VerticesCollection::find)
+      .def("size", &graphar::VerticesCollection::size)
+      .def_static(
+          "Make", [](const std::shared_ptr<graphar::GraphInfo>& graph_info,
+                     const std::string& type) {
             auto result = graphar::VerticesCollection::Make(graph_info, type);
             return ThrowOrReturn(result);
-        });
+          });
 
-    // Bind EdgeIter class
-    auto edge_iter = py::class_<graphar::EdgeIter, std::shared_ptr<graphar::EdgeIter>>(m, "EdgeIter");
-    edge_iter.def("__iter__", [](graphar::EdgeIter& it) -> graphar::EdgeIter& { return it; })
-        .def("__next__", [](graphar::EdgeIter& it) {
-            // TODO: Implement proper end checking
-            auto edge = *it;
-            ++it;
-            return edge;
-        })
-        .def("source", &graphar::EdgeIter::source)
-        .def("destination", &graphar::EdgeIter::destination)
-        .def("property", [](graphar::EdgeIter& self, const std::string& property) {
-            // We need to handle different property types
-            // For now, let's support common types used in examples
-            try {
-                return py::cast(self.property<std::string>(property).value());
-            } catch (...) {
-                try {
-                    return py::cast(self.property<int64_t>(property).value());
-                } catch (...) {
-                    throw std::runtime_error("Unsupported property type or property not found");
-                }
-            }
-        });
+  // Bind EdgeIter class
+  auto edge_iter =
+      py::class_<graphar::EdgeIter, std::shared_ptr<graphar::EdgeIter>>(
+          m, "EdgeIter");
+  edge_iter
+      .def("__iter__",
+           [](graphar::EdgeIter& it) -> graphar::EdgeIter& { return it; })
+      .def("__next__",
+           [](graphar::EdgeIter& it) {
+             // TODO: Implement proper end checking
+             auto edge = *it;
+             ++it;
+             return edge;
+           })
+      .def("source", &graphar::EdgeIter::source)
+      .def("destination", &graphar::EdgeIter::destination)
+      .def("property",
+           [](graphar::EdgeIter& self, const std::string& property) {
+             // We need to handle different property types
+             // For now, let's support common types used in examples
+             try {
+               return py::cast(self.property<std::string>(property).value());
+             } catch (...) {
+               try {
+                 return py::cast(self.property<int64_t>(property).value());
+               } catch (...) {
+                 throw std::runtime_error(
+                     "Unsupported property type or property not found");
+               }
+             }
+           });
 
-    // Bind EdgesCollection class
-    auto edges_collection = py::class_<graphar::EdgesCollection,
-                                     std::shared_ptr<graphar::EdgesCollection>>(m, "EdgesCollection");
-    edges_collection.def("__iter__", [](graphar::EdgesCollection& self) {
+  // Bind EdgesCollection class
+  auto edges_collection = py::class_<graphar::EdgesCollection,
+                                     std::shared_ptr<graphar::EdgesCollection>>(
+      m, "EdgesCollection");
+  edges_collection
+      .def(
+          "__iter__",
+          [](graphar::EdgesCollection& self) {
             return py::make_iterator(self.begin(), self.end());
-        }, py::keep_alive<0, 1>()) // Keep collection alive while iterator is used
-        .def("begin", &graphar::EdgesCollection::begin)
-        .def("end", &graphar::EdgesCollection::end)
-        .def("size", &graphar::EdgesCollection::size)
-        .def("find_src", &graphar::EdgesCollection::find_src)
-        .def("find_dst", &graphar::EdgesCollection::find_dst)
-        .def_static("Make",  [](const std::shared_ptr<graphar::GraphInfo>& graph_info, 
-                              const std::string& src_type,
-                              const std::string& edge_type,
-                              const std::string& dst_type,
-                              graphar::AdjListType adj_list_type) {
-            auto result = graphar::EdgesCollection::Make(graph_info, src_type, edge_type, dst_type, adj_list_type);
+          },
+          py::keep_alive<0,
+                         1>())  // Keep collection alive while iterator is used
+      .def("begin", &graphar::EdgesCollection::begin)
+      .def("end", &graphar::EdgesCollection::end)
+      .def("size", &graphar::EdgesCollection::size)
+      .def("find_src", &graphar::EdgesCollection::find_src)
+      .def("find_dst", &graphar::EdgesCollection::find_dst)
+      .def_static(
+          "Make",
+          [](const std::shared_ptr<graphar::GraphInfo>& graph_info,
+             const std::string& src_type, const std::string& edge_type,
+             const std::string& dst_type, graphar::AdjListType adj_list_type) {
+            auto result = graphar::EdgesCollection::Make(
+                graph_info, src_type, edge_type, dst_type, adj_list_type);
             return ThrowOrReturn(result);
-        });
+          });
 
-    // Bind builder::Vertex class
-    auto builder_vertex = py::class_<graphar::builder::Vertex, std::shared_ptr<graphar::builder::Vertex>>(m, "BuilderVertex");
-    builder_vertex.def(py::init<>())
-        .def(py::init<graphar::IdType>())
-        .def("GetId", &graphar::builder::Vertex::GetId)
-        .def("SetId", &graphar::builder::Vertex::SetId)
-        .def("Empty", &graphar::builder::Vertex::Empty)
-        .def("AddProperty", [](graphar::builder::Vertex& self, const std::string& name, const py::object& val) {
-            // Convert Python object to std::any
-            if (py::isinstance<py::int_>(val)) {
-                self.AddProperty(name, py::cast<int64_t>(val));
-            } else if (py::isinstance<py::str>(val)) {
-                self.AddProperty(name, py::cast<std::string>(val));
-            } else if (py::isinstance<py::list>(val)) {
-                // Handle list properties
-                py::list py_list = val.cast<py::list>();
-                std::vector<std::string> string_list;
-                for (auto item : py_list) {
-                    string_list.push_back(py::str(item).cast<std::string>());
-                }
-                self.AddProperty(graphar::Cardinality::LIST, name, string_list);
-            } else {
-                throw std::runtime_error("Unsupported property type");
-            }
-        })
-        .def("GetProperty", [](const graphar::builder::Vertex& self, const std::string& property) {
-            const auto& prop = self.GetProperty(property);
-            // Try to cast to common types
-            try {
-                return py::cast(std::any_cast<int64_t>(prop));
-            } catch (...) {
-                try {
-                    return py::cast(std::any_cast<std::string>(prop));
-                } catch (...) {
-                    throw std::runtime_error("Unsupported property type");
-                }
-            }
-        })
-        .def("GetProperties", &graphar::builder::Vertex::GetProperties)
-        .def("ContainProperty", &graphar::builder::Vertex::ContainProperty);
+  // Bind builder::Vertex class
+  auto builder_vertex =
+      py::class_<graphar::builder::Vertex,
+                 std::shared_ptr<graphar::builder::Vertex>>(m, "BuilderVertex");
+  builder_vertex.def(py::init<>())
+      .def(py::init<graphar::IdType>())
+      .def("GetId", &graphar::builder::Vertex::GetId)
+      .def("SetId", &graphar::builder::Vertex::SetId)
+      .def("Empty", &graphar::builder::Vertex::Empty)
+      .def("AddProperty",
+           [](graphar::builder::Vertex& self, const std::string& name,
+              const py::object& val) {
+             // Convert Python object to std::any
+             if (py::isinstance<py::int_>(val)) {
+               self.AddProperty(name, py::cast<int64_t>(val));
+             } else if (py::isinstance<py::str>(val)) {
+               self.AddProperty(name, py::cast<std::string>(val));
+             } else if (py::isinstance<py::list>(val)) {
+               // Handle list properties
+               py::list py_list = val.cast<py::list>();
+               std::vector<std::string> string_list;
+               for (auto item : py_list) {
+                 string_list.push_back(py::str(item).cast<std::string>());
+               }
+               self.AddProperty(graphar::Cardinality::LIST, name, string_list);
+             } else {
+               throw std::runtime_error("Unsupported property type");
+             }
+           })
+      .def("GetProperty",
+           [](const graphar::builder::Vertex& self,
+              const std::string& property) {
+             const auto& prop = self.GetProperty(property);
+             // Try to cast to common types
+             try {
+               return py::cast(std::any_cast<int64_t>(prop));
+             } catch (...) {
+               try {
+                 return py::cast(std::any_cast<std::string>(prop));
+               } catch (...) {
+                 throw std::runtime_error("Unsupported property type");
+               }
+             }
+           })
+      .def("GetProperties", &graphar::builder::Vertex::GetProperties)
+      .def("ContainProperty", &graphar::builder::Vertex::ContainProperty);
 
-    //WRITER
-    // Bind WriterOptions class
-    //TODO add csv_option_builder parquet_option_builder orc_option_builder
-    auto writer_options = py::class_<graphar::WriterOptions, std::shared_ptr<graphar::WriterOptions>>(m, "WriterOptions");
-    // Bind builder::VerticesBuilder class
-    auto vertices_builder = py::class_<graphar::builder::VerticesBuilder, std::shared_ptr<graphar::builder::VerticesBuilder>>(m, "VerticesBuilder");
-    vertices_builder.def("Clear", &graphar::builder::VerticesBuilder::Clear)
-        .def("SetWriterOptions", &graphar::builder::VerticesBuilder::SetWriterOptions)
-        .def("GetWriterOptions", &graphar::builder::VerticesBuilder::GetWriterOptions)
-        .def("SetValidateLevel", &graphar::builder::VerticesBuilder::SetValidateLevel)
-        .def("GetValidateLevel", &graphar::builder::VerticesBuilder::GetValidateLevel)
-        .def("AddVertex", [](graphar::builder::VerticesBuilder& self, graphar::builder::Vertex& v, 
-                             graphar::IdType index, const graphar::ValidateLevel& validate_level) {
+  // WRITER
+  //  Bind WriterOptions class
+  // TODO add csv_option_builder parquet_option_builder orc_option_builder
+  auto writer_options =
+      py::class_<graphar::WriterOptions,
+                 std::shared_ptr<graphar::WriterOptions>>(m, "WriterOptions");
+  // Bind builder::VerticesBuilder class
+  auto vertices_builder =
+      py::class_<graphar::builder::VerticesBuilder,
+                 std::shared_ptr<graphar::builder::VerticesBuilder>>(
+          m, "VerticesBuilder");
+  vertices_builder.def("Clear", &graphar::builder::VerticesBuilder::Clear)
+      .def("SetWriterOptions",
+           &graphar::builder::VerticesBuilder::SetWriterOptions)
+      .def("GetWriterOptions",
+           &graphar::builder::VerticesBuilder::GetWriterOptions)
+      .def("SetValidateLevel",
+           &graphar::builder::VerticesBuilder::SetValidateLevel)
+      .def("GetValidateLevel",
+           &graphar::builder::VerticesBuilder::GetValidateLevel)
+      .def(
+          "AddVertex",
+          [](graphar::builder::VerticesBuilder& self,
+             graphar::builder::Vertex& v, graphar::IdType index,
+             const graphar::ValidateLevel& validate_level) {
             return CheckStatus(self.AddVertex(v, index, validate_level));
-        }, py::arg("v"), py::arg("index") = -1, py::arg("validate_level") = graphar::ValidateLevel::default_validate)
-        .def("GetNum", &graphar::builder::VerticesBuilder::GetNum)
-        .def("Dump", [](graphar::builder::VerticesBuilder& self) {
-            return CheckStatus(self.Dump());
-        });
+          },
+          py::arg("v"), py::arg("index") = -1,
+          py::arg("validate_level") = graphar::ValidateLevel::default_validate)
+      .def("GetNum", &graphar::builder::VerticesBuilder::GetNum)
+      .def("Dump", [](graphar::builder::VerticesBuilder& self) {
+        return CheckStatus(self.Dump());
+      });
 
-    // Static factory methods for VerticesBuilder
-    vertices_builder.def_static("Make", [](const std::shared_ptr<graphar::VertexInfo>& vertex_info, 
-                                           const std::string& prefix,
-                                           std::shared_ptr<graphar::WriterOptions> writer_options,
-                                           graphar::IdType start_vertex_index,
-                                           const graphar::ValidateLevel& validate_level) {
-        auto result = graphar::builder::VerticesBuilder::Make(vertex_info, prefix, writer_options, start_vertex_index, validate_level);
+  // Static factory methods for VerticesBuilder
+  vertices_builder.def_static(
+      "Make",
+      [](const std::shared_ptr<graphar::VertexInfo>& vertex_info,
+         const std::string& prefix,
+         std::shared_ptr<graphar::WriterOptions> writer_options,
+         graphar::IdType start_vertex_index,
+         const graphar::ValidateLevel& validate_level) {
+        auto result = graphar::builder::VerticesBuilder::Make(
+            vertex_info, prefix, writer_options, start_vertex_index,
+            validate_level);
         return ThrowOrReturn(result);
-    }, py::arg("vertex_info"), py::arg("prefix"), py::arg("writer_options") = nullptr, 
-       py::arg("start_vertex_index") = 0, py::arg("validate_level") = graphar::ValidateLevel::no_validate);
+      },
+      py::arg("vertex_info"), py::arg("prefix"),
+      py::arg("writer_options") = nullptr, py::arg("start_vertex_index") = 0,
+      py::arg("validate_level") = graphar::ValidateLevel::no_validate);
 
-    vertices_builder.def_static("Make", [](const std::shared_ptr<graphar::GraphInfo>& graph_info, 
-                                           const std::string& type,
-                                           std::shared_ptr<graphar::WriterOptions> writer_options,
-                                           graphar::IdType start_vertex_index,
-                                           const graphar::ValidateLevel& validate_level) {
-        auto result = graphar::builder::VerticesBuilder::Make(graph_info, type, writer_options, start_vertex_index, validate_level);
+  vertices_builder.def_static(
+      "Make",
+      [](const std::shared_ptr<graphar::GraphInfo>& graph_info,
+         const std::string& type,
+         std::shared_ptr<graphar::WriterOptions> writer_options,
+         graphar::IdType start_vertex_index,
+         const graphar::ValidateLevel& validate_level) {
+        auto result = graphar::builder::VerticesBuilder::Make(
+            graph_info, type, writer_options, start_vertex_index,
+            validate_level);
         return ThrowOrReturn(result);
-    }, py::arg("graph_info"), py::arg("type"), py::arg("writer_options") = nullptr, 
-       py::arg("start_vertex_index") = 0, py::arg("validate_level") = graphar::ValidateLevel::no_validate);
-    vertices_builder.def_static("Make", [](const std::shared_ptr<graphar::VertexInfo>& vertex_info, 
-                                           const std::string& prefix,
-                                           graphar::IdType start_vertex_index) {
-        auto result = graphar::builder::VerticesBuilder::Make(vertex_info, prefix, start_vertex_index);
+      },
+      py::arg("graph_info"), py::arg("type"),
+      py::arg("writer_options") = nullptr, py::arg("start_vertex_index") = 0,
+      py::arg("validate_level") = graphar::ValidateLevel::no_validate);
+  vertices_builder.def_static(
+      "Make",
+      [](const std::shared_ptr<graphar::VertexInfo>& vertex_info,
+         const std::string& prefix, graphar::IdType start_vertex_index) {
+        auto result = graphar::builder::VerticesBuilder::Make(
+            vertex_info, prefix, start_vertex_index);
         return ThrowOrReturn(result);
-    }, py::arg("vertex_info"), py::arg("prefix"), py::arg("start_vertex_index") = 0);
+      },
+      py::arg("vertex_info"), py::arg("prefix"),
+      py::arg("start_vertex_index") = 0);
 
-    // Bind builder::Edge class
-    auto builder_edge = py::class_<graphar::builder::Edge, std::shared_ptr<graphar::builder::Edge>>(m, "BuilderEdge");
-    builder_edge.def(py::init<graphar::IdType, graphar::IdType>())
-        .def("Empty", &graphar::builder::Edge::Empty)
-        .def("GetSource", &graphar::builder::Edge::GetSource)
-        .def("GetDestination", &graphar::builder::Edge::GetDestination)
-        .def("AddProperty", [](graphar::builder::Edge& self, const std::string& name, const py::object& val) {
-            // Convert Python object to std::any
-            if (py::isinstance<py::int_>(val)) {
-                self.AddProperty(name, py::cast<int64_t>(val));
-            } else if (py::isinstance<py::str>(val)) {
-                self.AddProperty(name, py::cast<std::string>(val));
-            } else {
-                throw std::runtime_error("Unsupported property type");
-            }
-        })
-        .def("GetProperty", [](const graphar::builder::Edge& self, const std::string& property) {
-            const auto& prop = self.GetProperty(property);
-            // Try to cast to common types
-            try {
-                return py::cast(std::any_cast<std::string>(prop));
-            } catch (...) {
-                try {
-                    return py::cast(std::any_cast<int64_t>(prop));
-                } catch (...) {
-                    throw std::runtime_error("Unsupported property type");
-                }
-            }
-        })
-        .def("GetProperties", &graphar::builder::Edge::GetProperties)
-        .def("ContainProperty", &graphar::builder::Edge::ContainProperty);
+  // Bind builder::Edge class
+  auto builder_edge =
+      py::class_<graphar::builder::Edge,
+                 std::shared_ptr<graphar::builder::Edge>>(m, "BuilderEdge");
+  builder_edge.def(py::init<graphar::IdType, graphar::IdType>())
+      .def("Empty", &graphar::builder::Edge::Empty)
+      .def("GetSource", &graphar::builder::Edge::GetSource)
+      .def("GetDestination", &graphar::builder::Edge::GetDestination)
+      .def("AddProperty",
+           [](graphar::builder::Edge& self, const std::string& name,
+              const py::object& val) {
+             // Convert Python object to std::any
+             if (py::isinstance<py::int_>(val)) {
+               self.AddProperty(name, py::cast<int64_t>(val));
+             } else if (py::isinstance<py::str>(val)) {
+               self.AddProperty(name, py::cast<std::string>(val));
+             } else {
+               throw std::runtime_error("Unsupported property type");
+             }
+           })
+      .def("GetProperty",
+           [](const graphar::builder::Edge& self, const std::string& property) {
+             const auto& prop = self.GetProperty(property);
+             // Try to cast to common types
+             try {
+               return py::cast(std::any_cast<std::string>(prop));
+             } catch (...) {
+               try {
+                 return py::cast(std::any_cast<int64_t>(prop));
+               } catch (...) {
+                 throw std::runtime_error("Unsupported property type");
+               }
+             }
+           })
+      .def("GetProperties", &graphar::builder::Edge::GetProperties)
+      .def("ContainProperty", &graphar::builder::Edge::ContainProperty);
 
-    // Bind builder::EdgesBuilder class
-    auto edges_builder = py::class_<graphar::builder::EdgesBuilder, std::shared_ptr<graphar::builder::EdgesBuilder>>(m, "EdgesBuilder");
-    edges_builder
-        .def("SetValidateLevel", &graphar::builder::EdgesBuilder::SetValidateLevel)
-        .def("SetWriterOptions", &graphar::builder::EdgesBuilder::SetWriterOptions)
-        .def("GetWriterOptions", &graphar::builder::EdgesBuilder::GetWriterOptions)
-        .def("GetValidateLevel", &graphar::builder::EdgesBuilder::GetValidateLevel)
-        .def("Clear", &graphar::builder::EdgesBuilder::Clear)
-        .def("AddEdge", [](graphar::builder::EdgesBuilder& self, 
-                           const graphar::builder::Edge& e,
-                           const graphar::ValidateLevel& validate_level) {
+  // Bind builder::EdgesBuilder class
+  auto edges_builder =
+      py::class_<graphar::builder::EdgesBuilder,
+                 std::shared_ptr<graphar::builder::EdgesBuilder>>(
+          m, "EdgesBuilder");
+  edges_builder
+      .def("SetValidateLevel",
+           &graphar::builder::EdgesBuilder::SetValidateLevel)
+      .def("SetWriterOptions",
+           &graphar::builder::EdgesBuilder::SetWriterOptions)
+      .def("GetWriterOptions",
+           &graphar::builder::EdgesBuilder::GetWriterOptions)
+      .def("GetValidateLevel",
+           &graphar::builder::EdgesBuilder::GetValidateLevel)
+      .def("Clear", &graphar::builder::EdgesBuilder::Clear)
+      .def(
+          "AddEdge",
+          [](graphar::builder::EdgesBuilder& self,
+             const graphar::builder::Edge& e,
+             const graphar::ValidateLevel& validate_level) {
             return CheckStatus(self.AddEdge(e, validate_level));
-        }, py::arg("e"), py::arg("validate_level") = graphar::ValidateLevel::default_validate)
-        .def("GetNum", &graphar::builder::EdgesBuilder::GetNum)
-        .def("Dump", [](graphar::builder::EdgesBuilder& self) {
-            return CheckStatus(self.Dump());
-        });
+          },
+          py::arg("e"),
+          py::arg("validate_level") = graphar::ValidateLevel::default_validate)
+      .def("GetNum", &graphar::builder::EdgesBuilder::GetNum)
+      .def("Dump", [](graphar::builder::EdgesBuilder& self) {
+        return CheckStatus(self.Dump());
+      });
 
-    // Static factory methods for EdgesBuilder
-    edges_builder.def_static("Make", [](const std::shared_ptr<graphar::EdgeInfo>& edge_info,
-                                        const std::string& prefix,
-                                        graphar::AdjListType adj_list_type,
-                                        graphar::IdType num_vertices,
-                                        std::shared_ptr<graphar::WriterOptions> writer_options,
-                                        const graphar::ValidateLevel& validate_level) {
-        auto result = graphar::builder::EdgesBuilder::Make(edge_info, prefix, adj_list_type, num_vertices, writer_options, validate_level);
+  // Static factory methods for EdgesBuilder
+  edges_builder.def_static(
+      "Make",
+      [](const std::shared_ptr<graphar::EdgeInfo>& edge_info,
+         const std::string& prefix, graphar::AdjListType adj_list_type,
+         graphar::IdType num_vertices,
+         std::shared_ptr<graphar::WriterOptions> writer_options,
+         const graphar::ValidateLevel& validate_level) {
+        auto result = graphar::builder::EdgesBuilder::Make(
+            edge_info, prefix, adj_list_type, num_vertices, writer_options,
+            validate_level);
         return ThrowOrReturn(result);
-    }, py::arg("edge_info"), py::arg("prefix"), py::arg("adj_list_type"), py::arg("num_vertices"),
-       py::arg("writer_options") = nullptr, py::arg("validate_level") = graphar::ValidateLevel::no_validate);
+      },
+      py::arg("edge_info"), py::arg("prefix"), py::arg("adj_list_type"),
+      py::arg("num_vertices"), py::arg("writer_options") = nullptr,
+      py::arg("validate_level") = graphar::ValidateLevel::no_validate);
 
-    edges_builder.def_static("Make", [](const std::shared_ptr<graphar::GraphInfo>& graph_info,
-                                        const std::string& src_type,
-                                        const std::string& edge_type,
-                                        const std::string& dst_type,
-                                        const graphar::AdjListType& adj_list_type,
-                                        graphar::IdType num_vertices,
-                                        std::shared_ptr<graphar::WriterOptions> writer_options,
-                                        const graphar::ValidateLevel& validate_level) {
-        auto result = graphar::builder::EdgesBuilder::Make(graph_info, src_type, edge_type, dst_type, adj_list_type, num_vertices, writer_options, validate_level);
+  edges_builder.def_static(
+      "Make",
+      [](const std::shared_ptr<graphar::GraphInfo>& graph_info,
+         const std::string& src_type, const std::string& edge_type,
+         const std::string& dst_type, const graphar::AdjListType& adj_list_type,
+         graphar::IdType num_vertices,
+         std::shared_ptr<graphar::WriterOptions> writer_options,
+         const graphar::ValidateLevel& validate_level) {
+        auto result = graphar::builder::EdgesBuilder::Make(
+            graph_info, src_type, edge_type, dst_type, adj_list_type,
+            num_vertices, writer_options, validate_level);
         return ThrowOrReturn(result);
-    }, py::arg("graph_info"), py::arg("src_type"), py::arg("edge_type"), py::arg("dst_type"),
-       py::arg("adj_list_type"), py::arg("num_vertices"), py::arg("writer_options") = nullptr,
-       py::arg("validate_level") = graphar::ValidateLevel::no_validate);
+      },
+      py::arg("graph_info"), py::arg("src_type"), py::arg("edge_type"),
+      py::arg("dst_type"), py::arg("adj_list_type"), py::arg("num_vertices"),
+      py::arg("writer_options") = nullptr,
+      py::arg("validate_level") = graphar::ValidateLevel::no_validate);
 }  // namespace graphar

--- a/python/src/bindings/types_binding.cc
+++ b/python/src/bindings/types_binding.cc
@@ -66,13 +66,13 @@ extern "C" void bind_types(pybind11::module_& m) {
       .value("LIST", graphar::Cardinality::LIST)
       .value("SET", graphar::Cardinality::SET)
       .export_values();
-      
-    // Bind ValidateLevel enum
+
+  // Bind ValidateLevel enum
   py::enum_<graphar::ValidateLevel>(m, "ValidateLevel")
       .value("default_validate", graphar::ValidateLevel::default_validate)
       .value("no_validate", graphar::ValidateLevel::no_validate)
       .value("weak_validate", graphar::ValidateLevel::weak_validate)
       .value("strong_validate", graphar::ValidateLevel::strong_validate)
       .export_values();
-    
+
 }  // namespace graphar


### PR DESCRIPTION


<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
Currently there are some files(`.cpp/.h`) not incorperate into the graphar-clformat checklist, such as python/rust directories.

```cpp
file(GLOB_RECURSE FILES_NEED_FORMAT "src/graphar/*.h" "src/graphar/*.cc"
                                    "test/*.h" "test/*.cc"
                                    "examples/*.h" "examples/*.cc"
                                    "benchmarks/*.h" "benchmarks/*.cc")
file(GLOB_RECURSE FILES_NEED_LINT "src/graphar/*.h" "src/graphar/*.cc"
                                  "test/*.h" "test/*.cc"
                                  "examples/*.h" "examples/*.cc"
                                  "benchmarks/*.h" "benchmarks/*.cc")

add_custom_target(graphar-clformat
                  COMMAND clang-format --style=file -i ${FILES_NEED_FORMAT}
                  COMMENT "Running clang-format."
                  VERBATIM)
```

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Make the pre-commit check all `.cpp/.cc/.h/.hpp` directly.

2. Fix all not format files automatically by `pre-commit run clang-format -a`

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
