### PR TITLE
fix(cpp): correct hasLabel() for filtered collections

### DIFF
--- a/cpp/src/graphar/high-level/graph_reader.cc
+++ b/cpp/src/graphar/high-level/graph_reader.cc
@@ -104,7 +104,11 @@ Vertex::Vertex(IdType id,
 
 Result<bool> VertexIter::hasLabel(const std::string& label) noexcept {
   std::shared_ptr<arrow::ChunkedArray> column(nullptr);
-  label_reader_.seek(cur_offset_);
+  if (is_filtered_) {
+    label_reader_.seek(filtered_ids_[cur_offset_]);
+  } else {
+    label_reader_.seek(cur_offset_);
+  }
   GAR_ASSIGN_OR_RAISE(auto chunk_table, label_reader_.GetLabelChunk());
   column = util::GetArrowColumnByName(chunk_table, label);
   if (column != nullptr) {

--- a/cpp/test/test_graph.cc
+++ b/cpp/test/test_graph.cc
@@ -433,7 +433,7 @@ TEST_CASE_METHOD(GlobalFixture, "Graph") {
   SECTION("HasLabel") {
     // Get organisation vertices which have labels: university, company, public
     auto result = VerticesCollection::verticesWithLabel(
-        "university", ldbc_graph_info, "organisation");
+        "university", maybe_graph_info.value(), "organisation");
     REQUIRE(!result.has_error());
     auto vertices = result.value();
     REQUIRE(vertices->size() > 0);

--- a/cpp/test/test_graph.cc
+++ b/cpp/test/test_graph.cc
@@ -429,5 +429,25 @@ TEST_CASE_METHOD(GlobalFixture, "Graph") {
     REQUIRE(count == 10);
     std::cout << "TimestampType edge_count=" << count << std::endl;
   }
+
+  SECTION("HasLabel") {
+    // Get organisation vertices which have labels: university, company, public
+    auto result = VerticesCollection::verticesWithLabel(
+        "university", ldbc_graph_info, "organisation");
+    REQUIRE(!result.has_error());
+    auto vertices = result.value();
+    REQUIRE(vertices->size() > 0);
+
+    // Iterate and test hasLabel
+    size_t count = 0;
+    for (auto it = vertices->begin(); it != vertices->end() && count < 10;
+         ++it, ++count) {
+      REQUIRE(it.id() >= 0);
+      // university vertices should have label "university" as true
+      auto has_university = it.hasLabel("university");
+      REQUIRE(!has_university.has_error());
+      REQUIRE(has_university.value());
+    }
+  }
 }
 }  // namespace graphar

--- a/cpp/test/test_graph.cc
+++ b/cpp/test/test_graph.cc
@@ -431,22 +431,30 @@ TEST_CASE_METHOD(GlobalFixture, "Graph") {
   }
 
   SECTION("HasLabel") {
-    // Get organisation vertices which have labels: university, company, public
+    // Test hasLabel on organisation vertices which have labels
+    std::string ldbc_path = test_data_dir + "/ldbc/parquet/ldbc.graph.yml";
+    auto maybe_ldbc_graph_info = GraphInfo::Load(ldbc_path);
+    REQUIRE(maybe_ldbc_graph_info.status().ok());
+    auto ldbc_graph_info = maybe_ldbc_graph_info.value();
+
+    // Get university vertices (filtered by label)
     auto result = VerticesCollection::verticesWithLabel(
-        "university", maybe_graph_info.value(), "organisation");
+        "university", ldbc_graph_info, "organisation");
     REQUIRE(!result.has_error());
     auto vertices = result.value();
     REQUIRE(vertices->size() > 0);
 
-    // Iterate and test hasLabel
-    size_t count = 0;
-    for (auto it = vertices->begin(); it != vertices->end() && count < 10;
-         ++it, ++count) {
+    // Iterate and verify hasLabel works correctly on filtered collection
+    for (auto it = vertices->begin(); it != vertices->end(); ++it) {
       REQUIRE(it.id() >= 0);
       // university vertices should have label "university" as true
       auto has_university = it.hasLabel("university");
       REQUIRE(!has_university.has_error());
       REQUIRE(has_university.value());
+      // university vertices should have label "company" as false
+      auto has_company = it.hasLabel("company");
+      REQUIRE(!has_company.has_error());
+      REQUIRE(!has_company.value());
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to GraphAr.
If this is your first pull request you can find detailed information on [CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md)

The Apache GraphAr (incubating) community has restrictions on the naming of pr title. You can find instructions in
[CONTRIBUTING.md](https://github.com/apache/graphar/blob/main/CONTRIBUTING.md#title) too.
-->

### Reason for this PR
<!-- 
Why are you proposing this change? If this is already tracked in an issue, please link to the issue here.
Explaining clearly why this change is beneficial is important for the reviewers to understand the context.
-->

When calling hasLabel() on a filtered vertex collection, the function incorrectly uses cur_offset_ directly instead of looking up the actual vertex ID from filtered_ids_.

handle filtered collection in hasLabel()

close #926 

### What changes are included in this PR?
<!-- 
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Added conditional logic to use `filtered_ids_[cur_offset_]` when `is_filtered_` is true, matching the existing behavior in `label()`.
2. Added `HasLabel` test case in `cpp/test/test_graph.cc` covering filtered collection scenarios.

### Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes
### Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **BREAKING CHANGE: <description>** -->
no
<!--
Please uncomment the line below (and provide explanation) if the changes fix either
(a) a security vulnerability,
(b) a bug that caused incorrect or invalid data to be produced, or
(c) a bug that causes a crash (even when the API contract is upheld). 
We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **Critical Fix: <description>** -->
