### PR TITLE
chore(typos): fix spelling error in benchmark and cmake configurations

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -460,7 +460,7 @@ else()
 endif()
 
 # ------------------------------------------------------------------------------
-# build example
+# build examples
 # ------------------------------------------------------------------------------
 if (BUILD_EXAMPLES)
     find_package(Boost REQUIRED COMPONENTS graph)

--- a/cpp/benchmarks/arrow_chunk_reader_benchmark.cc
+++ b/cpp/benchmarks/arrow_chunk_reader_benchmark.cc
@@ -152,7 +152,7 @@ BENCHMARK_DEFINE_F(
   }
 }
 
-// select tow columns and internal ID column
+// select two columns and internal ID column
 BENCHMARK_DEFINE_F(
     BenchmarkFixture,
     VertexPropertyArrowChunkReaderReadChunk_firstGraph_TwoColumns_V1)
@@ -208,7 +208,7 @@ BENCHMARK_DEFINE_F(
   }
 }
 
-// select tow columns and internal ID column
+// select two columns and internal ID column
 BENCHMARK_DEFINE_F(
     BenchmarkFixture,
     VertexPropertyArrowChunkReaderReadChunk_firstGraph_TwoColumns_V2)
@@ -265,7 +265,7 @@ BENCHMARK_DEFINE_F(
   }
 }
 
-// select tow columns and internal ID column
+// select two columns and internal ID column
 BENCHMARK_DEFINE_F(
     BenchmarkFixture,
     VertexPropertyArrowChunkReaderReadChunk_secondGraph_TwoColumns_V1)
@@ -323,7 +323,7 @@ BENCHMARK_DEFINE_F(
   }
 }
 
-// select tow columns and internal ID column
+// select two columns and internal ID column
 BENCHMARK_DEFINE_F(
     BenchmarkFixture,
     VertexPropertyArrowChunkReaderReadChunk_secondGraph_TwoColumns_V2)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -59,10 +59,10 @@ find_package(ArrowAcero REQUIRED)
 find_package(Parquet REQUIRED)
 
 if(APPLE)
-  # cibuildwheel uses delocate to bundle external dylibs into the wheel.
-  # delocate needs to be able to resolve @rpath dependencies (e.g.
+  # cibuildwheel uses deallocate to bundle external dylibs into the wheel.
+  # deallocate needs to be able to resolve @rpath dependencies (e.g.
   # @rpath/libarrow.1300.dylib). We add the imported Arrow/Parquet library
-  # directories to LC_RPATH so delocate can find and copy them.
+  # directories to LC_RPATH so deallocate can find and copy them.
   set(_graphar_macos_rpaths "")
 
   foreach(_tgt IN ITEMS Arrow::arrow_shared ArrowDataset::arrow_dataset_shared ArrowAcero::arrow_acero_shared Parquet::parquet_shared)
@@ -111,7 +111,7 @@ target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
 # packaged libgraphar at runtime inside the wheel.
 if(APPLE)
   # Keep @loader_path for runtime inside the wheel, and add Arrow/Parquet
-  # library dirs so delocate can resolve @rpath dependencies during repair.
+  # library dirs so deallocate can resolve @rpath dependencies during repair.
   set(_core_rpath "@loader_path")
   if(_graphar_macos_rpaths)
     list(JOIN _graphar_macos_rpaths ";" _graphar_macos_rpaths_joined)


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->


### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
