### PR TITLE
chore(go): bootstrap Go SDK module and CI

### DIFF
--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -61,5 +61,6 @@ header:
     - "**/*.json"
     - "**/*.lock"
     - "**/*.svg"
+    - "**/go.sum"
     - cli/*.yml
     - cli/*.toml

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,129 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: GraphAr Go CI
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "go/**"
+      - ".github/workflows/go.yaml"
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - "go/**"
+      - ".github/workflows/go.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+
+defaults:
+  run:
+    shell: bash
+    working-directory: go/graphar
+
+jobs:
+  build:
+    name: Ubuntu Go ${{ matrix.go }}
+    runs-on: ubuntu-24.04
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, 'WIP') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Lowest supported version (matches the go.mod floor) + latest stable.
+        go: ["1.23", "stable"]
+    env:
+      GAR_TEST_DATA: ${{ github.workspace }}/testing/
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Pull the testing/ submodule so the cross-language interop test
+          # (info.TestLoadAllFixtures) has real C++/Java/Rust fixtures to load.
+          submodules: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+          cache-dependency-path: go/graphar/go.sum
+          check-latest: true
+
+      - name: Print Go version
+        run: go version
+
+      - name: Verify go.mod is tidy
+        run: |
+          go mod tidy
+          if ! git diff --quiet -- go.mod go.sum; then
+            echo "::error::go.mod / go.sum is not tidy. Run 'go mod tidy' locally and commit the result." >&2
+            git --no-pager diff -- go.mod go.sum
+            exit 1
+          fi
+
+      - name: gofmt
+        run: make fmt-check
+
+      - name: go vet
+        run: make vet
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test (race) + coverage
+        run: |
+          go test -race -covermode=atomic -coverprofile=coverage.out ./...
+          go tool cover -func=coverage.out | tail -n 1
+
+      - name: Coverage floor
+        run: make coverage-check COVER_OUT=coverage.out
+
+      - name: Upload coverage to Codecov
+        if: matrix.go == 'stable'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: go/graphar/coverage.out
+          flags: go
+          fail_ci_if_error: false
+
+  lint:
+    name: golangci-lint
+    runs-on: ubuntu-24.04
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, 'WIP') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+          cache-dependency-path: go/graphar/go.sum
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.8
+          working-directory: go/graphar
+          args: --timeout=5m

--- a/go/README.md
+++ b/go/README.md
@@ -24,8 +24,9 @@ The SDK reads and writes the same on-disk YAML schema as the C++, Java and
 Rust reference implementations, so a graph produced by any of them is
 loadable by any other.
 
-> Status: in development. The metadata layer (`types/`, `info/`) is
-> available; the data layer (`reader/`, `writer/`) is planned.
+> Status: in development. This module currently ships the build and CI
+> scaffold only; the metadata layer (`types/`, `info/`) and the data layer
+> (`reader/`, `writer/`) are planned.
 
 ## Install
 
@@ -36,6 +37,9 @@ go get github.com/apache/incubator-graphar/go/graphar
 Requires Go 1.23 or newer.
 
 ## Quick example
+
+The `info` package lands in the next stacked PR; the snippet below shows the
+intended API once it does.
 
 ```go
 import (
@@ -61,10 +65,12 @@ func main() {
 
 ## Packages
 
-| Package | What lives here |
+The module is currently a build/CI scaffold; the packages below are planned:
+
+| Package | What will live here |
 |---|---|
-| [`graphar/types`](./graphar/types) | Primitive value types: `DataType`, `FileType`, `AdjListType`, `Cardinality`, `InfoVersion`. No external dependencies. |
-| [`graphar/info`](./graphar/info) | Graph metadata model — `Property`, `PropertyGroup`, `VertexInfo`, `EdgeInfo`, `GraphInfo` — plus YAML load/save. Validates against the cpp reference rules so files round-trip across SDKs. |
+| `graphar/types` | Primitive value types: `DataType`, `FileType`, `AdjListType`, `Cardinality`, `InfoVersion`. No external dependencies. |
+| `graphar/info` | Graph metadata model — `Property`, `PropertyGroup`, `VertexInfo`, `EdgeInfo`, `GraphInfo` — plus YAML load/save. Validates against the cpp reference rules so files round-trip across SDKs. |
 
 ## Development
 
@@ -74,10 +80,10 @@ make ci         # gofmt + vet + lint + race tests + coverage floor
 make coverage   # produce coverage.out and print per-package coverage
 ```
 
-The cross-language interop gate (`info.TestLoadAllFixtures`) walks the
-[`testing/`](../testing) submodule for every `*.graph.yml` and verifies it
-loads and round-trips through `MarshalGraphInfo`. The test is skipped
-when the submodule is not initialised.
+Once the `info` package lands, a cross-language interop gate
+(`info.TestLoadAllFixtures`) will walk the [`testing/`](../testing) submodule
+for every `*.graph.yml` and verify it loads and round-trips through
+`MarshalGraphInfo`, skipping when the submodule is not initialised.
 
 ## Reporting issues / proposing changes
 

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,87 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# GraphAr Go SDK
+
+Pure-Go SDK for [Apache GraphAr](https://github.com/apache/incubator-graphar).
+The SDK reads and writes the same on-disk YAML schema as the C++, Java and
+Rust reference implementations, so a graph produced by any of them is
+loadable by any other.
+
+> Status: in development. The metadata layer (`types/`, `info/`) is
+> available; the data layer (`reader/`, `writer/`) is planned.
+
+## Install
+
+```bash
+go get github.com/apache/incubator-graphar/go/graphar
+```
+
+Requires Go 1.23 or newer.
+
+## Quick example
+
+```go
+import (
+    "io/fs"
+    "os"
+
+    "github.com/apache/incubator-graphar/go/graphar/info"
+)
+
+func main() {
+    fsys := os.DirFS("/path/to/graph")
+    g, err := info.LoadGraphInfo(fsys, "modern_graph.graph.yml")
+    if err != nil {
+        panic(err)
+    }
+    if v, ok := g.Vertex("person"); ok {
+        for _, name := range v.PropertyGroups().Names() {
+            println(name)
+        }
+    }
+}
+```
+
+## Packages
+
+| Package | What lives here |
+|---|---|
+| [`graphar/types`](./graphar/types) | Primitive value types: `DataType`, `FileType`, `AdjListType`, `Cardinality`, `InfoVersion`. No external dependencies. |
+| [`graphar/info`](./graphar/info) | Graph metadata model — `Property`, `PropertyGroup`, `VertexInfo`, `EdgeInfo`, `GraphInfo` — plus YAML load/save. Validates against the cpp reference rules so files round-trip across SDKs. |
+
+## Development
+
+```bash
+cd go/graphar
+make ci         # gofmt + vet + lint + race tests + coverage floor
+make coverage   # produce coverage.out and print per-package coverage
+```
+
+The cross-language interop gate (`info.TestLoadAllFixtures`) walks the
+[`testing/`](../testing) submodule for every `*.graph.yml` and verifies it
+loads and round-trips through `MarshalGraphInfo`. The test is skipped
+when the submodule is not initialised.
+
+## Reporting issues / proposing changes
+
+Open an issue at https://github.com/apache/incubator-graphar/issues. For
+larger changes (over 300–500 lines of diff), please start a discussion
+first as described in
+[CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/go/graphar/.gitignore
+++ b/go/graphar/.gitignore
@@ -1,0 +1,5 @@
+coverage.out
+coverage.html
+*.test
+*.out
+.DS_Store

--- a/go/graphar/.golangci.yml
+++ b/go/graphar/.golangci.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# golangci-lint configuration (v1.62.x format).
+# golangci-lint configuration.
 
 run:
   timeout: 5m

--- a/go/graphar/.golangci.yml
+++ b/go/graphar/.golangci.yml
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# golangci-lint configuration (v1.62.x format).
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - revive
+    - misspell
+    - gocritic
+    - unconvert
+    - prealloc
+    - gofmt
+    - goimports
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/apache/incubator-graphar/go/graphar
+
+  revive:
+    severity: warning
+    rules:
+      - name: exported
+        arguments:
+          - disableStutteringCheck
+      - name: package-comments
+      - name: var-naming
+      - name: error-return
+      - name: error-naming
+      - name: error-strings
+      - name: indent-error-flow
+      - name: superfluous-else
+      - name: blank-imports
+      - name: context-as-argument
+      - name: range-val-in-closure
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+
+  staticcheck:
+    checks:
+      - all
+
+  gocritic:
+    disabled-checks:
+      - hugeParam
+      - rangeValCopy
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude-use-default: false

--- a/go/graphar/Makefile
+++ b/go/graphar/Makefile
@@ -1,0 +1,128 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Coverage threshold per package (percent). CI fails below this floor.
+COVERAGE_MIN ?= 85
+
+GO        ?= go
+GOFMT     ?= gofmt
+GOIMPORTS ?= goimports
+COVER_OUT ?= coverage.out
+
+# Local import prefix for goimports grouping (see .golangci.yml).
+LOCAL_PREFIX := github.com/apache/incubator-graphar/go/graphar
+
+# License header check: the same tool the CI job uses (skywalking-eyes),
+# scoped to our Go files. REPO_ROOT is needed because the tool enumerates from
+# the git root.
+LICENSE_EYE ?= ghcr.io/apache/skywalking-eyes/license-eye:latest
+REPO_ROOT   := $(shell git rev-parse --show-toplevel 2>/dev/null || echo $(abspath $(CURDIR)/../..))
+
+.PHONY: help all fmt fmt-check vet lint test test-race coverage coverage-check tidy clean ci license-check
+
+help:
+	@echo "Targets:"
+	@echo "  fmt             - run gofmt -w and goimports on all .go files"
+	@echo "  fmt-check       - fail if any file needs gofmt"
+	@echo "  vet             - run go vet ./..."
+	@echo "  lint            - run golangci-lint (must be installed)"
+	@echo "  test            - run go test ./... with race detector off"
+	@echo "  test-race       - run go test -race ./..."
+	@echo "  coverage        - produce $(COVER_OUT) with -race and print per-package coverage"
+	@echo "  coverage-check  - fail if total coverage < COVERAGE_MIN ($(COVERAGE_MIN)%)"
+	@echo "  tidy            - go mod tidy"
+	@echo "  license-check   - check ASF headers on our Go files (skywalking-eyes, docker)"
+	@echo "  ci              - fmt-check + vet + lint + coverage + coverage-check"
+
+all: ci
+
+fmt:
+	$(GOFMT) -w .
+	@if command -v $(GOIMPORTS) >/dev/null 2>&1; then \
+	  $(GOIMPORTS) -w -local $(LOCAL_PREFIX) .; \
+	else \
+	  echo "$(GOIMPORTS) not installed; skipping import grouping"; \
+	  echo "  install: go install golang.org/x/tools/cmd/goimports@latest"; \
+	fi
+
+fmt-check:
+	@diff=$$($(GOFMT) -l .); \
+	if [ -n "$$diff" ]; then \
+	  echo "gofmt needs to be run on the following files:"; \
+	  echo "$$diff"; \
+	  exit 1; \
+	fi
+
+vet:
+	$(GO) vet ./...
+
+# golangci-lint is optional locally; CI installs it explicitly.
+# Use --version probe rather than command -v: asdf shims pretend to exist
+# even when no version is selected, so command -v can give a false positive.
+lint:
+	@if golangci-lint --version >/dev/null 2>&1; then \
+	  golangci-lint run ./...; \
+	else \
+	  echo "golangci-lint not available locally; skipping (CI will run it)"; \
+	fi
+
+test:
+	$(GO) test ./...
+
+test-race:
+	$(GO) test -race ./...
+
+coverage:
+	$(GO) test -race -coverprofile=$(COVER_OUT) -covermode=atomic ./...
+	@$(GO) tool cover -func=$(COVER_OUT) | tail -n 1
+
+# coverage-check enforces the COVERAGE_MIN floor on an existing profile. It does
+# not depend on `coverage`: CI (and `make ci`) already produce a -race profile,
+# and regenerating here would both duplicate that run and overwrite the -race
+# profile with a plain one. Only a bare `make coverage-check` with no profile on
+# disk builds one first.
+# When the profile has no executable statements yet (M0 bootstrap, before any
+# package ships testable code), the floor is skipped, a floor is for guarding
+# against regressions, not for blocking an empty repo. Statement count comes
+# from non-mode/non-summary lines in the profile file itself.
+coverage-check:
+	@test -f $(COVER_OUT) || $(MAKE) coverage
+	@stmts=$$(grep -cv -E '^(mode:|$$)' $(COVER_OUT) || true); \
+	if [ "$$stmts" -eq 0 ]; then \
+	  echo "no executable statements yet; skipping coverage floor"; \
+	  exit 0; \
+	fi; \
+	total=$$($(GO) tool cover -func=$(COVER_OUT) | tail -n 1 | awk '{print $$3}' | tr -d '%'); \
+	awk -v t=$$total -v m=$(COVERAGE_MIN) 'BEGIN { if (t+0 < m+0) { printf "coverage %.1f%% below minimum %s%%\n", t, m; exit 1 } else { printf "coverage %.1f%% >= minimum %s%%\n", t, m } }'
+
+tidy:
+	$(GO) mod tidy
+
+# license-check runs the CI license tool (skywalking-eyes) over our Go files.
+# The authoritative whole-repo gate is the CI job (config .github/.licenserc.yaml);
+# this checks the files we own, using the same tool so results agree.
+license-check:
+	@command -v docker >/dev/null 2>&1 || { echo "docker not found; needed for license-check"; exit 1; }
+	@cfg=$$(mktemp) && trap 'rm -f "$$cfg"' EXIT; \
+	  printf 'header:\n  license:\n    spdx-id: Apache-2.0\n    copyright-owner: Apache Software Foundation\n  paths:\n    - "go/graphar/**/*.go"\n' > "$$cfg"; \
+	  docker run --rm -v "$(REPO_ROOT):/w" -w /w -v "$$cfg:/lc.yaml" \
+	    $(LICENSE_EYE) -c /lc.yaml header check
+
+clean:
+	rm -f $(COVER_OUT)
+
+ci: fmt-check vet lint coverage coverage-check

--- a/go/graphar/doc.go
+++ b/go/graphar/doc.go
@@ -17,14 +17,13 @@
 
 // Package graphar is the Go SDK for Apache GraphAr.
 //
-// This umbrella package only carries documentation. Functionality lives in
-// sub-packages:
+// This umbrella package only carries documentation. The module is currently
+// a build and CI scaffold; the functional sub-packages are planned:
 //
 //   - types: primitive value types (DataType, FileType, AdjListType,
 //     Cardinality, InfoVersion).
 //   - info:  graph metadata model (Property, PropertyGroup, VertexInfo,
 //     EdgeInfo, GraphInfo) with YAML load/save and validation.
-//
-// Planned for later milestones: an fs filesystem abstraction and
-// reader/writer packages for chunked data access on top of Arrow.
+//   - reader/writer: chunked data access on top of Arrow, over an fs
+//     filesystem abstraction.
 package graphar

--- a/go/graphar/doc.go
+++ b/go/graphar/doc.go
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package graphar is the Go SDK for Apache GraphAr.
+//
+// This umbrella package only carries documentation. Functionality lives in
+// sub-packages:
+//
+//   - types: primitive value types (DataType, FileType, AdjListType,
+//     Cardinality, InfoVersion).
+//   - info:  graph metadata model (Property, PropertyGroup, VertexInfo,
+//     EdgeInfo, GraphInfo) with YAML load/save and validation.
+//
+// Planned for later milestones: an fs filesystem abstraction and
+// reader/writer packages for chunked data access on top of Arrow.
+package graphar

--- a/go/graphar/go.mod
+++ b/go/graphar/go.mod
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+module github.com/apache/incubator-graphar/go/graphar
+
+go 1.23.0

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -62,6 +62,14 @@ excludes = [
   "**/*.json",
   "**/*.lock",
   "**/*.svg",
+  "**/go.sum",
   "cli/*.yml",
   "cli/*.toml",
 ]
+
+# Go uses // line comments for license headers by convention (matching
+# Apache Arrow Go, Apache Beam Go SDK, Kubernetes etc.). Without this
+# override hawkeye defaults *.go to JAVADOC_STYLE (/* ... */) and would
+# reject the canonical Go header form.
+[mapping.DOUBLESLASH_STYLE]
+extensions = ["go"]


### PR DESCRIPTION
### Reason for this PR

This PR starts the Go SDK work tracked by #828.

The Go SDK needs a standalone module layout and CI/tooling foundation before
the actual GraphAr metadata APIs are added. Keeping this bootstrap change small
also makes the follow-up info implementation easier to review as a stacked PR.

Refs #828.

### What changes are included in this PR?

This PR adds the initial Go SDK scaffold:

- create the `go/graphar` Go module
- add the umbrella `graphar` package documentation
- add Go development targets for formatting, vetting, linting, testing,
  coverage, and license checks
- add a GitHub Actions workflow for Go CI when files under `go/**` change
- update license configuration for Go source files

This PR intentionally does not add the `types` or `info` package implementation
yet. Those APIs are planned for the stacked follow-up PR.

### Are these changes tested?

The intended local and CI checks are:

- `cd go/graphar && go mod tidy`
- `cd go/graphar && go test ./...`
- `cd go/graphar && make ci`
- `pre-commit run --files .github/workflows/go.yaml go/README.md go/graphar/.golangci.yml go/graphar/Makefile go/graphar/doc.go go/graphar/go.mod go/graphar/go.sum`

### Are there any user-facing changes?

Yes. This introduces the new Go SDK module directory and its README, but it does
not change any existing GraphAr API behavior.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `make cpplint` before submitting when changed files are in the `cpp` directory. (Not applicable: this PR does not change files in the `cpp` directory.)
- [x] I have performed `pre-commit run` before commit the changed files.
- [x] I have added tests to prove my changes are effective. (CI/tooling bootstrap is covered by the Go workflow and module checks listed above; implementation tests are added in the stacked follow-up PR.)