### PR TITLE
chore(ci): add commit message check and fix invalid args in check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,12 @@ jobs:
         pre-commit install
         pre-commit run clang-format -a
 
+    - name: Validate commit message format
+      run: |
+        COMMIT_MSG=$(git log -1 --pretty=%B)
+        echo "$COMMIT_MSG" > .git/COMMIT_EDITMSG
+        pre-commit run --hook-stage commit-msg --commit-msg-filename .git/COMMIT_EDITMSG 
+
     - name: cpplint
       working-directory: "cpp/build"
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,8 +64,7 @@ repos:
         stages: [commit-msg]
         args:
           - --verbose
-          - --scope-optional
-          - --types
+          - types
           - feat
           - fix
           - docs


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->

```shell
Conventional Commit......................................................Failed
- hook id: conventional-pre-commit
- exit code: 1

usage: conventional-pre-commit [-h] [--no-color] [--force-scope]
                               [--scopes SCOPES] [--strict] [--verbose]
                               [types ...] input
conventional-pre-commit: error: unrecognized arguments: --scope-optional --types
``` 

I accepted Copilot suggentions. Actually it cann't run success. 

<img width="714" height="454" alt="image" src="https://github.com/user-attachments/assets/ae83dbc6-0278-48b8-8c05-1fb4fbc64061" />



