### PR TITLE
feat: Added Rust pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,3 +88,20 @@ repos:
         files: ^maven-projects/spark/
         pass_filenames: false
         require_serial: true
+
+      - id: cargo-fmt
+        name: Rust cargo fmt
+        entry: bash -c 'cd rust && cargo fmt --all'
+        language: system
+        files: ^rust/.*\.(rs|toml|lock)$
+        pass_filenames: false
+        require_serial: true
+
+      - id: cargo-clippy
+        name: Rust cargo clippy
+        entry: bash -c 'cd rust && cargo clippy --all-targets --all-features -- -D warnings'
+        language: system
+        files: ^rust/.*\.(rs|toml|lock)$
+        pass_filenames: false
+        require_serial: true
+        stages: [manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,7 +93,7 @@ repos:
         name: Rust cargo fmt
         entry: bash -c 'cd rust && cargo fmt --all'
         language: system
-        files: ^rust/.*\.(rs|toml|lock)$
+        files: ^rust/.*\.rs$
         pass_filenames: false
         require_serial: true
 


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
--> 
This PR addresses the request to add missing Rust pre-commit hooks to the repository. The project already includes pre-commit checks for other languages, but Rust tooling was not yet covered. Adding these hooks helps keep Rust code formatted consistently and improves development workflow.

This work is related to issue #753.

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Added a Rust cargo fmt pre-commit hook for consistent formatting
Added a Rust cargo clippy hook which I configured as manual to surface lint warnings without blocking commits

### Are these changes tested?
<!-- 
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes the changes were tested. The cargo fmt hook was run locally to verify formatting behavior.
The cargo clippy hook was verified to run correctly and is configured as a manual hook due to platform-specific build dependencies.
### Are there any user-facing changes?

No. These changes only affect development tooling and do not impact end users or public APIs.


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
