### PR TITLE
fix(C++): fix all enumerations to use strongly-typed enums (enum class)

### DIFF
--- a/cpp/src/graphar/filesystem.cc
+++ b/cpp/src/graphar/filesystem.cc
@@ -96,14 +96,14 @@ namespace ds = arrow::dataset;
 std::shared_ptr<ds::FileFormat> FileSystem::GetFileFormat(
     const FileType type) const {
   switch (type) {
-  case CSV:
+  case FileType::CSV:
     return std::make_shared<ds::CsvFileFormat>();
-  case PARQUET:
+  case FileType::PARQUET:
     return std::make_shared<ds::ParquetFileFormat>();
-  case JSON:
+  case FileType::JSON:
     return std::make_shared<ds::JsonFileFormat>();
 #ifdef ARROW_ORC
-  case ORC:
+  case FileType::ORC:
     return std::make_shared<ds::OrcFileFormat>();
 #endif
   default:

--- a/cpp/src/graphar/fwd.h
+++ b/cpp/src/graphar/fwd.h
@@ -72,12 +72,12 @@ class FileSystem;
 using IdType = int64_t;
 class DataType;
 /** Defines how multiple values are handled for a given property key */
-enum Cardinality : int32_t { SINGLE, LIST, SET };
+enum class Cardinality : int32_t { SINGLE, LIST, SET };
 /** Type of file format */
-enum FileType : int32_t { CSV = 0, PARQUET = 1, ORC = 2, JSON = 3 };
-enum SelectType : int32_t { PROPERTIES = 0, LABELS = 1 };
+enum class FileType : int32_t { CSV = 0, PARQUET = 1, ORC = 2, JSON = 3 };
+enum class SelectType : int32_t { PROPERTIES = 0, LABELS = 1 };
 /** GetChunkVersion: V1 use scanner, V2 use FileReader */
-enum GetChunkVersion : int32_t { AUTO = 0, V1 = 1, V2 = 2 };
+enum class GetChunkVersion : int32_t { AUTO = 0, V1 = 1, V2 = 2 };
 enum class AdjListType : int32_t;
 
 template <typename T>

--- a/cpp/src/graphar/label.h
+++ b/cpp/src/graphar/label.h
@@ -40,7 +40,7 @@ using parquet::schema::PrimitiveNode;
 constexpr int BATCH_SIZE = 1024;  // the batch size
 
 /// The query type
-enum QUERY_TYPE {
+enum class QUERY_TYPE {
   COUNT,    // return the number of valid vertices
   INDEX,    // return the indices of valid vertices
   BITMAP,   // return the bitmap of valid vertices
@@ -57,6 +57,7 @@ int read_parquet_file_and_get_valid_indices(
     const int tested_label_num, std::vector<int> tested_label_ids,
     const std::function<bool(bool*, int)>& IsValid, int chunk_idx,
     int chunk_size, std::vector<int>* indices = nullptr,
-    uint64_t* bitmap = nullptr, const QUERY_TYPE query_type = COUNT);
+    uint64_t* bitmap = nullptr,
+    const QUERY_TYPE query_type = QUERY_TYPE::COUNT);
 
 #endif  // CPP_SRC_GRAPHAR_LABEL_H_

--- a/cpp/src/graphar/status.h
+++ b/cpp/src/graphar/status.h
@@ -21,6 +21,7 @@
 
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include "graphar/macros.h"
@@ -64,7 +65,12 @@
 namespace graphar::util {
 template <typename Head>
 void StringBuilderRecursive(std::ostringstream& stream, Head&& head) {
-  stream << head;
+  using Decayed = std::decay_t<Head>;
+  if constexpr (std::is_enum_v<Decayed>) {
+    stream << static_cast<std::underlying_type_t<Decayed>>(head);
+  } else {
+    stream << std::forward<Head>(head);
+  }
 }
 
 template <typename Head, typename... Tail>


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
fix: #855

Currently, our enum mixed with C-type and strongly-type. C-type enums exists implicit convertion which may lead to potential bugs in some scenerios. A better way is using strongly-type enums.

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fix all C-type enums.

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
N/A
### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
N/A
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
