### PR TITLE
fix(CI): upgrade cibuildwheel >= 2.22 to ensure download retry and use uv on MacOS to avoid rate limits

### DIFF
--- a/.github/workflows/python-wheel-workflow.yml
+++ b/.github/workflows/python-wheel-workflow.yml
@@ -114,6 +114,8 @@ jobs:
       CIBW_PLATFORM: ${{ matrix.os }}
       CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
       CIBW_SKIP: "*-musllinux_*"
+      # Use uv on macOS to avoid transient GitHub rate limits when cibuildwheel
+      CIBW_BUILD_FRONTEND: ${{ matrix.os == 'macos' && 'build[uv]' || 'build' }}
       # Pin arch to the matrix platform
       CIBW_ARCHS: ${{ matrix.platform }}
       CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.os == 'linux' && format('manylinux{0}', matrix.manylinux) || '' }}
@@ -232,7 +234,11 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          python -m pip install packaging "cibuildwheel>=2.22"
+          if [ "${{ matrix.os }}" = "macos" ]; then
+            python -m pip install packaging "cibuildwheel[uv]>=2.22"
+          else
+            python -m pip install packaging "cibuildwheel>=2.22"
+          fi
           mkdir -p python/dist
           python -m cibuildwheel --output-dir python/dist "$PKGDIR"
 

--- a/.github/workflows/python-wheel-workflow.yml
+++ b/.github/workflows/python-wheel-workflow.yml
@@ -232,7 +232,7 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          python -m pip install packaging cibuildwheel
+          python -m pip install packaging "cibuildwheel>=2.22"
           mkdir -p python/dist
           python -m cibuildwheel --output-dir python/dist "$PKGDIR"
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,12 +1,12 @@
 # GraphAr Python SDK
 
-GraphAr Python SDK provides Python bindings for the GraphAr C++ library, allowing user to work with GraphAr formatted graph data in Python environments. It includes both a high-level API for data manipulation and a command-line interface for common operations.
+GraphAr Python SDK provides Python bindings for the GraphAr C++ library, allowing users to work with GraphAr formatted graph data in Python environments. It includes both a high-level API for data manipulation and a command-line interface for common operations.
 
 ## Installation
 
 ### Prerequisites
 
-- Python >= 3.7
+- Python >= 3.9
 - pip (latest version recommended)
 - CMake >= 3.15 (for building from source)
 - Apache Arrow >= 12.0 (for building from source)


### PR DESCRIPTION


<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->
fix: #907 
upgrade cibuildwheel >= 2.22 to ensure download retry

The main problem is in Macos downloading cibuildwheel easy to reach rate limits. 
Use uv download can avoid this problem.

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
