### PR TITLE
fix: avoid using C-style pointers to prevent potential memory leaks

### DIFF
--- a/cpp/src/graphar/status.h
+++ b/cpp/src/graphar/status.h
@@ -233,33 +233,23 @@ class Status {
   }
 
   /** Return true iff the status indicates success. */
-  constexpr bool ok() const { return (state_.get() == nullptr); }
+  bool ok() const { return (state_.get() == nullptr); }
 
   /** Return true iff the status indicates a key lookup error. */
-  constexpr bool IsKeyError() const { return code() == StatusCode::kKeyError; }
+  bool IsKeyError() const { return code() == StatusCode::kKeyError; }
   /** Return true iff the status indicates a type match error. */
-  constexpr bool IsTypeError() const {
-    return code() == StatusCode::kTypeError;
-  }
+  bool IsTypeError() const { return code() == StatusCode::kTypeError; }
   /** Return true iff the status indicates invalid data. */
-  constexpr bool IsInvalid() const { return code() == StatusCode::kInvalid; }
+  bool IsInvalid() const { return code() == StatusCode::kInvalid; }
   /** Return true iff the status indicates an index out of bounds. */
-  constexpr bool IsIndexError() const {
-    return code() == StatusCode::kIndexError;
-  }
+  bool IsIndexError() const { return code() == StatusCode::kIndexError; }
   /** Return true iff the status indicates an yaml parse related failure. */
-  constexpr bool IsYamlError() const {
-    return code() == StatusCode::kYamlError;
-  }
+  bool IsYamlError() const { return code() == StatusCode::kYamlError; }
   /** Return true iff the status indicates an arrow-related failure. */
-  constexpr bool IsArrowError() const {
-    return code() == StatusCode::kArrowError;
-  }
+  bool IsArrowError() const { return code() == StatusCode::kArrowError; }
 
   /** Return the StatusCode value attached to this status. */
-  constexpr StatusCode code() const {
-    return ok() ? StatusCode::kOK : state_->code;
-  }
+  StatusCode code() const { return ok() ? StatusCode::kOK : state_->code; }
 
   /** Return the specific error message attached to this status. */
   const std::string& message() const {

--- a/cpp/src/graphar/status.h
+++ b/cpp/src/graphar/status.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <memory>
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -131,33 +132,38 @@ class Status {
   /** Create a success status. */
   Status() noexcept : state_(nullptr) {}
   /** Destructor. */
-  ~Status() noexcept {
-    if (state_ != nullptr) {
-      deleteState();
-    }
-  }
+  ~Status() noexcept = default;
   /**
    * @brief Constructs a status with the specified error code and message.
    * @param code The error code of the status.
    * @param msg The error message of the status.
    */
   Status(StatusCode code, std::string msg) {
-    state_ = new State;
+    state_ = std::make_unique<State>();
     state_->code = code;
     state_->msg = std::move(msg);
   }
   /** Copy the specified status. */
-  Status(const Status& s)
-      : state_((s.state_ == nullptr) ? nullptr : new State(*s.state_)) {}
-  /**  Move the specified status. */
-  Status(Status&& s) noexcept : state_(s.state_) { s.state_ = nullptr; }
-  /** Move assignment operator. */
-  Status& operator=(Status&& s) noexcept {
-    delete state_;
-    state_ = s.state_;
-    s.state_ = nullptr;
+  Status(const Status& s) {
+    if (s.state_) {
+      state_ = std::make_unique<State>(*s.state_);
+    }
+  }
+  /** Copy assignment operator. */
+  Status& operator=(const Status& s) {
+    if (this != &s) {
+      if (s.state_) {
+        state_ = std::make_unique<State>(*s.state_);
+      } else {
+        state_.reset();
+      }
+    }
     return *this;
   }
+  /**  Move the specified status. */
+  Status(Status&& s) noexcept = default;
+  /** Move assignment operator. */
+  Status& operator=(Status&& s) noexcept = default;
 
   /** Returns a success status. */
   static Status OK() { return {}; }
@@ -262,16 +268,11 @@ class Status {
   }
 
  private:
-  void deleteState() {
-    delete state_;
-    state_ = nullptr;
-  }
-
   struct State {
     StatusCode code;
     std::string msg;
   };
-  State* state_;
+  std::unique_ptr<State> state_;
 };
 
 }  // namespace graphar

--- a/cpp/src/graphar/status.h
+++ b/cpp/src/graphar/status.h
@@ -233,7 +233,7 @@ class Status {
   }
 
   /** Return true iff the status indicates success. */
-  constexpr bool ok() const { return (state_ == nullptr); }
+  constexpr bool ok() const { return (state_.get() == nullptr); }
 
   /** Return true iff the status indicates a key lookup error. */
   constexpr bool IsKeyError() const { return code() == StatusCode::kKeyError; }


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->

current `Status` missing copy assignment operator, which may cause memory leak.
modern cpp guidelines suggent using smart pointer instead of C-type pointer.

In this PR, it uses `std::unique_ptr<State> state_;` to replace orignal  `State* state_;`

BTW, This memory leak was detected by `.clang-tidy`.

#898 


### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
