### PR TITLE
refractor(C++): remove hardcoded row group size, keep 64M default

### DIFF
--- a/cpp/src/graphar/filesystem.cc
+++ b/cpp/src/graphar/filesystem.cc
@@ -269,8 +269,9 @@ Status FileSystem::WriteTableToFile(
   }
   case FileType::PARQUET: {
     auto schema = table->schema();
+    auto row_group_size = options->getParquetMaxRowGroupLength();
     RETURN_NOT_ARROW_OK(parquet::arrow::WriteTable(
-        *table, arrow::default_memory_pool(), output_stream, 64 * 1024 * 1024,
+        *table, arrow::default_memory_pool(), output_stream, row_group_size,
         options->getParquetWriterProperties(),
         options->getArrowWriterProperties()));
     break;
@@ -303,8 +304,9 @@ Status FileSystem::WriteLabelTableToFile(
   parquet::WriterProperties::Builder builder;
   builder.compression(arrow::Compression::type::ZSTD);  // enable compression
   builder.encoding(parquet::Encoding::RLE);
+  auto row_group_size = builder.build()->max_row_group_length();
   RETURN_NOT_ARROW_OK(parquet::arrow::WriteTable(
-      *table, arrow::default_memory_pool(), output_stream, 64 * 1024 * 1024,
+      *table, arrow::default_memory_pool(), output_stream, row_group_size,
       builder.build(), parquet::default_arrow_writer_properties()));
   return Status::OK();
 }

--- a/cpp/src/graphar/writer_util.cc
+++ b/cpp/src/graphar/writer_util.cc
@@ -86,6 +86,13 @@ WriterOptions::getParquetWriterProperties() const {
   return builder.build();
 }
 
+int64_t WriterOptions::getParquetMaxRowGroupLength() const {
+  if (parquetOption_) {
+    return parquetOption_->max_row_group_length;
+  }
+  return parquet::WriterProperties::Builder().build()->max_row_group_length();
+}
+
 std::shared_ptr<parquet::ArrowWriterProperties>
 WriterOptions::getArrowWriterProperties() const {
   parquet::ArrowWriterProperties::Builder builder;

--- a/cpp/src/graphar/writer_util.h
+++ b/cpp/src/graphar/writer_util.h
@@ -94,7 +94,7 @@ class WriterOptions {
     std::vector<::parquet::SortingColumn> sorting_columns;
     int64_t dictionary_pagesize_limit = 1024 * 1024;
     int64_t write_batch_size = 1024;
-    int64_t max_row_group_length = 1024 * 1024;
+    int64_t max_row_group_length = 64 * 1024 * 1024;
     int64_t data_pagesize = 1024 * 1024;
     size_t max_statistics_size = 4096;
     int compression_level = std::numeric_limits<int>::min();
@@ -429,6 +429,7 @@ class WriterOptions {
   std::shared_ptr<parquet::WriterProperties> getParquetWriterProperties() const;
   std::shared_ptr<parquet::ArrowWriterProperties> getArrowWriterProperties()
       const;
+  int64_t getParquetMaxRowGroupLength() const;
 #ifdef ARROW_ORC
   arrow::adapters::orc::WriteOptions getOrcOption() const;
 #endif


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
Currently, row group size is hard code: 64 * 1024 * 1024

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
