### PR TITLE
chore: apply pre-commit in CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -53,3 +53,10 @@ jobs:
     
     - name: clang-format
       run: pre-commit run clang-format -a
+
+    - name: python
+      run: |
+        pre-commit run ruff-check
+        pre-commit run ruff-format
+        pre-commit run typos
+

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-slim
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: true
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -45,18 +45,28 @@ jobs:
       with:
         submodules: true
 
-    - name: cmake-format check
-      run: |
-        pip install pre-commit
-        pre-commit install 
-        pre-commit run cmake-format -a
-    
-    - name: clang-format
-      run: pre-commit run clang-format -a
+    - name: cmake-format
+      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      with:
+        extra_args: cmake-format
 
-    - name: python
-      run: |
-        pre-commit run ruff-check
-        pre-commit run ruff-format
-        pre-commit run typos
+    - name: clang-format
+      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      with:
+        extra_args: cmake-format
+
+    - name: ruff-check
+      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      with:
+        extra_args: ruff-check
+
+    - name: ruff-format
+      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      with:
+        extra_args: ruff-format
+
+    - name: typos
+      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      with:
+        extra_args: typos
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -44,6 +44,7 @@ jobs:
     - uses: actions/checkout@v7
       with:
         submodules: true
+        fetch-depth: 0
 
     - name: cmake-format
       uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         args:
         - '--verbose'
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.0
+    rev: v0.15.20
     hooks:
     - id: ruff-check
       files: ^python/


### PR DESCRIPTION
### Reason for this PR
pre-commit is never enforced in CI for the python code

### What changes are included in this PR?
- enforce `pre-commit` in CI for the Python code
- bump the `checkout` version

### Are these changes tested?
.

### Are there any user-facing changes?
No

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `make cpplint` before submitting when changed files are in the `cpp` directory.
- [x] I have performed `pre-commit run` before commit the changed files.
- [ ] I have added tests to prove my changes are effective.