### PR TITLE
feat(go): add GraphAr info metadata support

### DIFF
--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -61,5 +61,6 @@ header:
     - "**/*.json"
     - "**/*.lock"
     - "**/*.svg"
+    - "**/go.sum"
     - cli/*.yml
     - cli/*.toml

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,129 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: GraphAr Go CI
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "go/**"
+      - ".github/workflows/go.yaml"
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - "go/**"
+      - ".github/workflows/go.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+
+defaults:
+  run:
+    shell: bash
+    working-directory: go/graphar
+
+jobs:
+  build:
+    name: Ubuntu Go ${{ matrix.go }}
+    runs-on: ubuntu-24.04
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, 'WIP') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Lowest supported version (matches the go.mod floor) + latest stable.
+        go: ["1.23", "stable"]
+    env:
+      GAR_TEST_DATA: ${{ github.workspace }}/testing/
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Pull the testing/ submodule so the cross-language interop test
+          # (info.TestLoadAllFixtures) has real C++/Java/Rust fixtures to load.
+          submodules: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+          cache-dependency-path: go/graphar/go.sum
+          check-latest: true
+
+      - name: Print Go version
+        run: go version
+
+      - name: Verify go.mod is tidy
+        run: |
+          go mod tidy
+          if ! git diff --quiet -- go.mod go.sum; then
+            echo "::error::go.mod / go.sum is not tidy. Run 'go mod tidy' locally and commit the result." >&2
+            git --no-pager diff -- go.mod go.sum
+            exit 1
+          fi
+
+      - name: gofmt
+        run: make fmt-check
+
+      - name: go vet
+        run: make vet
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test (race) + coverage
+        run: |
+          go test -race -covermode=atomic -coverprofile=coverage.out ./...
+          go tool cover -func=coverage.out | tail -n 1
+
+      - name: Coverage floor
+        run: make coverage-check COVER_OUT=coverage.out
+
+      - name: Upload coverage to Codecov
+        if: matrix.go == 'stable'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: go/graphar/coverage.out
+          flags: go
+          fail_ci_if_error: false
+
+  lint:
+    name: golangci-lint
+    runs-on: ubuntu-24.04
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, 'WIP') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+          cache-dependency-path: go/graphar/go.sum
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.8
+          working-directory: go/graphar
+          args: --timeout=5m

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,87 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# GraphAr Go SDK
+
+Pure-Go SDK for [Apache GraphAr](https://github.com/apache/incubator-graphar).
+The SDK reads and writes the same on-disk YAML schema as the C++, Java and
+Rust reference implementations, so a graph produced by any of them is
+loadable by any other.
+
+> Status: in development. The metadata layer (`types/`, `info/`) is
+> available; the data layer (`reader/`, `writer/`) is planned.
+
+## Install
+
+```bash
+go get github.com/apache/incubator-graphar/go/graphar
+```
+
+Requires Go 1.23 or newer.
+
+## Quick example
+
+```go
+import (
+    "io/fs"
+    "os"
+
+    "github.com/apache/incubator-graphar/go/graphar/info"
+)
+
+func main() {
+    fsys := os.DirFS("/path/to/graph")
+    g, err := info.LoadGraphInfo(fsys, "modern_graph.graph.yml")
+    if err != nil {
+        panic(err)
+    }
+    if v, ok := g.Vertex("person"); ok {
+        for _, name := range v.PropertyGroups().Names() {
+            println(name)
+        }
+    }
+}
+```
+
+## Packages
+
+| Package | What lives here |
+|---|---|
+| [`graphar/types`](./graphar/types) | Primitive value types: `DataType`, `FileType`, `AdjListType`, `Cardinality`, `InfoVersion`. No external dependencies. |
+| [`graphar/info`](./graphar/info) | Graph metadata model — `Property`, `PropertyGroup`, `VertexInfo`, `EdgeInfo`, `GraphInfo` — plus YAML load/save. Validates against the cpp reference rules so files round-trip across SDKs. |
+
+## Development
+
+```bash
+cd go/graphar
+make ci         # gofmt + vet + lint + race tests + coverage floor
+make coverage   # produce coverage.out and print per-package coverage
+```
+
+The cross-language interop gate (`info.TestLoadAllFixtures`) walks the
+[`testing/`](../testing) submodule for every `*.graph.yml` and verifies it
+loads and round-trips through `MarshalGraphInfo`. The test is skipped
+when the submodule is not initialised.
+
+## Reporting issues / proposing changes
+
+Open an issue at https://github.com/apache/incubator-graphar/issues. For
+larger changes (over 300–500 lines of diff), please start a discussion
+first as described in
+[CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/go/graphar/.gitignore
+++ b/go/graphar/.gitignore
@@ -1,0 +1,5 @@
+coverage.out
+coverage.html
+*.test
+*.out
+.DS_Store

--- a/go/graphar/.golangci.yml
+++ b/go/graphar/.golangci.yml
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# golangci-lint configuration (v1.62.x format).
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - revive
+    - misspell
+    - gocritic
+    - unconvert
+    - prealloc
+    - gofmt
+    - goimports
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/apache/incubator-graphar/go/graphar
+
+  revive:
+    severity: warning
+    rules:
+      - name: exported
+        arguments:
+          - disableStutteringCheck
+      - name: package-comments
+      - name: var-naming
+      - name: error-return
+      - name: error-naming
+      - name: error-strings
+      - name: indent-error-flow
+      - name: superfluous-else
+      - name: blank-imports
+      - name: context-as-argument
+      - name: range-val-in-closure
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+
+  staticcheck:
+    checks:
+      - all
+
+  gocritic:
+    disabled-checks:
+      - hugeParam
+      - rangeValCopy
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude-use-default: false

--- a/go/graphar/Makefile
+++ b/go/graphar/Makefile
@@ -1,0 +1,128 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Coverage threshold per package (percent). CI fails below this floor.
+COVERAGE_MIN ?= 85
+
+GO        ?= go
+GOFMT     ?= gofmt
+GOIMPORTS ?= goimports
+COVER_OUT ?= coverage.out
+
+# Local import prefix for goimports grouping (see .golangci.yml).
+LOCAL_PREFIX := github.com/apache/incubator-graphar/go/graphar
+
+# License header check: the same tool the CI job uses (skywalking-eyes),
+# scoped to our Go files. REPO_ROOT is needed because the tool enumerates from
+# the git root.
+LICENSE_EYE ?= ghcr.io/apache/skywalking-eyes/license-eye:latest
+REPO_ROOT   := $(shell git rev-parse --show-toplevel 2>/dev/null || echo $(abspath $(CURDIR)/../..))
+
+.PHONY: help all fmt fmt-check vet lint test test-race coverage coverage-check tidy clean ci license-check
+
+help:
+	@echo "Targets:"
+	@echo "  fmt             - run gofmt -w and goimports on all .go files"
+	@echo "  fmt-check       - fail if any file needs gofmt"
+	@echo "  vet             - run go vet ./..."
+	@echo "  lint            - run golangci-lint (must be installed)"
+	@echo "  test            - run go test ./... with race detector off"
+	@echo "  test-race       - run go test -race ./..."
+	@echo "  coverage        - produce $(COVER_OUT) with -race and print per-package coverage"
+	@echo "  coverage-check  - fail if total coverage < COVERAGE_MIN ($(COVERAGE_MIN)%)"
+	@echo "  tidy            - go mod tidy"
+	@echo "  license-check   - check ASF headers on our Go files (skywalking-eyes, docker)"
+	@echo "  ci              - fmt-check + vet + lint + coverage + coverage-check"
+
+all: ci
+
+fmt:
+	$(GOFMT) -w .
+	@if command -v $(GOIMPORTS) >/dev/null 2>&1; then \
+	  $(GOIMPORTS) -w -local $(LOCAL_PREFIX) .; \
+	else \
+	  echo "$(GOIMPORTS) not installed; skipping import grouping"; \
+	  echo "  install: go install golang.org/x/tools/cmd/goimports@latest"; \
+	fi
+
+fmt-check:
+	@diff=$$($(GOFMT) -l .); \
+	if [ -n "$$diff" ]; then \
+	  echo "gofmt needs to be run on the following files:"; \
+	  echo "$$diff"; \
+	  exit 1; \
+	fi
+
+vet:
+	$(GO) vet ./...
+
+# golangci-lint is optional locally; CI installs it explicitly.
+# Use --version probe rather than command -v: asdf shims pretend to exist
+# even when no version is selected, so command -v can give a false positive.
+lint:
+	@if golangci-lint --version >/dev/null 2>&1; then \
+	  golangci-lint run ./...; \
+	else \
+	  echo "golangci-lint not available locally; skipping (CI will run it)"; \
+	fi
+
+test:
+	$(GO) test ./...
+
+test-race:
+	$(GO) test -race ./...
+
+coverage:
+	$(GO) test -race -coverprofile=$(COVER_OUT) -covermode=atomic ./...
+	@$(GO) tool cover -func=$(COVER_OUT) | tail -n 1
+
+# coverage-check enforces the COVERAGE_MIN floor on an existing profile. It does
+# not depend on `coverage`: CI (and `make ci`) already produce a -race profile,
+# and regenerating here would both duplicate that run and overwrite the -race
+# profile with a plain one. Only a bare `make coverage-check` with no profile on
+# disk builds one first.
+# When the profile has no executable statements yet (M0 bootstrap, before any
+# package ships testable code), the floor is skipped, a floor is for guarding
+# against regressions, not for blocking an empty repo. Statement count comes
+# from non-mode/non-summary lines in the profile file itself.
+coverage-check:
+	@test -f $(COVER_OUT) || $(MAKE) coverage
+	@stmts=$$(grep -cv -E '^(mode:|$$)' $(COVER_OUT) || true); \
+	if [ "$$stmts" -eq 0 ]; then \
+	  echo "no executable statements yet; skipping coverage floor"; \
+	  exit 0; \
+	fi; \
+	total=$$($(GO) tool cover -func=$(COVER_OUT) | tail -n 1 | awk '{print $$3}' | tr -d '%'); \
+	awk -v t=$$total -v m=$(COVERAGE_MIN) 'BEGIN { if (t+0 < m+0) { printf "coverage %.1f%% below minimum %s%%\n", t, m; exit 1 } else { printf "coverage %.1f%% >= minimum %s%%\n", t, m } }'
+
+tidy:
+	$(GO) mod tidy
+
+# license-check runs the CI license tool (skywalking-eyes) over our Go files.
+# The authoritative whole-repo gate is the CI job (config .github/.licenserc.yaml);
+# this checks the files we own, using the same tool so results agree.
+license-check:
+	@command -v docker >/dev/null 2>&1 || { echo "docker not found; needed for license-check"; exit 1; }
+	@cfg=$$(mktemp) && trap 'rm -f "$$cfg"' EXIT; \
+	  printf 'header:\n  license:\n    spdx-id: Apache-2.0\n    copyright-owner: Apache Software Foundation\n  paths:\n    - "go/graphar/**/*.go"\n' > "$$cfg"; \
+	  docker run --rm -v "$(REPO_ROOT):/w" -w /w -v "$$cfg:/lc.yaml" \
+	    $(LICENSE_EYE) -c /lc.yaml header check
+
+clean:
+	rm -f $(COVER_OUT)
+
+ci: fmt-check vet lint coverage coverage-check

--- a/go/graphar/doc.go
+++ b/go/graphar/doc.go
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package graphar is the Go SDK for Apache GraphAr.
+//
+// This umbrella package only carries documentation. Functionality lives in
+// sub-packages:
+//
+//   - types: primitive value types (DataType, FileType, AdjListType,
+//     Cardinality, InfoVersion).
+//   - info:  graph metadata model (Property, PropertyGroup, VertexInfo,
+//     EdgeInfo, GraphInfo) with YAML load/save and validation.
+//
+// Planned for later milestones: an fs filesystem abstraction and
+// reader/writer packages for chunked data access on top of Arrow.
+package graphar

--- a/go/graphar/go.mod
+++ b/go/graphar/go.mod
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+module github.com/apache/incubator-graphar/go/graphar
+
+go 1.23.0
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go/graphar/go.sum
+++ b/go/graphar/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/graphar/info/adjacent_list.go
+++ b/go/graphar/info/adjacent_list.go
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"strings"
+
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+// AdjacentList describes one layout (CSR/CSC/COO-style) of an edge type.
+type AdjacentList struct {
+	// Type is the layout category. Required and unique within an EdgeInfo.
+	Type types.AdjListType
+	// FileType is the on-disk physical format.
+	FileType types.FileType
+	// Prefix is the subdirectory under the edge's prefix; when empty the
+	// Type.String() with a trailing slash is used.
+	Prefix string
+}
+
+// EffectivePrefix returns the explicit Prefix, or Type.String() when empty,
+// always with exactly one trailing slash for safe path concatenation.
+func (a AdjacentList) EffectivePrefix() string {
+	if a.Prefix != "" {
+		return strings.TrimRight(a.Prefix, "/") + "/"
+	}
+	return a.Type.String() + "/"
+}
+
+// Validate returns a ValidationError if a is malformed. file_type must be
+// csv / parquet / orc; json is rejected, as it is for property groups.
+func (a AdjacentList) Validate() error {
+	switch a.Type {
+	case types.UnorderedBySource, types.UnorderedByDest,
+		types.OrderedBySource, types.OrderedByDest:
+		// valid
+	default:
+		return newValidationError(ErrInvalidEdgeInfo, "adj_lists.type",
+			"unknown adjacency list type %d", a.Type)
+	}
+	if a.FileType.IsZero() {
+		return newValidationError(ErrInvalidEdgeInfo, "adj_lists.file_type",
+			"adjacency list file type must be set")
+	}
+	if a.FileType == types.FileTypeJSON {
+		return newValidationError(ErrInvalidEdgeInfo, "adj_lists.file_type",
+			"json file type is not supported in adjacency lists")
+	}
+	return nil
+}
+
+// Equal reports whether two adjacency lists are equivalent.
+func (a AdjacentList) Equal(other AdjacentList) bool {
+	return a.Type == other.Type &&
+		a.FileType == other.FileType &&
+		a.Prefix == other.Prefix
+}

--- a/go/graphar/info/adjacent_list_test.go
+++ b/go/graphar/info/adjacent_list_test.go
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+func TestAdjacentListEffectivePrefix(t *testing.T) {
+	t.Parallel()
+	a := AdjacentList{Type: types.OrderedBySource, FileType: types.FileTypeParquet}
+	if got := a.EffectivePrefix(); got != "ordered_by_source/" {
+		t.Errorf("EffectivePrefix() = %q", got)
+	}
+	a.Prefix = "ordered_by_src/"
+	if got := a.EffectivePrefix(); got != "ordered_by_src/" {
+		t.Errorf("explicit prefix not honoured: %q", got)
+	}
+	// An explicit prefix without a trailing slash is normalised to one.
+	a.Prefix = "custom"
+	if got := a.EffectivePrefix(); got != "custom/" {
+		t.Errorf("prefix trailing slash not normalised: %q", got)
+	}
+}
+
+func TestAdjacentListValidate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a    AdjacentList
+		want error
+	}{
+		{"zero", AdjacentList{}, ErrInvalidEdgeInfo},
+		{"unknown type", AdjacentList{Type: 0xff, FileType: types.FileTypeCSV}, ErrInvalidEdgeInfo},
+		{"missing file type", AdjacentList{Type: types.OrderedBySource}, ErrInvalidEdgeInfo},
+		{"json file type rejected", AdjacentList{Type: types.OrderedBySource, FileType: types.FileTypeJSON}, ErrInvalidEdgeInfo},
+		{"ok", AdjacentList{Type: types.OrderedBySource, FileType: types.FileTypeCSV}, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.a.Validate()
+			if c.want == nil {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, c.want) {
+				t.Errorf("got %v, want wrap of %v", err, c.want)
+			}
+		})
+	}
+}
+
+func TestAdjacentListEqual(t *testing.T) {
+	t.Parallel()
+	a := AdjacentList{Type: types.OrderedBySource, FileType: types.FileTypeParquet, Prefix: "p/"}
+	if !a.Equal(a) {
+		t.Error("reflexive failed")
+	}
+	other := a
+	other.Type = types.OrderedByDest
+	if a.Equal(other) {
+		t.Error("different type reported equal")
+	}
+	other = a
+	other.FileType = types.FileTypeCSV
+	if a.Equal(other) {
+		t.Error("different filetype reported equal")
+	}
+	other = a
+	other.Prefix = "q/"
+	if a.Equal(other) {
+		t.Error("different prefix reported equal")
+	}
+}

--- a/go/graphar/info/doc.go
+++ b/go/graphar/info/doc.go
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package info models the GraphAr graph metadata: properties, property groups,
+// vertex info, edge info and graph info. The types are value-semantic and
+// immutable after construction; mutating operations return new objects.
+//
+// The on-disk format is a small set of YAML documents shared across the GraphAr
+// implementations (modulo field ordering). Load and Save translate between YAML
+// and the in-memory types via
+// a private DTO layer so that on-disk evolution does not bleed into the
+// public API.
+//
+// Package info has no dependency on Apache Arrow; it can be used by callers
+// that only care about graph metadata without paying the Arrow import cost.
+package info

--- a/go/graphar/info/e2e_test.go
+++ b/go/graphar/info/e2e_test.go
@@ -1,0 +1,433 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/incubator-graphar/go/graphar/info"
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+// assertPropType fails the test unless pg has a property `name` of type want.
+func assertPropType(t *testing.T, pg *info.PropertyGroups, name string, want types.DataType) {
+	t.Helper()
+	got, ok := pg.PropertyType(name)
+	if !ok {
+		t.Errorf("PropertyType(%s) not found, want %v", name, want)
+		return
+	}
+	if !got.Equal(want) {
+		t.Errorf("PropertyType(%s) = %v, want %v", name, got, want)
+	}
+}
+
+// loadFixture loads a graph yaml from testing/<relDir>/<graphFile>. It skips
+// (not fails) when the testing/ submodule or the specific fixture is absent,
+// so a vanilla clone without submodules stays green.
+func loadFixture(t *testing.T, relDir, graphFile string) *info.GraphInfo {
+	t.Helper()
+	root := testingRoot(t)
+	if root == "" {
+		t.Skip("testing/ submodule not initialised; run `git submodule update --init testing`")
+	}
+	dir := filepath.Join(root, relDir)
+	if _, err := os.Stat(filepath.Join(dir, graphFile)); err != nil {
+		t.Skipf("fixture %s/%s not present: %v", relDir, graphFile, err)
+	}
+	g, err := info.LoadGraphInfo(os.DirFS(dir), graphFile)
+	if err != nil {
+		t.Fatalf("LoadGraphInfo(%s/%s): %v", relDir, graphFile, err)
+	}
+	return g
+}
+
+// loadLdbc loads a graph yaml from testing/ldbc_sample/<format>/<graphFile>.
+func loadLdbc(t *testing.T, format, graphFile string) *info.GraphInfo {
+	t.Helper()
+	return loadFixture(t, filepath.Join("ldbc_sample", format), graphFile)
+}
+
+// TestE2EPersonVertex verifies the parsed content of the ldbc_sample
+// person vertex against the actual on-disk fixture, not just that it loads.
+func TestE2EPersonVertex(t *testing.T) {
+	t.Parallel()
+	g := loadLdbc(t, "parquet", "ldbc_sample.graph.yml")
+
+	if g.Name() != "ldbc_sample" {
+		t.Errorf("Name() = %q, want ldbc_sample", g.Name())
+	}
+	if v := g.Version().String(); v != "gar/v1" {
+		t.Errorf("Version() = %q, want gar/v1", v)
+	}
+	if n := len(g.Vertices()); n != 1 {
+		t.Fatalf("len(Vertices()) = %d, want 1", n)
+	}
+
+	v, ok := g.Vertex("person")
+	if !ok {
+		t.Fatal("Vertex(person) not found")
+	}
+	if v.ChunkSize() != 100 {
+		t.Errorf("ChunkSize() = %d, want 100", v.ChunkSize())
+	}
+	if v.Prefix() != "vertex/person/" {
+		t.Errorf("Prefix() = %q, want vertex/person/", v.Prefix())
+	}
+
+	pg := v.PropertyGroups()
+	if pg.Len() != 2 {
+		t.Errorf("PropertyGroups.Len() = %d, want 2", pg.Len())
+	}
+
+	// id: int64, primary, alone in its own group.
+	assertPropType(t, pg, "id", types.Int64())
+	if !pg.IsPrimary("id") {
+		t.Error("IsPrimary(id) = false, want true")
+	}
+	if idGroup, ok := pg.GroupOf("id"); !ok || len(idGroup.Properties) != 1 {
+		t.Errorf("GroupOf(id) has %d properties, want 1", len(idGroup.Properties))
+	}
+
+	// firstName/lastName/gender: string, non-primary, sharing one group.
+	for _, name := range []string{"firstName", "lastName", "gender"} {
+		assertPropType(t, pg, name, types.String())
+		if pg.IsPrimary(name) {
+			t.Errorf("IsPrimary(%s) = true, want false", name)
+		}
+	}
+	if nameGroup, ok := pg.GroupOf("firstName"); !ok || len(nameGroup.Properties) != 3 {
+		t.Errorf("GroupOf(firstName) has %d properties, want 3", len(nameGroup.Properties))
+	}
+}
+
+// TestE2EKnowsEdge verifies the parsed content of the person-knows-person edge,
+// including the three adjacency-list layouts derived from (ordered, aligned_by).
+func TestE2EKnowsEdge(t *testing.T) {
+	t.Parallel()
+	g := loadLdbc(t, "parquet", "ldbc_sample.graph.yml")
+
+	e, ok := g.Edge("person", "knows", "person")
+	if !ok {
+		t.Fatal("Edge(person, knows, person) not found")
+	}
+	if e.ChunkSize() != 1024 {
+		t.Errorf("ChunkSize() = %d, want 1024", e.ChunkSize())
+	}
+	if e.SrcChunkSize() != 100 || e.DstChunkSize() != 100 {
+		t.Errorf("Src/DstChunkSize() = %d/%d, want 100/100", e.SrcChunkSize(), e.DstChunkSize())
+	}
+	if e.Directed() {
+		t.Error("Directed() = true, want false")
+	}
+	if e.Prefix() != "edge/person_knows_person/" {
+		t.Errorf("Prefix() = %q, want edge/person_knows_person/", e.Prefix())
+	}
+
+	// adj_lists: (false,src)->UnorderedBySource, (true,src)->OrderedBySource,
+	// (true,dst)->OrderedByDest.
+	if n := len(e.AdjListTypes()); n != 3 {
+		t.Errorf("len(AdjListTypes()) = %d, want 3", n)
+	}
+	for _, want := range []types.AdjListType{
+		types.UnorderedBySource, types.OrderedBySource, types.OrderedByDest,
+	} {
+		al, ok := e.AdjList(want)
+		if !ok {
+			t.Errorf("AdjList(%v) not found", want)
+			continue
+		}
+		if al.FileType != types.FileTypeParquet {
+			t.Errorf("AdjList(%v).FileType = %v, want parquet", want, al.FileType)
+		}
+	}
+
+	// creationDate property: string.
+	assertPropType(t, e.PropertyGroups(), "creationDate", types.String())
+}
+
+// TestE2EFeatureListType exercises the list<float> element-type path against the
+// real with_feature fixture - the one list spelling shipped in testing/.
+func TestE2EFeatureListType(t *testing.T) {
+	t.Parallel()
+	g := loadLdbc(t, "parquet", "ldbc_sample_with_feature.graph.yml")
+
+	v, ok := g.Vertex("person")
+	if !ok {
+		t.Fatal("Vertex(person) not found")
+	}
+	if pg := v.PropertyGroups(); pg.Len() != 3 {
+		t.Errorf("PropertyGroups.Len() = %d, want 3 (id, names, feature)", pg.Len())
+	}
+
+	got, ok := v.PropertyType("feature")
+	if !ok {
+		t.Fatal("PropertyType(feature) not found")
+	}
+	if !got.Equal(types.List(types.Float())) {
+		t.Errorf("PropertyType(feature) = %v, want list<float>", got)
+	}
+	if got.String() != "list<float>" {
+		t.Errorf("feature.String() = %q, want list<float>", got.String())
+	}
+}
+
+// TestE2EScalarDateTimestamp exercises the date and timestamp scalar types via
+// the dedicated ldbc_sample fixtures.
+func TestE2EScalarDateTimestamp(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		graph    string
+		edge     string
+		property string
+		want     types.DataType
+	}{
+		{"ldbc_sample_date.graph.yml", "knows-date", "creationDate-date", types.Date()},
+		{"ldbc_sample_timestamp.graph.yml", "knows-timestamp", "creationDate-timestamp", types.Timestamp()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.edge, func(t *testing.T) {
+			g := loadLdbc(t, "parquet", tc.graph)
+			e, ok := g.Edge("person", tc.edge, "person")
+			if !ok {
+				t.Fatalf("Edge(person, %s, person) not found", tc.edge)
+			}
+			assertPropType(t, e.PropertyGroups(), tc.property, tc.want)
+		})
+	}
+}
+
+// TestE2EMultiFormat loads the same ldbc_sample graph from its csv, orc and
+// parquet variants and asserts the file_type is parsed correctly per format.
+func TestE2EMultiFormat(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		format string
+		want   types.FileType
+	}{
+		{"csv", types.FileTypeCSV},
+		{"orc", types.FileTypeORC},
+		{"parquet", types.FileTypeParquet},
+	}
+	for _, tc := range cases {
+		t.Run(tc.format, func(t *testing.T) {
+			g := loadLdbc(t, tc.format, "ldbc_sample.graph.yml")
+			v, ok := g.Vertex("person")
+			if !ok {
+				t.Fatal("Vertex(person) not found")
+			}
+			grp, ok := v.PropertyGroups().GroupOf("id")
+			if !ok {
+				t.Fatal("GroupOf(id) not found")
+			}
+			if grp.FileType != tc.want {
+				t.Errorf("person id group FileType = %v, want %v", grp.FileType, tc.want)
+			}
+		})
+	}
+}
+
+// TestE2EModernGraph covers the TinkerPop modern graph: multiple vertex/edge
+// types, per-property-group prefixes, a directed edge, and the double type.
+func TestE2EModernGraph(t *testing.T) {
+	t.Parallel()
+	g := loadFixture(t, "modern_graph", "modern_graph.graph.yml")
+
+	if g.Name() != "modern_graph" {
+		t.Errorf("Name() = %q, want modern_graph", g.Name())
+	}
+	if len(g.Vertices()) != 2 || len(g.Edges()) != 2 {
+		t.Fatalf("got %d vertices / %d edges, want 2 / 2", len(g.Vertices()), len(g.Edges()))
+	}
+
+	person, ok := g.Vertex("person")
+	if !ok {
+		t.Fatal("Vertex(person) not found")
+	}
+	if person.ChunkSize() != 2 {
+		t.Errorf("person.ChunkSize() = %d, want 2", person.ChunkSize())
+	}
+	assertPropType(t, person.PropertyGroups(), "age", types.Int64())
+	// Per-group prefix is parsed.
+	if grp, ok := person.PropertyGroups().GroupOf("id"); !ok || grp.Prefix != "id/" {
+		t.Errorf("person id group Prefix = %q, want id/", grp.Prefix)
+	}
+
+	if sw, ok := g.Vertex("software"); !ok {
+		t.Error("Vertex(software) not found")
+	} else if sw.ChunkSize() != 10 {
+		t.Errorf("software.ChunkSize() = %d, want 10", sw.ChunkSize())
+	}
+
+	// created: person -> software, directed, with a double weight property.
+	created, ok := g.Edge("person", "created", "software")
+	if !ok {
+		t.Fatal("Edge(person, created, software) not found")
+	}
+	if !created.Directed() {
+		t.Error("created.Directed() = false, want true")
+	}
+	if created.DstChunkSize() != 10 {
+		t.Errorf("created.DstChunkSize() = %d, want 10", created.DstChunkSize())
+	}
+	assertPropType(t, created.PropertyGroups(), "weight", types.Double())
+	// Single adjacency list with an explicit prefix.
+	if al, ok := created.AdjList(types.OrderedBySource); !ok {
+		t.Error("created AdjList(OrderedBySource) not found")
+	} else if al.Prefix != "ordered_by_source/" {
+		t.Errorf("created adj prefix = %q, want ordered_by_source/", al.Prefix)
+	}
+}
+
+// TestE2ENebula covers the nebula fixture: a graph-level prefix, an edge that
+// omits the `directed` field (must default to false), and non-primary props.
+func TestE2ENebula(t *testing.T) {
+	t.Parallel()
+	g := loadFixture(t, "nebula", "basketballplayergraph.graph.yml")
+
+	if g.Name() != "basketballplayergraph" {
+		t.Errorf("Name() = %q, want basketballplayergraph", g.Name())
+	}
+	if g.Prefix() != "/tmp/graphar/nebula2graphar/" {
+		t.Errorf("Prefix() = %q, want /tmp/graphar/nebula2graphar/", g.Prefix())
+	}
+
+	player, ok := g.Vertex("player")
+	if !ok {
+		t.Fatal("Vertex(player) not found")
+	}
+	assertPropType(t, player.PropertyGroups(), "_vertexId", types.String())
+	if !player.PropertyGroups().IsPrimary("_vertexId") {
+		t.Error("player._vertexId IsPrimary = false, want true")
+	}
+
+	follow, ok := g.Edge("player", "follow", "player")
+	if !ok {
+		t.Fatal("Edge(player, follow, player) not found")
+	}
+	// `directed` is absent in the fixture -> defaults to false.
+	if follow.Directed() {
+		t.Error("follow.Directed() = true, want false (absent -> default)")
+	}
+	assertPropType(t, follow.PropertyGroups(), "degree", types.Int64())
+}
+
+// TestE2ENeo4jMovie covers the neo4j MovieGraph: many edge types and an edge
+// (ACTED_IN) that carries NO property groups at all.
+func TestE2ENeo4jMovie(t *testing.T) {
+	t.Parallel()
+	g := loadFixture(t, "neo4j", "MovieGraph.graph.yml")
+
+	if g.Name() != "MovieGraph" {
+		t.Errorf("Name() = %q, want MovieGraph", g.Name())
+	}
+	if len(g.Vertices()) != 2 || len(g.Edges()) != 6 {
+		t.Fatalf("got %d vertices / %d edges, want 2 / 6", len(g.Vertices()), len(g.Edges()))
+	}
+
+	person, ok := g.Vertex("Person")
+	if !ok {
+		t.Fatal("Vertex(Person) not found")
+	}
+	if !person.PropertyGroups().IsPrimary("name") {
+		t.Error("Person.name IsPrimary = false, want true")
+	}
+	assertPropType(t, person.PropertyGroups(), "born", types.Int64())
+
+	// ACTED_IN has adjacency lists but no property groups.
+	acted, ok := g.Edge("Person", "ACTED_IN", "Movie")
+	if !ok {
+		t.Fatal("Edge(Person, ACTED_IN, Movie) not found")
+	}
+	if acted.PropertyGroups() != nil {
+		t.Errorf("ACTED_IN.PropertyGroups() = %v, want nil (no properties)", acted.PropertyGroups())
+	}
+	if acted.HasProperty("weight") {
+		t.Error("ACTED_IN.HasProperty(weight) = true, want false")
+	}
+	if len(acted.AdjListTypes()) != 2 {
+		t.Errorf("ACTED_IN has %d adj lists, want 2", len(acted.AdjListTypes()))
+	}
+}
+
+// TestE2EJavaLabelDialect verifies the Java `label:` alias (in place of `type:`)
+// is accepted on read and mapped to the vertex Type.
+func TestE2EJavaLabelDialect(t *testing.T) {
+	t.Parallel()
+	g := loadFixture(t, filepath.Join("java", "ldbc_sample", "parquet"), "ldbc_sample.graph.yml")
+
+	// The person vertex file uses `label: person` rather than `type: person`.
+	v, ok := g.Vertex("person")
+	if !ok {
+		t.Fatal("Vertex(person) not found - label: alias not mapped to Type")
+	}
+	if v.Type() != "person" {
+		t.Errorf("Type() = %q, want person", v.Type())
+	}
+	assertPropType(t, v.PropertyGroups(), "id", types.Int64())
+}
+
+// TestE2ELdbcFull covers the full LDBC schema: many vertex and edge types,
+// exercising the multi-entity index at scale.
+func TestE2ELdbcFull(t *testing.T) {
+	t.Parallel()
+	g := loadFixture(t, "ldbc", "ldbc.graph.yml")
+
+	if g.Name() != "ldbc" {
+		t.Errorf("Name() = %q, want ldbc", g.Name())
+	}
+	if len(g.Vertices()) != 8 {
+		t.Errorf("len(Vertices()) = %d, want 8", len(g.Vertices()))
+	}
+	if len(g.Edges()) != 23 {
+		t.Errorf("len(Edges()) = %d, want 23", len(g.Edges()))
+	}
+	person, ok := g.Vertex("person")
+	if !ok {
+		t.Fatal("Vertex(person) not found")
+	}
+	if person.ChunkSize() != 4096 {
+		t.Errorf("person.ChunkSize() = %d, want 4096", person.ChunkSize())
+	}
+	if !person.HasProperty("firstName") {
+		t.Error("person.HasProperty(firstName) = false, want true")
+	}
+	// Spot-check a representative edge triplet resolves.
+	if _, ok := g.Edge("person", "knows", "person"); !ok {
+		t.Error("Edge(person, knows, person) not found")
+	}
+}
+
+// TestE2EJSONRejected asserts the json fixture is rejected on Validate:
+// file_type json is parseable (so liberal Load accepts it) but is not a valid
+// PropertyGroup storage format, so Validate must reject it - for the right
+// reason (property-group validation, not e.g. a missing file).
+func TestE2EJSONRejected(t *testing.T) {
+	t.Parallel()
+	g := loadFixture(t, filepath.Join("ldbc_sample", "json"), "LdbcSample.graph.yml")
+	err := g.Validate()
+	if err == nil {
+		t.Fatal("Validate accepted a json-file_type graph; want rejection")
+	}
+	if !errors.Is(err, info.ErrInvalidPropertyGroup) {
+		t.Errorf("want ErrInvalidPropertyGroup, got %v", err)
+	}
+}

--- a/go/graphar/info/edge_info.go
+++ b/go/graphar/info/edge_info.go
@@ -1,0 +1,263 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"cmp"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+// EdgeInfo is the immutable metadata for one edge type (src, edge, dst).
+type EdgeInfo struct {
+	srcType      string
+	edgeType     string
+	dstType      string
+	chunkSize    int64
+	srcChunkSize int64
+	dstChunkSize int64
+	directed     bool
+	prefix       string
+	adjLists     []AdjacentList
+	adjByType    map[types.AdjListType]AdjacentList
+	groups       *PropertyGroups
+	version      types.InfoVersion
+}
+
+// EdgeInfoOption configures an EdgeInfo at construction time.
+type EdgeInfoOption func(*edgeInfoConfig)
+
+type edgeInfoConfig struct {
+	prefix  string
+	version types.InfoVersion
+	groups  []PropertyGroup
+}
+
+// WithEdgePrefix sets the on-disk prefix for edge files. Defaults to
+// "edge/<src>_<edge>_<dst>/".
+func WithEdgePrefix(p string) EdgeInfoOption {
+	return func(c *edgeInfoConfig) { c.prefix = p }
+}
+
+// WithEdgeVersion overrides the InfoVersion (default: gar/v1).
+func WithEdgeVersion(v types.InfoVersion) EdgeInfoOption {
+	return func(c *edgeInfoConfig) { c.version = v.Clone() }
+}
+
+// WithEdgePropertyGroups attaches property groups to the edge type. Empty
+// (or omitted) is allowed: an edge type may carry only its adjacency lists.
+//
+// The slice is deep-cloned: callers may safely mutate either the outer slice
+// or each PropertyGroup's Properties after this call without affecting the
+// resulting EdgeInfo.
+func WithEdgePropertyGroups(groups []PropertyGroup) EdgeInfoOption {
+	return func(c *edgeInfoConfig) {
+		c.groups = clonePropertyGroups(groups)
+	}
+}
+
+// NewEdgeInfo constructs an EdgeInfo and validates it. All three type names
+// and all three chunk sizes are mandatory. adjLists must be non-empty and
+// every entry must have a known AdjListType.
+func NewEdgeInfo(
+	src, edge, dst string,
+	chunkSize, srcChunkSize, dstChunkSize int64,
+	directed bool,
+	adjLists []AdjacentList,
+	opts ...EdgeInfoOption,
+) (*EdgeInfo, error) {
+	e, err := newEdgeInfoUnvalidated(src, edge, dst, chunkSize, srcChunkSize, dstChunkSize, directed, adjLists, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err := e.Validate(); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+// newEdgeInfoUnvalidated builds an EdgeInfo without validating (the liberal
+// load path): adj lists are indexed (duplicate types still error) but not
+// validated, and lists may be empty. Call Validate to enforce the full contract.
+func newEdgeInfoUnvalidated(
+	src, edge, dst string,
+	chunkSize, srcChunkSize, dstChunkSize int64,
+	directed bool,
+	adjLists []AdjacentList,
+	opts ...EdgeInfoOption,
+) (*EdgeInfo, error) {
+	cfg := edgeInfoConfig{version: types.NewInfoVersion(types.DefaultVersion)}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	adjCp := slices.Clone(adjLists)
+	adjByType := make(map[types.AdjListType]AdjacentList, len(adjCp))
+	for i, a := range adjCp {
+		if _, dup := adjByType[a.Type]; dup {
+			return nil, newValidationError(ErrInvalidEdgeInfo,
+				fmt.Sprintf("adj_lists[%d].type", i),
+				"duplicate adj_list type %q", a.Type.String())
+		}
+		adjByType[a.Type] = a
+	}
+	prefix := cfg.prefix
+	if prefix == "" && src != "" && edge != "" && dst != "" {
+		prefix = "edge/" + src + "_" + edge + "_" + dst + "/"
+	}
+	var groups *PropertyGroups
+	if len(cfg.groups) > 0 {
+		pg, err := buildPropertyGroups(cfg.groups)
+		if err != nil {
+			return nil, fmt.Errorf("edge_info(%s_%s_%s): %w", src, edge, dst, err)
+		}
+		groups = pg
+	}
+	return &EdgeInfo{
+		srcType:      src,
+		edgeType:     edge,
+		dstType:      dst,
+		chunkSize:    chunkSize,
+		srcChunkSize: srcChunkSize,
+		dstChunkSize: dstChunkSize,
+		directed:     directed,
+		prefix:       prefix,
+		adjLists:     adjCp,
+		adjByType:    adjByType,
+		groups:       groups,
+		version:      cfg.version,
+	}, nil
+}
+
+// SrcType returns the source vertex type.
+func (e *EdgeInfo) SrcType() string { return e.srcType }
+
+// EdgeType returns the edge type name.
+func (e *EdgeInfo) EdgeType() string { return e.edgeType }
+
+// DstType returns the destination vertex type.
+func (e *EdgeInfo) DstType() string { return e.dstType }
+
+// Triplet returns the (src, edge, dst) tuple.
+func (e *EdgeInfo) Triplet() (string, string, string) { return e.srcType, e.edgeType, e.dstType }
+
+// ChunkSize returns the edge-side chunk size.
+func (e *EdgeInfo) ChunkSize() int64 { return e.chunkSize }
+
+// SrcChunkSize returns the source-side chunk size.
+func (e *EdgeInfo) SrcChunkSize() int64 { return e.srcChunkSize }
+
+// DstChunkSize returns the destination-side chunk size.
+func (e *EdgeInfo) DstChunkSize() int64 { return e.dstChunkSize }
+
+// Directed reports whether the edge is directed.
+func (e *EdgeInfo) Directed() bool { return e.directed }
+
+// Prefix returns the on-disk prefix.
+func (e *EdgeInfo) Prefix() string { return e.prefix }
+
+// Version returns the InfoVersion.
+func (e *EdgeInfo) Version() types.InfoVersion { return e.version.Clone() }
+
+// AdjLists returns the layouts sorted by type for determinism.
+func (e *EdgeInfo) AdjLists() []AdjacentList {
+	out := slices.Clone(e.adjLists)
+	slices.SortStableFunc(out, func(a, b AdjacentList) int {
+		return cmp.Compare(a.Type, b.Type)
+	})
+	return out
+}
+
+// AdjListTypes returns the set of available layouts in sorted order.
+func (e *EdgeInfo) AdjListTypes() []types.AdjListType {
+	return slices.Sorted(maps.Keys(e.adjByType))
+}
+
+// AdjList returns the adjacency list for the given layout, or false when
+// absent.
+func (e *EdgeInfo) AdjList(t types.AdjListType) (AdjacentList, bool) {
+	a, ok := e.adjByType[t]
+	return a, ok
+}
+
+// PropertyGroups returns the property group index, or nil when the edge has
+// no properties.
+func (e *EdgeInfo) PropertyGroups() *PropertyGroups { return e.groups }
+
+// HasProperty reports whether the named property exists on this edge type.
+func (e *EdgeInfo) HasProperty(name string) bool {
+	return e.groups != nil && e.groups.Has(name)
+}
+
+// Validate enforces cross-field invariants and edge-specific rules:
+//   - non-empty src/edge/dst
+//   - chunk sizes > 0
+//   - at least one adjacency list
+//   - every property group's properties are single-valued
+func (e *EdgeInfo) Validate() error {
+	if e.srcType == "" {
+		return newValidationError(ErrInvalidEdgeInfo, "src_type", "must not be empty")
+	}
+	if e.edgeType == "" {
+		return newValidationError(ErrInvalidEdgeInfo, "edge_type", "must not be empty")
+	}
+	if e.dstType == "" {
+		return newValidationError(ErrInvalidEdgeInfo, "dst_type", "must not be empty")
+	}
+	if e.chunkSize <= 0 {
+		return newValidationError(ErrInvalidEdgeInfo, "chunk_size", "must be > 0")
+	}
+	if err := e.version.Validate(); err != nil {
+		return newValidationError(ErrInvalidEdgeInfo, "version", "%s", err)
+	}
+	if e.srcChunkSize <= 0 {
+		return newValidationError(ErrInvalidEdgeInfo, "src_chunk_size", "must be > 0")
+	}
+	if e.dstChunkSize <= 0 {
+		return newValidationError(ErrInvalidEdgeInfo, "dst_chunk_size", "must be > 0")
+	}
+	if len(e.adjLists) == 0 {
+		return newValidationError(ErrInvalidEdgeInfo, "adj_lists",
+			"at least one adjacency list is required")
+	}
+	for i, a := range e.adjLists {
+		if err := a.Validate(); err != nil {
+			return fmt.Errorf("adj_lists[%d]: %w", i, err)
+		}
+	}
+	if e.groups != nil {
+		if err := e.groups.Validate(); err != nil {
+			return err
+		}
+		if err := validateUserDefinedTypes(e.groups, e.version, ErrInvalidEdgeInfo); err != nil {
+			return err
+		}
+		for _, name := range e.groups.Names() {
+			p, _, _ := e.groups.Property(name)
+			if p.Cardinality != types.CardinalitySingle {
+				return newValidationError(ErrInvalidEdgeInfo,
+					"property_groups.properties.cardinality",
+					"edge property %q must have cardinality single, got %s",
+					p.Name, p.Cardinality)
+			}
+		}
+	}
+	return nil
+}

--- a/go/graphar/info/edge_info_test.go
+++ b/go/graphar/info/edge_info_test.go
@@ -1,0 +1,206 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+func basicAdjLists() []AdjacentList {
+	return []AdjacentList{
+		{Type: types.OrderedBySource, FileType: types.FileTypeParquet},
+		{Type: types.OrderedByDest, FileType: types.FileTypeParquet},
+	}
+}
+
+func TestNewEdgeInfoRejectsZeroVersion(t *testing.T) {
+	t.Parallel()
+	_, err := NewEdgeInfo("person", "knows", "person", 1024, 100, 100, true, basicAdjLists(),
+		WithEdgeVersion(types.InfoVersion{}))
+	if !errors.Is(err, ErrInvalidEdgeInfo) {
+		t.Errorf("expected ErrInvalidEdgeInfo for zero version, got %v", err)
+	}
+}
+
+func TestNewEdgeInfoDefaults(t *testing.T) {
+	t.Parallel()
+	e, err := NewEdgeInfo("person", "knows", "person", 1024, 100, 100, true, basicAdjLists())
+	if err != nil {
+		t.Fatalf("NewEdgeInfo: %v", err)
+	}
+	if e.SrcType() != "person" || e.EdgeType() != "knows" || e.DstType() != "person" {
+		t.Errorf("triplet mismatch: %s/%s/%s", e.SrcType(), e.EdgeType(), e.DstType())
+	}
+	src, edge, dst := e.Triplet()
+	if src != "person" || edge != "knows" || dst != "person" {
+		t.Errorf("Triplet() = %s/%s/%s", src, edge, dst)
+	}
+	if e.ChunkSize() != 1024 || e.SrcChunkSize() != 100 || e.DstChunkSize() != 100 {
+		t.Errorf("chunk sizes mismatch")
+	}
+	if !e.Directed() {
+		t.Errorf("Directed should be true")
+	}
+	if e.Prefix() != "edge/person_knows_person/" {
+		t.Errorf("default prefix = %q", e.Prefix())
+	}
+	if e.Version().Version != types.DefaultVersion {
+		t.Errorf("default version mismatch")
+	}
+	if len(e.AdjLists()) != 2 {
+		t.Errorf("AdjLists len = %d", len(e.AdjLists()))
+	}
+	if got := e.AdjListTypes(); len(got) != 2 || got[0] != types.OrderedBySource || got[1] != types.OrderedByDest {
+		t.Errorf("AdjListTypes = %v", got)
+	}
+	if _, ok := e.AdjList(types.OrderedBySource); !ok {
+		t.Errorf("AdjList lookup failed")
+	}
+	if _, ok := e.AdjList(types.UnorderedByDest); ok {
+		t.Errorf("AdjList returned ok for missing type")
+	}
+	if e.PropertyGroups() != nil {
+		t.Errorf("PropertyGroups should be nil when not provided")
+	}
+}
+
+func TestNewEdgeInfoWithProperties(t *testing.T) {
+	t.Parallel()
+	groups := []PropertyGroup{{
+		Properties: []Property{{Name: "since", Type: types.Int64(), Cardinality: types.CardinalitySingle}},
+		FileType:   types.FileTypeParquet,
+	}}
+	e, err := NewEdgeInfo("person", "knows", "person", 1024, 100, 100, false, basicAdjLists(),
+		WithEdgePrefix("custom/"),
+		WithEdgePropertyGroups(groups),
+		WithEdgeVersion(types.NewInfoVersion(2)),
+	)
+	if err != nil {
+		t.Fatalf("NewEdgeInfo: %v", err)
+	}
+	if e.Prefix() != "custom/" {
+		t.Errorf("prefix override failed: %q", e.Prefix())
+	}
+	if !e.HasProperty("since") {
+		t.Errorf("HasProperty(since) returned false")
+	}
+	if e.PropertyGroups() == nil {
+		t.Fatalf("PropertyGroups nil")
+	}
+	if e.Version().Version != 2 {
+		t.Errorf("version override failed")
+	}
+}
+
+func TestNewEdgeInfoRejectsListCardinality(t *testing.T) {
+	t.Parallel()
+	groups := []PropertyGroup{{
+		Properties: []Property{{Name: "tags", Type: types.String(), Cardinality: types.CardinalityList}},
+		FileType:   types.FileTypeParquet,
+	}}
+	_, err := NewEdgeInfo("person", "knows", "person", 1024, 100, 100, false, basicAdjLists(),
+		WithEdgePropertyGroups(groups))
+	if !errors.Is(err, ErrInvalidEdgeInfo) {
+		t.Errorf("expected ErrInvalidEdgeInfo for list cardinality on edge, got %v", err)
+	}
+}
+
+func TestNewEdgeInfoValidationFailures(t *testing.T) {
+	t.Parallel()
+	good := basicAdjLists()
+	cases := []struct {
+		name string
+		fn   func() (*EdgeInfo, error)
+		want error
+	}{
+		{"empty src", func() (*EdgeInfo, error) {
+			return NewEdgeInfo("", "k", "d", 1, 1, 1, false, good)
+		}, ErrInvalidEdgeInfo},
+		{"empty edge", func() (*EdgeInfo, error) {
+			return NewEdgeInfo("s", "", "d", 1, 1, 1, false, good)
+		}, ErrInvalidEdgeInfo},
+		{"empty dst", func() (*EdgeInfo, error) {
+			return NewEdgeInfo("s", "k", "", 1, 1, 1, false, good)
+		}, ErrInvalidEdgeInfo},
+		{"chunk_size 0", func() (*EdgeInfo, error) {
+			return NewEdgeInfo("s", "k", "d", 0, 1, 1, false, good)
+		}, ErrInvalidEdgeInfo},
+		{"src_chunk_size 0", func() (*EdgeInfo, error) {
+			return NewEdgeInfo("s", "k", "d", 1, 0, 1, false, good)
+		}, ErrInvalidEdgeInfo},
+		{"dst_chunk_size 0", func() (*EdgeInfo, error) {
+			return NewEdgeInfo("s", "k", "d", 1, 1, 0, false, good)
+		}, ErrInvalidEdgeInfo},
+		{"no adj lists", func() (*EdgeInfo, error) {
+			return NewEdgeInfo("s", "k", "d", 1, 1, 1, false, nil)
+		}, ErrInvalidEdgeInfo},
+		{"duplicate adj list types", func() (*EdgeInfo, error) {
+			dup := []AdjacentList{
+				{Type: types.OrderedBySource, FileType: types.FileTypeParquet},
+				{Type: types.OrderedBySource, FileType: types.FileTypeCSV},
+			}
+			return NewEdgeInfo("s", "k", "d", 1, 1, 1, false, dup)
+		}, ErrInvalidEdgeInfo},
+		{"invalid adj list", func() (*EdgeInfo, error) {
+			bad := []AdjacentList{{FileType: types.FileTypeCSV}} // missing Type
+			return NewEdgeInfo("s", "k", "d", 1, 1, 1, false, bad)
+		}, ErrInvalidEdgeInfo},
+		{"invalid property group", func() (*EdgeInfo, error) {
+			groups := []PropertyGroup{{FileType: types.FileTypeParquet}} // empty properties
+			return NewEdgeInfo("s", "k", "d", 1, 1, 1, false, good, WithEdgePropertyGroups(groups))
+		}, ErrInvalidPropertyGroup},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := c.fn()
+			if !errors.Is(err, c.want) {
+				t.Errorf("got %v, want wrap of %v", err, c.want)
+			}
+		})
+	}
+}
+
+func TestEdgeInfoAdjListsSorted(t *testing.T) {
+	t.Parallel()
+	mixed := []AdjacentList{
+		{Type: types.OrderedByDest, FileType: types.FileTypeParquet},
+		{Type: types.UnorderedBySource, FileType: types.FileTypeParquet},
+		{Type: types.OrderedBySource, FileType: types.FileTypeParquet},
+	}
+	e, err := NewEdgeInfo("s", "k", "d", 1, 1, 1, false, mixed)
+	if err != nil {
+		t.Fatalf("NewEdgeInfo: %v", err)
+	}
+	got := e.AdjLists()
+	for i := 1; i < len(got); i++ {
+		if got[i-1].Type > got[i].Type {
+			t.Errorf("AdjLists not sorted: %v", got)
+			break
+		}
+	}
+	types_ := e.AdjListTypes()
+	for i := 1; i < len(types_); i++ {
+		if types_[i-1] > types_[i] {
+			t.Errorf("AdjListTypes not sorted: %v", types_)
+			break
+		}
+	}
+}

--- a/go/graphar/info/errors.go
+++ b/go/graphar/info/errors.go
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors. Callers should test with errors.Is, not string match.
+var (
+	// ErrInvalidProperty is returned when a Property fails validation.
+	ErrInvalidProperty = errors.New("graphar/info: invalid property")
+	// ErrInvalidPropertyGroup is returned when a PropertyGroup fails validation.
+	ErrInvalidPropertyGroup = errors.New("graphar/info: invalid property group")
+	// ErrInvalidVertexInfo is returned when a VertexInfo fails validation.
+	ErrInvalidVertexInfo = errors.New("graphar/info: invalid vertex info")
+	// ErrInvalidEdgeInfo is returned when an EdgeInfo fails validation.
+	ErrInvalidEdgeInfo = errors.New("graphar/info: invalid edge info")
+	// ErrInvalidGraphInfo is returned when a GraphInfo fails validation.
+	ErrInvalidGraphInfo = errors.New("graphar/info: invalid graph info")
+	// ErrInvalidYAML is returned for malformed YAML input.
+	ErrInvalidYAML = errors.New("graphar/info: invalid YAML")
+)
+
+// ValidationError adds a structured field path + reason on top of one of the
+// sentinel errors above. errors.Is on a ValidationError reports true for the
+// wrapped sentinel.
+type ValidationError struct {
+	// Field is a dotted path locating the offending field, e.g.
+	// "vertex_info.property_groups[0].properties[2].name".
+	Field string
+	// Reason is the human-readable cause.
+	Reason string
+	// Sentinel is the underlying ErrInvalid... category.
+	Sentinel error
+	// Cause is an optional wrapped error kept in the chain so errors.Is matches
+	// it too (e.g. a types.ErrInvalidDataType behind an invalid property).
+	Cause error
+}
+
+func (e *ValidationError) Error() string {
+	if e.Field == "" {
+		return fmt.Sprintf("%s: %s", e.Sentinel.Error(), e.Reason)
+	}
+	return fmt.Sprintf("%s: %s: %s", e.Sentinel.Error(), e.Field, e.Reason)
+}
+
+// Unwrap exposes the sentinel (and any wrapped cause) so errors.Is matches
+// both categories.
+func (e *ValidationError) Unwrap() []error {
+	if e.Cause == nil {
+		return []error{e.Sentinel}
+	}
+	return []error{e.Sentinel, e.Cause}
+}
+
+func newValidationError(sentinel error, field, reasonFmt string, args ...any) *ValidationError {
+	return &ValidationError{
+		Field:    field,
+		Reason:   fmt.Sprintf(reasonFmt, args...),
+		Sentinel: sentinel,
+	}
+}

--- a/go/graphar/info/graph_info.go
+++ b/go/graphar/info/graph_info.go
@@ -1,0 +1,307 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"cmp"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+// EdgeTriplet uniquely identifies an edge type by (src, edge, dst).
+type EdgeTriplet struct {
+	Src, Edge, Dst string
+}
+
+// String returns the triplet spelling "src_edge_dst".
+func (t EdgeTriplet) String() string {
+	return t.Src + "_" + t.Edge + "_" + t.Dst
+}
+
+// compare orders triplets by src, then edge, then dst.
+func (t EdgeTriplet) compare(o EdgeTriplet) int {
+	if c := cmp.Compare(t.Src, o.Src); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(t.Edge, o.Edge); c != 0 {
+		return c
+	}
+	return cmp.Compare(t.Dst, o.Dst)
+}
+
+// GraphInfo is the top-level graph metadata aggregate.
+type GraphInfo struct {
+	name      string
+	prefix    string
+	version   types.InfoVersion
+	vertices  map[string]*VertexInfo
+	edges     map[EdgeTriplet]*EdgeInfo
+	labels    []string
+	extraInfo map[string]string
+	// File references from the loaded graph yaml, keyed by vertex type / edge
+	// triplet. Empty for a graph built programmatically; MarshalGraphInfo then
+	// derives default names.
+	vertexFileRefs map[string]string
+	edgeFileRefs   map[EdgeTriplet]string
+}
+
+// GraphInfoOption configures a GraphInfo at construction time.
+type GraphInfoOption func(*graphInfoConfig)
+
+type graphInfoConfig struct {
+	prefix         string
+	version        types.InfoVersion
+	vertices       []*VertexInfo
+	edges          []*EdgeInfo
+	labels         []string
+	extraInfo      map[string]string
+	vertexFileRefs map[string]string
+	edgeFileRefs   map[EdgeTriplet]string
+}
+
+// WithGraphPrefix sets the on-disk root prefix.
+func WithGraphPrefix(p string) GraphInfoOption {
+	return func(c *graphInfoConfig) { c.prefix = p }
+}
+
+// WithGraphVersion overrides the InfoVersion (default: gar/v1).
+func WithGraphVersion(v types.InfoVersion) GraphInfoOption {
+	return func(c *graphInfoConfig) { c.version = v.Clone() }
+}
+
+// WithVertices attaches vertex infos. Duplicate type names are rejected.
+func WithVertices(vs ...*VertexInfo) GraphInfoOption {
+	return func(c *graphInfoConfig) { c.vertices = append(c.vertices, vs...) }
+}
+
+// WithEdges attaches edge infos. Duplicate (src,edge,dst) triplets are
+// rejected.
+func WithEdges(es ...*EdgeInfo) GraphInfoOption {
+	return func(c *graphInfoConfig) { c.edges = append(c.edges, es...) }
+}
+
+// WithGraphLabels attaches graph-level labels (distinct from vertex labels).
+func WithGraphLabels(labels ...string) GraphInfoOption {
+	return func(c *graphInfoConfig) {
+		c.labels = slices.Clone(labels)
+	}
+}
+
+// WithGraphExtraInfo attaches free-form key/value metadata carried on the
+// graph document (the on-disk extra_info field). The map is copied.
+func WithGraphExtraInfo(extra map[string]string) GraphInfoOption {
+	return func(c *graphInfoConfig) {
+		c.extraInfo = maps.Clone(extra)
+	}
+}
+
+// withVertexFileRefs records the vertex file references from a loaded graph
+// yaml so MarshalGraphInfo can reproduce them. Used by the load path only.
+func withVertexFileRefs(m map[string]string) GraphInfoOption {
+	return func(c *graphInfoConfig) { c.vertexFileRefs = m }
+}
+
+// withEdgeFileRefs records the edge file references from a loaded graph yaml.
+func withEdgeFileRefs(m map[EdgeTriplet]string) GraphInfoOption {
+	return func(c *graphInfoConfig) { c.edgeFileRefs = m }
+}
+
+// NewGraphInfo constructs a GraphInfo and validates it.
+func NewGraphInfo(name string, opts ...GraphInfoOption) (*GraphInfo, error) {
+	g, err := newGraphInfoUnvalidated(name, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err := g.Validate(); err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+
+// newGraphInfoUnvalidated builds a GraphInfo without validating (the liberal
+// load path): duplicate vertex types / edge triplets still error, but
+// cross-references and child validity are not checked. Call Validate to enforce
+// the full contract.
+func newGraphInfoUnvalidated(name string, opts ...GraphInfoOption) (*GraphInfo, error) {
+	cfg := graphInfoConfig{version: types.NewInfoVersion(types.DefaultVersion)}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	g := &GraphInfo{
+		name:           name,
+		prefix:         cfg.prefix,
+		version:        cfg.version,
+		vertices:       make(map[string]*VertexInfo, len(cfg.vertices)),
+		edges:          make(map[EdgeTriplet]*EdgeInfo, len(cfg.edges)),
+		labels:         cfg.labels,
+		extraInfo:      cfg.extraInfo,
+		vertexFileRefs: cfg.vertexFileRefs,
+		edgeFileRefs:   cfg.edgeFileRefs,
+	}
+	for _, v := range cfg.vertices {
+		if v == nil {
+			return nil, newValidationError(ErrInvalidGraphInfo, "vertices", "nil vertex info")
+		}
+		if _, dup := g.vertices[v.Type()]; dup {
+			return nil, newValidationError(ErrInvalidGraphInfo, "vertices",
+				"duplicate vertex type %q", v.Type())
+		}
+		g.vertices[v.Type()] = v
+	}
+	for _, e := range cfg.edges {
+		if e == nil {
+			return nil, newValidationError(ErrInvalidGraphInfo, "edges", "nil edge info")
+		}
+		src, edge, dst := e.Triplet()
+		key := EdgeTriplet{Src: src, Edge: edge, Dst: dst}
+		if _, dup := g.edges[key]; dup {
+			return nil, newValidationError(ErrInvalidGraphInfo, "edges",
+				"duplicate edge triplet %q", key.String())
+		}
+		g.edges[key] = e
+	}
+	return g, nil
+}
+
+// Name returns the graph name.
+func (g *GraphInfo) Name() string { return g.name }
+
+// Prefix returns the on-disk root prefix.
+func (g *GraphInfo) Prefix() string { return g.prefix }
+
+// Version returns the InfoVersion.
+func (g *GraphInfo) Version() types.InfoVersion { return g.version.Clone() }
+
+// Labels returns a copy of the graph-level labels.
+func (g *GraphInfo) Labels() []string { return slices.Clone(g.labels) }
+
+// ExtraInfo returns a copy of the free-form key/value metadata carried on the
+// graph document.
+func (g *GraphInfo) ExtraInfo() map[string]string {
+	return maps.Clone(g.extraInfo)
+}
+
+// VertexFileName returns the file reference recorded for the vertex type when
+// the graph was loaded, and false when none was recorded (e.g. a graph built
+// programmatically, which derives its names on marshal).
+func (g *GraphInfo) VertexFileName(typ string) (string, bool) {
+	n, ok := g.vertexFileRefs[typ]
+	return n, ok
+}
+
+// EdgeFileName returns the file reference recorded for the edge triplet when
+// the graph was loaded, and false when none was recorded.
+func (g *GraphInfo) EdgeFileName(src, edge, dst string) (string, bool) {
+	n, ok := g.edgeFileRefs[EdgeTriplet{Src: src, Edge: edge, Dst: dst}]
+	return n, ok
+}
+
+// resolveVertexFile picks the file name for a vertex type: an explicit
+// override wins, then the loaded reference, then the derived default.
+func (g *GraphInfo) resolveVertexFile(typ string, override map[string]string) string {
+	if n, ok := override[typ]; ok {
+		return n
+	}
+	if n, ok := g.vertexFileRefs[typ]; ok {
+		return n
+	}
+	return typ + ".vertex.yml"
+}
+
+// resolveEdgeFile picks the file name for an edge triplet, with the same
+// precedence as resolveVertexFile.
+func (g *GraphInfo) resolveEdgeFile(key EdgeTriplet, override map[EdgeTriplet]string) string {
+	if n, ok := override[key]; ok {
+		return n
+	}
+	if n, ok := g.edgeFileRefs[key]; ok {
+		return n
+	}
+	return key.String() + ".edge.yml"
+}
+
+// Vertex returns the vertex info for the given type name.
+func (g *GraphInfo) Vertex(typ string) (*VertexInfo, bool) {
+	v, ok := g.vertices[typ]
+	return v, ok
+}
+
+// Edge returns the edge info for the given triplet.
+func (g *GraphInfo) Edge(src, edge, dst string) (*EdgeInfo, bool) {
+	e, ok := g.edges[EdgeTriplet{Src: src, Edge: edge, Dst: dst}]
+	return e, ok
+}
+
+// Vertices returns vertex infos sorted by type name.
+func (g *GraphInfo) Vertices() []*VertexInfo {
+	return slices.SortedFunc(maps.Values(g.vertices), func(a, b *VertexInfo) int {
+		return cmp.Compare(a.Type(), b.Type())
+	})
+}
+
+// Edges returns edge infos sorted by triplet.
+func (g *GraphInfo) Edges() []*EdgeInfo {
+	return slices.SortedFunc(maps.Values(g.edges), func(a, b *EdgeInfo) int {
+		as, ae, ad := a.Triplet()
+		bs, be, bd := b.Triplet()
+		return EdgeTriplet{Src: as, Edge: ae, Dst: ad}.compare(EdgeTriplet{Src: bs, Edge: be, Dst: bd})
+	})
+}
+
+// Validate enforces cross-field invariants: non-empty name and that every
+// edge type references vertex types known to this graph.
+func (g *GraphInfo) Validate() error {
+	if g.name == "" {
+		return newValidationError(ErrInvalidGraphInfo, "name", "must not be empty")
+	}
+	if err := g.version.Validate(); err != nil {
+		return newValidationError(ErrInvalidGraphInfo, "version", "%s", err)
+	}
+	if err := validateLabels(g.labels, ErrInvalidGraphInfo); err != nil {
+		return err
+	}
+	// Validate contained vertices and edges in deterministic (sorted) order so
+	// that multi-failure messages are reproducible (Go map iteration is random).
+	for _, typ := range slices.Sorted(maps.Keys(g.vertices)) {
+		if err := g.vertices[typ].Validate(); err != nil {
+			return fmt.Errorf("vertices[%q]: %w", typ, err)
+		}
+	}
+	triplets := slices.SortedFunc(maps.Keys(g.edges), func(a, b EdgeTriplet) int {
+		return a.compare(b)
+	})
+	for _, triplet := range triplets {
+		if err := g.edges[triplet].Validate(); err != nil {
+			return fmt.Errorf("edges[%s]: %w", triplet.String(), err)
+		}
+		if _, ok := g.vertices[triplet.Src]; !ok {
+			return newValidationError(ErrInvalidGraphInfo,
+				fmt.Sprintf("edges[%s].src_type", triplet.String()),
+				"references unknown vertex type %q", triplet.Src)
+		}
+		if _, ok := g.vertices[triplet.Dst]; !ok {
+			return newValidationError(ErrInvalidGraphInfo,
+				fmt.Sprintf("edges[%s].dst_type", triplet.String()),
+				"references unknown vertex type %q", triplet.Dst)
+		}
+	}
+	return nil
+}

--- a/go/graphar/info/graph_info_test.go
+++ b/go/graphar/info/graph_info_test.go
@@ -1,0 +1,214 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+func mustVertex(t *testing.T, typ string) *VertexInfo {
+	t.Helper()
+	v, err := NewVertexInfo(typ, 100, []PropertyGroup{{
+		Properties: []Property{{Name: "id", Type: types.Int64(), IsPrimary: true}},
+		FileType:   types.FileTypeParquet,
+	}})
+	if err != nil {
+		t.Fatalf("mustVertex(%q): %v", typ, err)
+	}
+	return v
+}
+
+func mustEdge(t *testing.T, src, edge, dst string) *EdgeInfo {
+	t.Helper()
+	e, err := NewEdgeInfo(src, edge, dst, 100, 100, 100, false, basicAdjLists())
+	if err != nil {
+		t.Fatalf("mustEdge: %v", err)
+	}
+	return e
+}
+
+func TestNewGraphInfoRejectsZeroVersion(t *testing.T) {
+	t.Parallel()
+	_, err := NewGraphInfo("g", WithGraphVersion(types.InfoVersion{}))
+	if !errors.Is(err, ErrInvalidGraphInfo) {
+		t.Errorf("expected ErrInvalidGraphInfo for zero version, got %v", err)
+	}
+}
+
+func TestNewGraphInfoBasic(t *testing.T) {
+	t.Parallel()
+	person := mustVertex(t, "person")
+	soft := mustVertex(t, "software")
+	knows := mustEdge(t, "person", "knows", "person")
+	created := mustEdge(t, "person", "created", "software")
+
+	g, err := NewGraphInfo("g",
+		WithGraphPrefix("graph/"),
+		WithVertices(person, soft),
+		WithEdges(knows, created),
+	)
+	if err != nil {
+		t.Fatalf("NewGraphInfo: %v", err)
+	}
+	if g.Name() != "g" || g.Prefix() != "graph/" {
+		t.Errorf("getters mismatch: name=%q prefix=%q", g.Name(), g.Prefix())
+	}
+	if got, ok := g.Vertex("person"); !ok || got.Type() != "person" {
+		t.Errorf("Vertex(person) = (%v,%v)", got, ok)
+	}
+	if _, ok := g.Vertex("missing"); ok {
+		t.Errorf("Vertex(missing) reported ok=true")
+	}
+	if got, ok := g.Edge("person", "knows", "person"); !ok || got.EdgeType() != "knows" {
+		t.Errorf("Edge lookup failed: %v %v", got, ok)
+	}
+	if _, ok := g.Edge("person", "missing", "person"); ok {
+		t.Errorf("Edge(person,missing,person) ok=true")
+	}
+	if vs := g.Vertices(); len(vs) != 2 || vs[0].Type() > vs[1].Type() {
+		t.Errorf("Vertices not sorted: %v", vs)
+	}
+	if es := g.Edges(); len(es) != 2 {
+		t.Errorf("Edges len = %d", len(es))
+	}
+}
+
+func TestNewGraphInfoSortingEdges(t *testing.T) {
+	t.Parallel()
+	v1 := mustVertex(t, "a")
+	v2 := mustVertex(t, "b")
+	v3 := mustVertex(t, "c")
+	es := []*EdgeInfo{
+		mustEdge(t, "c", "k", "a"),
+		mustEdge(t, "a", "k", "b"),
+		mustEdge(t, "a", "k", "a"),
+		mustEdge(t, "b", "k", "a"),
+	}
+	g, err := NewGraphInfo("g",
+		WithVertices(v1, v2, v3),
+		WithEdges(es...),
+	)
+	if err != nil {
+		t.Fatalf("NewGraphInfo: %v", err)
+	}
+	got := g.Edges()
+	// Must be lexicographically by (src,edge,dst).
+	for i := 1; i < len(got); i++ {
+		prev, cur := got[i-1], got[i]
+		key := func(e *EdgeInfo) string {
+			s, ed, d := e.Triplet()
+			return s + "|" + ed + "|" + d
+		}
+		if key(prev) > key(cur) {
+			t.Errorf("edges not sorted: %v then %v", key(prev), key(cur))
+		}
+	}
+}
+
+func TestNewGraphInfoValidationFailures(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		fn   func() (*GraphInfo, error)
+		want error
+	}{
+		{"empty name", func() (*GraphInfo, error) { return NewGraphInfo("") }, ErrInvalidGraphInfo},
+		{"nil vertex", func() (*GraphInfo, error) {
+			return NewGraphInfo("g", WithVertices(nil))
+		}, ErrInvalidGraphInfo},
+		{"duplicate vertex", func() (*GraphInfo, error) {
+			return NewGraphInfo("g", WithVertices(mustVertex(t, "a"), mustVertex(t, "a")))
+		}, ErrInvalidGraphInfo},
+		{"nil edge", func() (*GraphInfo, error) {
+			return NewGraphInfo("g", WithVertices(mustVertex(t, "a")), WithEdges(nil))
+		}, ErrInvalidGraphInfo},
+		{"duplicate edge", func() (*GraphInfo, error) {
+			return NewGraphInfo("g",
+				WithVertices(mustVertex(t, "a"), mustVertex(t, "b")),
+				WithEdges(mustEdge(t, "a", "k", "b"), mustEdge(t, "a", "k", "b")),
+			)
+		}, ErrInvalidGraphInfo},
+		{"unknown src", func() (*GraphInfo, error) {
+			return NewGraphInfo("g",
+				WithVertices(mustVertex(t, "a")),
+				WithEdges(mustEdge(t, "ghost", "k", "a")),
+			)
+		}, ErrInvalidGraphInfo},
+		{"unknown dst", func() (*GraphInfo, error) {
+			return NewGraphInfo("g",
+				WithVertices(mustVertex(t, "a")),
+				WithEdges(mustEdge(t, "a", "k", "ghost")),
+			)
+		}, ErrInvalidGraphInfo},
+		{"empty label", func() (*GraphInfo, error) {
+			return NewGraphInfo("g", WithGraphLabels(""))
+		}, ErrInvalidGraphInfo},
+		{"duplicate labels", func() (*GraphInfo, error) {
+			return NewGraphInfo("g", WithGraphLabels("a", "a"))
+		}, ErrInvalidGraphInfo},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := c.fn()
+			if !errors.Is(err, c.want) {
+				t.Errorf("got %v, want wrap of %v", err, c.want)
+			}
+		})
+	}
+}
+
+func TestEdgeTripletString(t *testing.T) {
+	t.Parallel()
+	tr := EdgeTriplet{Src: "a", Edge: "k", Dst: "b"}
+	if tr.String() != "a_k_b" {
+		t.Errorf("EdgeTriplet.String = %q", tr.String())
+	}
+}
+
+func TestGraphInfoValidateDeterministicErrorOrder(t *testing.T) {
+	t.Parallel()
+	// Two edges both reference unknown vertex types. With the pre-fix map
+	// iteration, the failing field/triplet flipped run-to-run; the fix sorts
+	// edges first, so repeated calls must produce identical errors.
+	mk := func() error {
+		// Construct a GraphInfo directly to bypass Validate-on-construct
+		// (which would reject these edges immediately on the first random
+		// iteration order). The Validate test must observe Validate alone.
+		// The edges are individually valid but reference the unknown vertex
+		// "z", so the deterministic failure is the endpoint check.
+		v := mustVertex(t, "a")
+		g := &GraphInfo{
+			name:     "g",
+			vertices: map[string]*VertexInfo{"a": v},
+			edges: map[EdgeTriplet]*EdgeInfo{
+				{Src: "z", Edge: "k", Dst: "a"}: mustEdge(t, "z", "k", "a"),
+				{Src: "a", Edge: "k", Dst: "z"}: mustEdge(t, "a", "k", "z"),
+			},
+		}
+		return g.Validate()
+	}
+	first := mk().Error()
+	for range 20 {
+		if got := mk().Error(); got != first {
+			t.Fatalf("Validate error not deterministic across runs:\nfirst: %s\nthen:  %s", first, got)
+		}
+	}
+}

--- a/go/graphar/info/integration_test.go
+++ b/go/graphar/info/integration_test.go
@@ -1,0 +1,173 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/apache/incubator-graphar/go/graphar/info"
+)
+
+// graphFileRefs extracts the vertex and edge file references from a graph yaml
+// document and returns them sorted, so two documents can be compared
+// independent of listing order.
+func graphFileRefs(t *testing.T, doc []byte) []string {
+	t.Helper()
+	var y struct {
+		Vertices []string `yaml:"vertices"`
+		Edges    []string `yaml:"edges"`
+	}
+	if err := yaml.Unmarshal(doc, &y); err != nil {
+		t.Fatalf("parse graph yaml refs: %v", err)
+	}
+	refs := append(y.Vertices, y.Edges...)
+	slices.Sort(refs)
+	return refs
+}
+
+// testingRoot resolves the testing/ fixture directory. It honours the
+// GAR_TEST_DATA environment variable first (as the other SDKs do),
+// then falls back to walking up from the current working directory. Returns ""
+// when neither locates a directory.
+func testingRoot(t *testing.T) string {
+	t.Helper()
+	if env := os.Getenv("GAR_TEST_DATA"); env != "" {
+		if info, err := os.Stat(env); err == nil && info.IsDir() {
+			return env
+		}
+		t.Fatalf("GAR_TEST_DATA=%q is not a directory", env)
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	// Bound the walk so we never go above the volume root.
+	for range 12 {
+		candidate := filepath.Join(dir, "testing")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
+}
+
+// TestLoadAllFixtures asserts every graph.yml shipped in the testing/
+// submodule parses cleanly through LoadGraphInfo. This is the cross-language
+// interop gate: any fixture written by C++ / Java / Rust / Python must round
+// through the Go SDK.
+//
+// When testing/ is not present (e.g. submodule not initialised in a vanilla
+// clone) the test is skipped rather than failed, since the absence is an
+// environment configuration, not a code defect.
+func TestLoadAllFixtures(t *testing.T) {
+	t.Parallel()
+	root := testingRoot(t)
+	if root == "" {
+		t.Skip("testing/ submodule not initialised; run `git submodule update --init testing` to enable interop test")
+	}
+
+	// Some subdirectories ship fixtures that are minimal or experimental.
+	// We still load every file we find; this skip-list is
+	// only for paths that are not graph yaml at all (e.g. transformer rules).
+	type fixture struct {
+		graphPath string
+		fsRoot    string
+	}
+	var fixtures []fixture
+
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(p, ".graph.yml") && !strings.HasSuffix(p, ".graph.yaml") {
+			return nil
+		}
+		// transformer/ directory holds graph yamls used as transformer
+		// inputs; they reference vertex/edge files that may not be in the
+		// same directory tree (split into in/out). Skip those to keep the
+		// gate strict for the core fixture set.
+		if strings.Contains(p, string(os.PathSeparator)+"transformer"+string(os.PathSeparator)) {
+			return nil
+		}
+		// json/ fixtures use file_type: json which is parseable but
+		// rejected by PropertyGroup validation (writable-but-not-valid).
+		// Skip them in the strict
+		// interop gate; readability is covered by the unit-level yaml
+		// tests instead.
+		if strings.Contains(p, string(os.PathSeparator)+"json"+string(os.PathSeparator)) {
+			return nil
+		}
+		dir := filepath.Dir(p)
+		rel, err := filepath.Rel(dir, p)
+		if err != nil {
+			return err
+		}
+		fixtures = append(fixtures, fixture{graphPath: rel, fsRoot: dir})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk testing/: %v", err)
+	}
+	if len(fixtures) == 0 {
+		t.Skip("no *.graph.yml found under testing/; submodule may be empty")
+	}
+
+	t.Logf("loading %d fixture graphs from %s", len(fixtures), root)
+	for _, f := range fixtures {
+		t.Run(filepath.Join(filepath.Base(f.fsRoot), f.graphPath), func(t *testing.T) {
+			fsys := os.DirFS(f.fsRoot)
+			g, err := info.LoadGraphInfo(fsys, f.graphPath)
+			if err != nil {
+				t.Fatalf("LoadGraphInfo(%s/%s): %v", f.fsRoot, f.graphPath, err)
+			}
+			if g.Name() == "" {
+				t.Errorf("loaded graph has empty name")
+			}
+			// Round-trip: marshalling with defaults must reproduce the exact
+			// vertex/edge file references from the original graph yaml.
+			out, err := info.MarshalGraphInfo(g)
+			if err != nil {
+				t.Fatalf("MarshalGraphInfo round-trip: %v", err)
+			}
+			original, err := os.ReadFile(filepath.Join(f.fsRoot, f.graphPath))
+			if err != nil {
+				t.Fatalf("read original graph yaml: %v", err)
+			}
+			wantRefs := graphFileRefs(t, original)
+			gotRefs := graphFileRefs(t, out)
+			if !slices.Equal(wantRefs, gotRefs) {
+				t.Errorf("file references changed on round-trip\n got: %v\nwant: %v", gotRefs, wantRefs)
+			}
+		})
+	}
+}

--- a/go/graphar/info/load.go
+++ b/go/graphar/info/load.go
@@ -1,0 +1,233 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"fmt"
+	"io"
+	iofs "io/fs"
+	"path"
+	"strings"
+
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+// LoadVertexInfo decodes a vertex info YAML document from r.
+//
+// Loading is liberal: any document that parses succeeds, even one that violates
+// GraphAr's semantic rules - call Validate to enforce them. Only unparseable
+// input (bad YAML, an unknown enum, a duplicate property name) or a document
+// that does not name its type is rejected here.
+func LoadVertexInfo(r io.Reader) (*VertexInfo, error) {
+	var y vertexInfoYAML
+	if err := decode(r, &y); err != nil {
+		return nil, err
+	}
+	return vertexInfoFromYAML(y)
+}
+
+// LoadEdgeInfo decodes an edge info YAML document from r. Loading is liberal;
+// see LoadVertexInfo for the read-vs-validate contract. Call Validate on the
+// result to enforce GraphAr's semantic rules.
+func LoadEdgeInfo(r io.Reader) (*EdgeInfo, error) {
+	var y edgeInfoYAML
+	if err := decode(r, &y); err != nil {
+		return nil, err
+	}
+	return edgeInfoFromYAML(y)
+}
+
+// LoadGraphInfo decodes a graph info YAML at graphPath inside fsys and then
+// resolves every referenced vertex/edge file relative to graphPath's directory.
+//
+// References inside the graph yaml are filenames (e.g. "person.vertex.yml")
+// taken as paths relative to the graph yaml's directory. Use path/filepath-style
+// separators acceptable to io/fs.
+//
+// Loading is liberal (see LoadVertexInfo); Validate recurses into every vertex
+// and edge to enforce the full contract, including cross-references.
+func LoadGraphInfo(fsys iofs.FS, graphPath string) (*GraphInfo, error) {
+	gy, err := readGraphYAML(fsys, graphPath)
+	if err != nil {
+		return nil, err
+	}
+	// Minimal completeness: a graph document must name itself, otherwise the
+	// input was some other (mis-filed) document decoded into a zero DTO.
+	if gy.Name == "" {
+		return nil, fmt.Errorf("%q: %w: graph info document has no name", graphPath, ErrInvalidYAML)
+	}
+	dir := path.Dir(graphPath)
+
+	vertices := make([]*VertexInfo, 0, len(gy.Vertices))
+	vertexRefs := make(map[string]string, len(gy.Vertices))
+	for _, vname := range gy.Vertices {
+		vpath, err := joinFSPath(dir, vname)
+		if err != nil {
+			return nil, fmt.Errorf("graph_info(%q).vertices[%q]: %w", graphPath, vname, err)
+		}
+		v, err := loadVertexInfoFile(fsys, vpath)
+		if err != nil {
+			return nil, fmt.Errorf("graph_info(%q).vertices[%q]: %w", graphPath, vname, err)
+		}
+		vertices = append(vertices, v)
+		vertexRefs[v.Type()] = vname
+	}
+	edges := make([]*EdgeInfo, 0, len(gy.Edges))
+	edgeRefs := make(map[EdgeTriplet]string, len(gy.Edges))
+	for _, ename := range gy.Edges {
+		epath, err := joinFSPath(dir, ename)
+		if err != nil {
+			return nil, fmt.Errorf("graph_info(%q).edges[%q]: %w", graphPath, ename, err)
+		}
+		e, err := loadEdgeInfoFile(fsys, epath)
+		if err != nil {
+			return nil, fmt.Errorf("graph_info(%q).edges[%q]: %w", graphPath, ename, err)
+		}
+		edges = append(edges, e)
+		src, edge, dst := e.Triplet()
+		edgeRefs[EdgeTriplet{Src: src, Edge: edge, Dst: dst}] = ename
+	}
+
+	opts := []GraphInfoOption{}
+	if gy.Prefix != "" {
+		opts = append(opts, WithGraphPrefix(gy.Prefix))
+	}
+	if len(vertices) > 0 {
+		opts = append(opts, WithVertices(vertices...), withVertexFileRefs(vertexRefs))
+	}
+	if len(edges) > 0 {
+		opts = append(opts, WithEdges(edges...), withEdgeFileRefs(edgeRefs))
+	}
+	if gy.Version != "" {
+		ver, err := types.ParseInfoVersion(gy.Version)
+		if err != nil {
+			return nil, fmt.Errorf("graph_info.version: %w", err)
+		}
+		opts = append(opts, WithGraphVersion(ver))
+	}
+	if len(gy.Labels) > 0 {
+		opts = append(opts, WithGraphLabels(gy.Labels...))
+	}
+	if len(gy.ExtraInfo) > 0 {
+		extra := make(map[string]string, len(gy.ExtraInfo))
+		for _, kv := range gy.ExtraInfo {
+			extra[kv.Key] = kv.Value
+		}
+		opts = append(opts, WithGraphExtraInfo(extra))
+	}
+	return newGraphInfoUnvalidated(gy.Name, opts...)
+}
+
+func readGraphYAML(fsys iofs.FS, p string) (*graphInfoYAML, error) {
+	f, err := fsys.Open(p)
+	if err != nil {
+		return nil, fmt.Errorf("open %q: %w", p, err)
+	}
+	defer f.Close() //nolint:errcheck // best-effort close on a read-only handle.
+	var y graphInfoYAML
+	if err := decode(f, &y); err != nil {
+		return nil, fmt.Errorf("%q: %w", p, err)
+	}
+	return &y, nil
+}
+
+func loadVertexInfoFile(fsys iofs.FS, p string) (*VertexInfo, error) {
+	f, err := fsys.Open(p)
+	if err != nil {
+		return nil, fmt.Errorf("open %q: %w", p, err)
+	}
+	defer f.Close() //nolint:errcheck // best-effort close.
+	return LoadVertexInfo(f)
+}
+
+func loadEdgeInfoFile(fsys iofs.FS, p string) (*EdgeInfo, error) {
+	f, err := fsys.Open(p)
+	if err != nil {
+		return nil, fmt.Errorf("open %q: %w", p, err)
+	}
+	defer f.Close() //nolint:errcheck // best-effort close.
+	return LoadEdgeInfo(f)
+}
+
+func decode(r io.Reader, out any) error {
+	// Unknown fields are ignored: other SDKs add fields over time (labels,
+	// extra_info, per-adj-list property_groups all arrived late) and a reader
+	// that rejected them would break forward compatibility.
+	dec := yaml.NewDecoder(r)
+	if err := dec.Decode(out); err != nil {
+		// Wrap both sentinels with %w (Go 1.20+ multi-%w) so callers can
+		// errors.Is the package sentinel AND errors.As the underlying
+		// yaml.TypeError / io.ErrUnexpectedEOF / etc. for line numbers.
+		return fmt.Errorf("%w: %w", ErrInvalidYAML, err)
+	}
+	return nil
+}
+
+// validateFileRef checks a vertex/edge file reference: non-empty, not absolute,
+// and a valid relative fs path with no "." or ".." element. Shared by the load
+// path (joinFSPath) and the write path so a graph yaml never references a file
+// the loader would refuse to open.
+func validateFileRef(name string) error {
+	if name == "" {
+		return fmt.Errorf("%w: empty file reference", ErrInvalidGraphInfo)
+	}
+	if strings.HasPrefix(name, "/") {
+		return fmt.Errorf("%w: absolute path %q not allowed", ErrInvalidGraphInfo, name)
+	}
+	// fs.ValidPath(".") is true but "." is a directory, not a file reference.
+	if name == "." {
+		return fmt.Errorf("%w: file reference %q is not a file", ErrInvalidGraphInfo, name)
+	}
+	if !iofs.ValidPath(name) {
+		return fmt.Errorf("%w: invalid file reference %q", ErrInvalidGraphInfo, name)
+	}
+	return nil
+}
+
+// joinFSPath resolves name as a path relative to dir within an io/fs.FS root.
+// It rejects names that escape dir via "..", that start with "/" (absolute),
+// or that are otherwise not fs.ValidPath. The resulting path is always
+// contained within dir; this is the security boundary that backs the
+// "references are relative to the graph yaml's directory" contract.
+func joinFSPath(dir, name string) (string, error) {
+	if err := validateFileRef(name); err != nil {
+		return "", err
+	}
+	var joined string
+	if dir == "" || dir == "." {
+		joined = path.Clean(name)
+	} else {
+		joined = path.Join(dir, name)
+	}
+	// path.Clean / path.Join collapse ".." - an escape attempt either yields
+	// a path outside dir, or (when fs.FS root is the destination) a sibling
+	// directory the graph yaml had no right to reach.
+	if !iofs.ValidPath(joined) {
+		return "", fmt.Errorf("%w: invalid path %q", ErrInvalidGraphInfo, name)
+	}
+	if dir != "" && dir != "." {
+		cleanDir := path.Clean(dir)
+		if joined != cleanDir && !strings.HasPrefix(joined, cleanDir+"/") {
+			return "", fmt.Errorf("%w: file reference %q escapes graph directory %q",
+				ErrInvalidGraphInfo, name, dir)
+		}
+	}
+	return joined, nil
+}

--- a/go/graphar/info/load_test.go
+++ b/go/graphar/info/load_test.go
@@ -1,0 +1,353 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"errors"
+	"io/fs"
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func tinyFixtureFS() fstest.MapFS {
+	return fstest.MapFS{
+		"sample.graph.yml": &fstest.MapFile{Data: []byte(
+			"name: sample\n" +
+				"vertices:\n" +
+				"  - person.vertex.yml\n" +
+				"edges:\n" +
+				"  - person_knows_person.edge.yml\n" +
+				"version: gar/v1\n",
+		)},
+		"person.vertex.yml": &fstest.MapFile{Data: []byte(
+			"type: person\n" +
+				"chunk_size: 100\n" +
+				"prefix: vertex/person/\n" +
+				"property_groups:\n" +
+				"  - properties:\n" +
+				"      - name: id\n" +
+				"        data_type: int64\n" +
+				"        is_primary: true\n" +
+				"    file_type: parquet\n" +
+				"version: gar/v1\n",
+		)},
+		"person_knows_person.edge.yml": &fstest.MapFile{Data: []byte(
+			"src_type: person\n" +
+				"edge_type: knows\n" +
+				"dst_type: person\n" +
+				"chunk_size: 1\n" +
+				"src_chunk_size: 1\n" +
+				"dst_chunk_size: 1\n" +
+				"directed: false\n" +
+				"adj_lists:\n" +
+				"  - ordered: true\n" +
+				"    aligned_by: src\n" +
+				"    file_type: parquet\n" +
+				"version: gar/v1\n",
+		)},
+	}
+}
+
+func TestLoadGraphInfoFlat(t *testing.T) {
+	t.Parallel()
+	g, err := LoadGraphInfo(tinyFixtureFS(), "sample.graph.yml")
+	if err != nil {
+		t.Fatalf("LoadGraphInfo: %v", err)
+	}
+	if g.Name() != "sample" {
+		t.Errorf("name = %q", g.Name())
+	}
+	if _, ok := g.Vertex("person"); !ok {
+		t.Errorf("missing person vertex")
+	}
+	if _, ok := g.Edge("person", "knows", "person"); !ok {
+		t.Errorf("missing person->knows->person edge")
+	}
+}
+
+func TestLoadGraphInfoNestedDir(t *testing.T) {
+	t.Parallel()
+	// Same fixture, placed under a subdirectory to exercise path resolution.
+	files := tinyFixtureFS()
+	nested := fstest.MapFS{}
+	for k, v := range files {
+		nested["graphs/"+k] = v
+	}
+	g, err := LoadGraphInfo(nested, "graphs/sample.graph.yml")
+	if err != nil {
+		t.Fatalf("LoadGraphInfo (nested): %v", err)
+	}
+	if g.Name() != "sample" {
+		t.Errorf("name = %q", g.Name())
+	}
+}
+
+func TestLoadGraphInfoMissingGraphFile(t *testing.T) {
+	t.Parallel()
+	_, err := LoadGraphInfo(tinyFixtureFS(), "missing.graph.yml")
+	if err == nil {
+		t.Fatal("expected error opening missing graph yaml")
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected fs.ErrNotExist, got %v", err)
+	}
+}
+
+func TestLoadGraphInfoMissingReferencedVertex(t *testing.T) {
+	t.Parallel()
+	fsys := fstest.MapFS{
+		"g.graph.yml": &fstest.MapFile{Data: []byte(
+			"name: g\nvertices:\n  - ghost.vertex.yml\nversion: gar/v1\n",
+		)},
+	}
+	_, err := LoadGraphInfo(fsys, "g.graph.yml")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected fs.ErrNotExist for missing vertex file, got %v", err)
+	}
+}
+
+func TestLoadGraphInfoMissingReferencedEdge(t *testing.T) {
+	t.Parallel()
+	fsys := fstest.MapFS{
+		"g.graph.yml": &fstest.MapFile{Data: []byte(
+			"name: g\nedges:\n  - ghost.edge.yml\nversion: gar/v1\n",
+		)},
+	}
+	_, err := LoadGraphInfo(fsys, "g.graph.yml")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected fs.ErrNotExist for missing edge file, got %v", err)
+	}
+}
+
+func TestLoadGraphInfoBadGraphYAML(t *testing.T) {
+	t.Parallel()
+	fsys := fstest.MapFS{
+		"g.graph.yml": &fstest.MapFile{Data: []byte("name: [")},
+	}
+	_, err := LoadGraphInfo(fsys, "g.graph.yml")
+	if !errors.Is(err, ErrInvalidYAML) {
+		t.Errorf("expected ErrInvalidYAML, got %v", err)
+	}
+}
+
+func TestLoadGraphInfoBadVersion(t *testing.T) {
+	t.Parallel()
+	fsys := fstest.MapFS{
+		"g.graph.yml": &fstest.MapFile{Data: []byte("name: g\nversion: bogus\n")},
+	}
+	_, err := LoadGraphInfo(fsys, "g.graph.yml")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLoadGraphInfoRejectsPathTraversal(t *testing.T) {
+	t.Parallel()
+	// References that escape the graph yaml's directory via ".." must be
+	// rejected, even when fsys.Open would otherwise serve them.
+	fsys := fstest.MapFS{
+		"graphs/g.graph.yml": &fstest.MapFile{Data: []byte(
+			"name: g\nvertices:\n  - ../secrets.vertex.yml\nversion: gar/v1\n",
+		)},
+		"secrets.vertex.yml": &fstest.MapFile{Data: []byte(
+			"type: secret\nchunk_size: 1\n" +
+				"property_groups:\n  - properties:\n      - name: id\n        data_type: int64\n        is_primary: true\n    file_type: parquet\n" +
+				"version: gar/v1\n",
+		)},
+	}
+	_, err := LoadGraphInfo(fsys, "graphs/g.graph.yml")
+	if !errors.Is(err, ErrInvalidGraphInfo) {
+		t.Errorf("expected ErrInvalidGraphInfo for path escape, got %v", err)
+	}
+}
+
+func TestLoadGraphInfoRejectsAbsolutePath(t *testing.T) {
+	t.Parallel()
+	fsys := fstest.MapFS{
+		"g.graph.yml": &fstest.MapFile{Data: []byte(
+			"name: g\nvertices:\n  - /etc/passwd.vertex.yml\nversion: gar/v1\n",
+		)},
+	}
+	_, err := LoadGraphInfo(fsys, "g.graph.yml")
+	if !errors.Is(err, ErrInvalidGraphInfo) {
+		t.Errorf("expected ErrInvalidGraphInfo for absolute path, got %v", err)
+	}
+}
+
+func TestLoadGraphInfoRejectsDotFileRef(t *testing.T) {
+	t.Parallel()
+	fsys := fstest.MapFS{
+		"g.graph.yml": &fstest.MapFile{Data: []byte(
+			"name: g\nvertices:\n  - .\nversion: gar/v1\n",
+		)},
+	}
+	_, err := LoadGraphInfo(fsys, "g.graph.yml")
+	if !errors.Is(err, ErrInvalidGraphInfo) {
+		t.Errorf("expected ErrInvalidGraphInfo for \".\" file ref, got %v", err)
+	}
+}
+
+func TestLoadGraphInfoMissingNameRejected(t *testing.T) {
+	t.Parallel()
+	// A non-graph document mis-filed as the graph yaml decodes to a zero name.
+	fsys := fstest.MapFS{
+		"g.graph.yml": &fstest.MapFile{Data: []byte("prefix: p/\nversion: gar/v1\n")},
+	}
+	_, err := LoadGraphInfo(fsys, "g.graph.yml")
+	if !errors.Is(err, ErrInvalidYAML) {
+		t.Errorf("expected ErrInvalidYAML for graph with no name, got %v", err)
+	}
+}
+
+func TestLoadGraphInfoBadCrossRef(t *testing.T) {
+	t.Parallel()
+	// Graph references vertices/edges that exist as files but the edge
+	// triplet refers to a vertex type not declared in the graph itself.
+	fsys := fstest.MapFS{
+		"g.graph.yml": &fstest.MapFile{Data: []byte(
+			"name: g\n" +
+				"vertices:\n  - a.vertex.yml\n" +
+				"edges:\n  - a_k_ghost.edge.yml\n" +
+				"version: gar/v1\n",
+		)},
+		"a.vertex.yml": &fstest.MapFile{Data: []byte(
+			"type: a\nchunk_size: 1\n" +
+				"property_groups:\n  - properties:\n      - name: id\n        data_type: int64\n        is_primary: true\n    file_type: parquet\n" +
+				"version: gar/v1\n",
+		)},
+		"a_k_ghost.edge.yml": &fstest.MapFile{Data: []byte(
+			"src_type: a\nedge_type: k\ndst_type: ghost\n" +
+				"chunk_size: 1\nsrc_chunk_size: 1\ndst_chunk_size: 1\ndirected: false\n" +
+				"adj_lists:\n  - type: ordered_by_source\n    file_type: parquet\n" +
+				"version: gar/v1\n",
+		)},
+	}
+	// Liberal read: the graph loads even though an edge references an
+	// undeclared vertex; Validate is what surfaces the cross-reference error.
+	g, err := LoadGraphInfo(fsys, "g.graph.yml")
+	if err != nil {
+		t.Fatalf("LoadGraphInfo should be liberal, got load error: %v", err)
+	}
+	if err := g.Validate(); !errors.Is(err, ErrInvalidGraphInfo) {
+		t.Errorf("expected ErrInvalidGraphInfo from Validate (unknown vertex referenced), got %v", err)
+	}
+}
+
+// TestGraphInfoPreservesFileRefs checks that a file reference not matching the
+// derived default ("People.vertex.yml" for type "person") survives a load and
+// re-marshal instead of silently becoming "person.vertex.yml".
+func TestGraphInfoPreservesFileRefs(t *testing.T) {
+	t.Parallel()
+	src := fstest.MapFS{
+		"g.graph.yml": &fstest.MapFile{Data: []byte(
+			"name: g\nvertices:\n  - People.vertex.yml\nversion: gar/v1\n")},
+		"People.vertex.yml": &fstest.MapFile{Data: []byte(
+			"type: person\nchunk_size: 1\n" +
+				"property_groups:\n  - file_type: parquet\n    properties:\n      - name: id\n        data_type: int64\n        is_primary: true\n" +
+				"version: gar/v1\n")},
+	}
+	g, err := LoadGraphInfo(src, "g.graph.yml")
+	if err != nil {
+		t.Fatalf("LoadGraphInfo: %v", err)
+	}
+	if name, ok := g.VertexFileName("person"); !ok || name != "People.vertex.yml" {
+		t.Errorf("VertexFileName(person) = %q,%v, want People.vertex.yml,true", name, ok)
+	}
+	out, err := MarshalGraphInfo(g)
+	if err != nil {
+		t.Fatalf("MarshalGraphInfo: %v", err)
+	}
+	if s := string(out); !strings.Contains(s, "People.vertex.yml") || strings.Contains(s, "person.vertex.yml") {
+		t.Errorf("marshaled refs not preserved\n%s", s)
+	}
+}
+
+// TestGraphInfoLabelsAndExtraInfoRoundTrip covers modelling of graph-level
+// labels and the extra_info key/value list: they used to trip KnownFields and
+// be rejected; now they load, are queryable, and survive a marshal round-trip.
+func TestGraphInfoLabelsAndExtraInfoRoundTrip(t *testing.T) {
+	t.Parallel()
+	vfile := &fstest.MapFile{Data: []byte(
+		"type: a\nchunk_size: 1\n" +
+			"property_groups:\n  - file_type: parquet\n    properties:\n      - name: id\n        data_type: int64\n        is_primary: true\n" +
+			"version: gar/v1\n")}
+	src := fstest.MapFS{
+		"g.graph.yml": &fstest.MapFile{Data: []byte(
+			"name: g\n" +
+				"vertices:\n  - a.vertex.yml\n" +
+				"labels:\n  - lbl1\n  - lbl2\n" +
+				"extra_info:\n  - key: author\n    value: zeki\n  - key: created\n    value: \"2026\"\n" +
+				"version: gar/v1\n")},
+		"a.vertex.yml": vfile,
+	}
+	g, err := LoadGraphInfo(src, "g.graph.yml")
+	if err != nil {
+		t.Fatalf("LoadGraphInfo: %v", err)
+	}
+	if got := g.Labels(); !slices.Equal(got, []string{"lbl1", "lbl2"}) {
+		t.Errorf("Labels() = %v, want [lbl1 lbl2]", got)
+	}
+	if ei := g.ExtraInfo(); ei["author"] != "zeki" || ei["created"] != "2026" {
+		t.Errorf("ExtraInfo() = %v", ei)
+	}
+
+	out, err := MarshalGraphInfo(g)
+	if err != nil {
+		t.Fatalf("MarshalGraphInfo: %v", err)
+	}
+	rt := fstest.MapFS{
+		"g.graph.yml":  &fstest.MapFile{Data: out},
+		"a.vertex.yml": vfile,
+	}
+	g2, err := LoadGraphInfo(rt, "g.graph.yml")
+	if err != nil {
+		t.Fatalf("re-LoadGraphInfo: %v", err)
+	}
+	if !slices.Equal(g2.Labels(), g.Labels()) {
+		t.Errorf("labels lost on round-trip: %v", g2.Labels())
+	}
+	if !maps.Equal(g2.ExtraInfo(), g.ExtraInfo()) {
+		t.Errorf("extra_info lost on round-trip: %v", g2.ExtraInfo())
+	}
+}
+
+// TestLoadGraphInfoLiberalValidateRecursion covers that a graph with a
+// semantically invalid child (a CSV property group carrying a list type) LOADS
+// but is rejected by Validate - exercising the graph -> vertex ->
+// property-group validation recursion introduced with the liberal-read change.
+func TestLoadGraphInfoLiberalValidateRecursion(t *testing.T) {
+	t.Parallel()
+	fsys := fstest.MapFS{
+		"g.graph.yml": &fstest.MapFile{Data: []byte(
+			"name: g\nvertices:\n  - a.vertex.yml\nversion: gar/v1\n")},
+		"a.vertex.yml": &fstest.MapFile{Data: []byte(
+			"type: a\nchunk_size: 1\n" +
+				"property_groups:\n  - file_type: csv\n    properties:\n      - name: tags\n        data_type: list<int32>\n        is_primary: false\n" +
+				"version: gar/v1\n")},
+	}
+	g, err := LoadGraphInfo(fsys, "g.graph.yml")
+	if err != nil {
+		t.Fatalf("liberal load should accept csv+list, got %v", err)
+	}
+	if err := g.Validate(); !errors.Is(err, ErrInvalidPropertyGroup) {
+		t.Errorf("Validate should reject csv+list via recursion, got %v", err)
+	}
+}

--- a/go/graphar/info/property.go
+++ b/go/graphar/info/property.go
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+// Property is a single named field within a PropertyGroup.
+//
+// The zero value of Property is not legal (Name and Type are required); use
+// NewProperty or populate the fields explicitly before passing to
+// PropertyGroup.
+type Property struct {
+	// Name is the on-disk column name. Required, non-empty.
+	Name string
+	// Type is the logical data type.
+	Type types.DataType
+	// IsPrimary marks the property as part of the primary key. Primary
+	// properties may not be nullable.
+	IsPrimary bool
+	// IsNullable indicates whether the property may be absent in a record.
+	// The on-disk default (applied by the loader and by NewProperty) is
+	// !IsPrimary - non-primary properties are nullable unless stated otherwise;
+	// the zero value of a bare Property literal is false.
+	IsNullable bool
+	// Cardinality is the multiplicity of values. Defaults to CardinalitySingle.
+	// Edge properties must remain CardinalitySingle.
+	Cardinality types.Cardinality
+}
+
+// NewProperty constructs a Property with the on-disk defaults
+// (IsNullable = !isPrimary, same as the loader; Cardinality = single) and
+// validates it.
+func NewProperty(name string, dt types.DataType, isPrimary bool) (Property, error) {
+	p := Property{
+		Name:        name,
+		Type:        dt,
+		IsPrimary:   isPrimary,
+		IsNullable:  !isPrimary,
+		Cardinality: types.CardinalitySingle,
+	}
+	if err := p.Validate(); err != nil {
+		return Property{}, err
+	}
+	return p, nil
+}
+
+// Validate returns a ValidationError if p is malformed.
+func (p Property) Validate() error {
+	if p.Name == "" {
+		return newValidationError(ErrInvalidProperty, "name", "must not be empty")
+	}
+	if p.Type.IsZero() {
+		return newValidationError(ErrInvalidProperty, "data_type",
+			"property %q has no data type set; use one of the types factory functions", p.Name)
+	}
+	if err := p.Type.Validate(); err != nil {
+		ve := newValidationError(ErrInvalidProperty, "data_type",
+			"property %q: %s", p.Name, err)
+		ve.Cause = err
+		return ve
+	}
+	if p.IsPrimary && p.IsNullable {
+		return newValidationError(ErrInvalidProperty, "is_nullable",
+			"primary property %q must not be nullable", p.Name)
+	}
+	// We do not constrain Cardinality here: edge-specific
+	// restrictions live with EdgeInfo.Validate to keep this type reusable.
+	return nil
+}
+
+// Equal reports whether two properties describe the same field.
+func (p Property) Equal(other Property) bool {
+	return p.Name == other.Name &&
+		p.Type.Equal(other.Type) &&
+		p.IsPrimary == other.IsPrimary &&
+		p.IsNullable == other.IsNullable &&
+		p.Cardinality == other.Cardinality
+}

--- a/go/graphar/info/property_group.go
+++ b/go/graphar/info/property_group.go
@@ -1,0 +1,288 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+// clonePropertyGroups returns an independent copy of in: the outer slice is
+// fresh, and each PropertyGroup's Properties slice is cloned so callers cannot
+// mutate stored state through aliased backing arrays.
+func clonePropertyGroups(in []PropertyGroup) []PropertyGroup {
+	out := make([]PropertyGroup, len(in))
+	for i, g := range in {
+		out[i] = g
+		out[i].Properties = slices.Clone(g.Properties)
+	}
+	return out
+}
+
+// validateUserDefinedTypes checks that every user-defined property type in pg
+// is declared in ver's UserDefinedTypes list, matching how a version records
+// the custom types a document may use. A nil pg passes.
+func validateUserDefinedTypes(pg *PropertyGroups, ver types.InfoVersion, sentinel error) error {
+	if pg == nil {
+		return nil
+	}
+	declared := make(map[string]struct{}, len(ver.UserDefinedTypes))
+	for _, t := range ver.UserDefinedTypes {
+		declared[t] = struct{}{}
+	}
+	for _, name := range pg.Names() {
+		p, _, _ := pg.Property(name)
+		if p.Type.ID() != types.UserDefinedType {
+			continue
+		}
+		if _, ok := declared[p.Type.UserDefinedName()]; !ok {
+			return newValidationError(sentinel, "property_groups.properties.data_type",
+				"user-defined type %q of property %q is not declared in version %q",
+				p.Type.UserDefinedName(), p.Name, ver.String())
+		}
+	}
+	return nil
+}
+
+// PropertyGroup is a contiguous set of properties stored together in one
+// physical file (per chunk).
+type PropertyGroup struct {
+	// Properties listed in declaration order. Must be non-empty.
+	Properties []Property
+	// FileType is the on-disk physical format.
+	FileType types.FileType
+	// Prefix is the subdirectory under the vertex/edge prefix that holds this
+	// group's files. When empty, the prefix is derived by joining
+	// the property names with '_'.
+	Prefix string
+}
+
+// EffectivePrefix returns the explicit Prefix (normalised to one trailing
+// slash) or, when empty, the property names joined by '_' plus a slash.
+func (g PropertyGroup) EffectivePrefix() string {
+	if g.Prefix != "" {
+		return strings.TrimRight(g.Prefix, "/") + "/"
+	}
+	names := make([]string, 0, len(g.Properties))
+	for _, p := range g.Properties {
+		names = append(names, p.Name)
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	return strings.Join(names, "_") + "/"
+}
+
+// Validate checks the group is well-formed: a valid FileType (json rejected),
+// non-empty unique-named properties, and the CSV-only restriction against list
+// types and non-single cardinality.
+func (g PropertyGroup) Validate() error {
+	if g.FileType.IsZero() {
+		return newValidationError(ErrInvalidPropertyGroup, "file_type",
+			"property group must specify a file type")
+	}
+	if g.FileType == types.FileTypeJSON {
+		return newValidationError(ErrInvalidPropertyGroup, "file_type",
+			"json file type is not supported in property groups")
+	}
+	if len(g.Properties) == 0 {
+		return newValidationError(ErrInvalidPropertyGroup, "properties",
+			"property group must have at least one property")
+	}
+	seen := make(map[string]struct{}, len(g.Properties))
+	for i, p := range g.Properties {
+		if err := p.Validate(); err != nil {
+			return fmt.Errorf("properties[%d]: %w", i, err)
+		}
+		if _, dup := seen[p.Name]; dup {
+			return newValidationError(ErrInvalidPropertyGroup,
+				fmt.Sprintf("properties[%d].name", i),
+				"duplicate property name %q within group", p.Name)
+		}
+		seen[p.Name] = struct{}{}
+		// CSV can't hold lists or multi-value cardinality.
+		if g.FileType == types.FileTypeCSV {
+			if p.Type.ID() == types.ListType {
+				return newValidationError(ErrInvalidPropertyGroup,
+					fmt.Sprintf("properties[%d].data_type", i),
+					"property %q: csv file type does not support list data type", p.Name)
+			}
+			if p.Cardinality != types.CardinalitySingle {
+				return newValidationError(ErrInvalidPropertyGroup,
+					fmt.Sprintf("properties[%d].cardinality", i),
+					"property %q: csv file type requires cardinality single, got %s",
+					p.Name, p.Cardinality)
+			}
+		}
+	}
+	return nil
+}
+
+// Equal reports whether two property groups carry the same fields in the
+// same order.
+func (g PropertyGroup) Equal(other PropertyGroup) bool {
+	return g.FileType == other.FileType && g.Prefix == other.Prefix &&
+		slices.EqualFunc(g.Properties, other.Properties, Property.Equal)
+}
+
+// PropertyGroups is a read-only collection of PropertyGroup with name-based
+// indexes. Build via NewPropertyGroups, which validates the input and
+// constructs the lookup tables once.
+type PropertyGroups struct {
+	groups []PropertyGroup
+	// byName maps property name → index into groups.
+	byName map[string]int
+	// names is the flat list of property names for ordered iteration.
+	names []string
+}
+
+// buildPropertyGroups clones the groups and builds the name index without
+// validating contents (the liberal load path). It errors only on a duplicate
+// property name, which the index cannot represent; empty input is allowed.
+func buildPropertyGroups(groups []PropertyGroup) (*PropertyGroups, error) {
+	cp := clonePropertyGroups(groups)
+	byName := make(map[string]int)
+	names := make([]string, 0)
+	for i, g := range cp {
+		for _, p := range g.Properties {
+			if prev, dup := byName[p.Name]; dup {
+				return nil, newValidationError(ErrInvalidPropertyGroup,
+					fmt.Sprintf("property_groups[%d].properties.name", i),
+					"property %q already declared in group %d", p.Name, prev)
+			}
+			byName[p.Name] = i
+			names = append(names, p.Name)
+		}
+	}
+	return &PropertyGroups{groups: cp, byName: byName, names: names}, nil
+}
+
+// NewPropertyGroups validates the groups and builds a queryable index. A nil
+// or empty input is rejected. This is the strict programmatic constructor; the
+// load path uses buildPropertyGroups plus an explicit Validate.
+func NewPropertyGroups(groups []PropertyGroup) (*PropertyGroups, error) {
+	if len(groups) == 0 {
+		return nil, newValidationError(ErrInvalidPropertyGroup, "property_groups",
+			"at least one property group is required")
+	}
+	pg, err := buildPropertyGroups(groups)
+	if err != nil {
+		return nil, err
+	}
+	if err := pg.Validate(); err != nil {
+		return nil, err
+	}
+	return pg, nil
+}
+
+// Validate checks every contained property group. It does not enforce
+// non-emptiness - an empty set is valid at this level; vertex/edge-specific
+// rules live on their respective Validate methods.
+func (pg *PropertyGroups) Validate() error {
+	for i, g := range pg.groups {
+		if err := g.Validate(); err != nil {
+			return fmt.Errorf("property_groups[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// Groups returns an independent copy of the underlying groups. Callers may
+// mutate the returned slice - including each group's Properties - without
+// affecting the receiver.
+func (pg *PropertyGroups) Groups() []PropertyGroup {
+	return clonePropertyGroups(pg.groups)
+}
+
+// Names returns property names in declaration order.
+func (pg *PropertyGroups) Names() []string {
+	return slices.Clone(pg.names)
+}
+
+// Has reports whether a property with the given name exists.
+func (pg *PropertyGroups) Has(name string) bool {
+	_, ok := pg.byName[name]
+	return ok
+}
+
+// Property returns the named property and the group index it belongs to.
+// Reports false when the name is unknown.
+func (pg *PropertyGroups) Property(name string) (Property, int, bool) {
+	idx, ok := pg.byName[name]
+	if !ok {
+		return Property{}, -1, false
+	}
+	for _, p := range pg.groups[idx].Properties {
+		if p.Name == name {
+			return p, idx, true
+		}
+	}
+	return Property{}, -1, false
+}
+
+// PropertyType returns the data type of the named property.
+func (pg *PropertyGroups) PropertyType(name string) (types.DataType, bool) {
+	p, _, ok := pg.Property(name)
+	if !ok {
+		return types.DataType{}, false
+	}
+	return p.Type, true
+}
+
+// IsPrimary reports whether the named property is part of the primary key.
+// Returns false if the name is unknown.
+func (pg *PropertyGroups) IsPrimary(name string) bool {
+	p, _, ok := pg.Property(name)
+	return ok && p.IsPrimary
+}
+
+// IsNullable reports whether the named property is nullable. Returns false
+// if the name is unknown.
+func (pg *PropertyGroups) IsNullable(name string) bool {
+	p, _, ok := pg.Property(name)
+	return ok && p.IsNullable
+}
+
+// GroupOf returns the group that contains the named property. The returned
+// group is an independent copy; mutating it (including its Properties) does
+// not affect the receiver.
+func (pg *PropertyGroups) GroupOf(name string) (PropertyGroup, bool) {
+	idx, ok := pg.byName[name]
+	if !ok {
+		return PropertyGroup{}, false
+	}
+	g := pg.groups[idx]
+	g.Properties = slices.Clone(g.Properties)
+	return g, true
+}
+
+// Len returns the number of groups.
+func (pg *PropertyGroups) Len() int { return len(pg.groups) }
+
+// HasGroup reports whether g (by structural equality) is among the groups.
+func (pg *PropertyGroups) HasGroup(g PropertyGroup) bool {
+	for _, candidate := range pg.groups {
+		if candidate.Equal(g) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/graphar/info/property_group_test.go
+++ b/go/graphar/info/property_group_test.go
@@ -1,0 +1,376 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+func makeProp(name string, dt types.DataType, primary bool) Property {
+	return Property{Name: name, Type: dt, IsPrimary: primary, Cardinality: types.CardinalitySingle}
+}
+
+func TestPropertyGroupEffectivePrefix(t *testing.T) {
+	t.Parallel()
+	g := PropertyGroup{
+		Properties: []Property{makeProp("a", types.Int32(), false), makeProp("b", types.Int32(), false)},
+		FileType:   types.FileTypeParquet,
+	}
+	if got := g.EffectivePrefix(); got != "a_b/" {
+		t.Errorf("EffectivePrefix() = %q, want a_b/", got)
+	}
+	g.Prefix = "name_age/"
+	if got := g.EffectivePrefix(); got != "name_age/" {
+		t.Errorf("explicit prefix not honoured: %q", got)
+	}
+	// An explicit prefix without a trailing slash is normalised to one.
+	g.Prefix = "name_age"
+	if got := g.EffectivePrefix(); got != "name_age/" {
+		t.Errorf("prefix trailing slash not normalised: %q", got)
+	}
+	// Empty group: EffectivePrefix returns empty so we don't synthesise "/"
+	empty := PropertyGroup{FileType: types.FileTypeCSV}
+	if got := empty.EffectivePrefix(); got != "" {
+		t.Errorf("empty group EffectivePrefix = %q", got)
+	}
+}
+
+func TestPropertyGroupValidate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		group PropertyGroup
+		want  error
+	}{
+		{
+			name:  "empty properties",
+			group: PropertyGroup{FileType: types.FileTypeParquet},
+			want:  ErrInvalidPropertyGroup,
+		},
+		{
+			name: "invalid inner property",
+			group: PropertyGroup{
+				Properties: []Property{{Type: types.Int32()}}, // missing name
+				FileType:   types.FileTypeParquet,
+			},
+			want: ErrInvalidProperty,
+		},
+		{
+			name: "duplicate property name",
+			group: PropertyGroup{
+				Properties: []Property{makeProp("x", types.Int32(), false), makeProp("x", types.Int64(), false)},
+				FileType:   types.FileTypeParquet,
+			},
+			want: ErrInvalidPropertyGroup,
+		},
+		{
+			name: "json file type rejected",
+			group: PropertyGroup{
+				Properties: []Property{makeProp("a", types.Int32(), false)},
+				FileType:   types.FileTypeJSON,
+			},
+			want: ErrInvalidPropertyGroup,
+		},
+		{
+			name: "csv rejects list data type",
+			group: PropertyGroup{
+				Properties: []Property{makeProp("t", types.List(types.Int32()), false)},
+				FileType:   types.FileTypeCSV,
+			},
+			want: ErrInvalidPropertyGroup,
+		},
+		{
+			name: "csv rejects non-single cardinality",
+			group: PropertyGroup{
+				Properties: []Property{{Name: "t", Type: types.String(), Cardinality: types.CardinalityList}},
+				FileType:   types.FileTypeCSV,
+			},
+			want: ErrInvalidPropertyGroup,
+		},
+		{
+			name: "csv allows scalar single (control)",
+			group: PropertyGroup{
+				Properties: []Property{makeProp("a", types.Int32(), false)},
+				FileType:   types.FileTypeCSV,
+			},
+			want: nil,
+		},
+		{
+			name: "parquet allows list (control)",
+			group: PropertyGroup{
+				Properties: []Property{makeProp("t", types.List(types.Int32()), false)},
+				FileType:   types.FileTypeParquet,
+			},
+			want: nil,
+		},
+		{
+			name: "ok",
+			group: PropertyGroup{
+				Properties: []Property{makeProp("a", types.Int32(), false)},
+				FileType:   types.FileTypeParquet,
+			},
+			want: nil,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.group.Validate()
+			if c.want == nil {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, c.want) {
+				t.Errorf("got %v, want wrap of %v", err, c.want)
+			}
+		})
+	}
+}
+
+func TestPropertyGroupEqual(t *testing.T) {
+	t.Parallel()
+	base := PropertyGroup{
+		Properties: []Property{makeProp("a", types.Int32(), false)},
+		FileType:   types.FileTypeParquet,
+		Prefix:     "p/",
+	}
+	if !base.Equal(base) {
+		t.Error("reflexive failed")
+	}
+	other := base
+	other.FileType = types.FileTypeCSV
+	if base.Equal(other) {
+		t.Error("different file types reported equal")
+	}
+	other = base
+	other.Prefix = "q/"
+	if base.Equal(other) {
+		t.Error("different prefixes reported equal")
+	}
+	other = base
+	other.Properties = []Property{makeProp("a", types.Int64(), false)}
+	if base.Equal(other) {
+		t.Error("different inner properties reported equal")
+	}
+	other = base
+	other.Properties = append([]Property{makeProp("x", types.Int32(), false)}, other.Properties...)
+	if base.Equal(other) {
+		t.Error("different property lists (length) reported equal")
+	}
+}
+
+func TestNewPropertyGroupsEmpty(t *testing.T) {
+	t.Parallel()
+	_, err := NewPropertyGroups(nil)
+	if !errors.Is(err, ErrInvalidPropertyGroup) {
+		t.Errorf("expected ErrInvalidPropertyGroup, got %v", err)
+	}
+	_, err = NewPropertyGroups([]PropertyGroup{})
+	if !errors.Is(err, ErrInvalidPropertyGroup) {
+		t.Errorf("expected ErrInvalidPropertyGroup, got %v", err)
+	}
+}
+
+func TestNewPropertyGroupsDuplicateAcrossGroups(t *testing.T) {
+	t.Parallel()
+	g1 := PropertyGroup{
+		Properties: []Property{makeProp("id", types.Int64(), true)},
+		FileType:   types.FileTypeParquet,
+	}
+	g2 := PropertyGroup{
+		Properties: []Property{makeProp("id", types.Int64(), false)},
+		FileType:   types.FileTypeParquet,
+	}
+	_, err := NewPropertyGroups([]PropertyGroup{g1, g2})
+	if !errors.Is(err, ErrInvalidPropertyGroup) {
+		t.Errorf("expected ErrInvalidPropertyGroup, got %v", err)
+	}
+}
+
+func TestPropertyGroupsLookup(t *testing.T) {
+	t.Parallel()
+	pg, err := NewPropertyGroups([]PropertyGroup{
+		{Properties: []Property{makeProp("id", types.Int64(), true)}, FileType: types.FileTypeParquet},
+		{Properties: []Property{
+			makeProp("firstName", types.String(), false),
+			{Name: "age", Type: types.Int32(), IsNullable: true, Cardinality: types.CardinalitySingle},
+		}, FileType: types.FileTypeParquet},
+	})
+	if err != nil {
+		t.Fatalf("NewPropertyGroups: %v", err)
+	}
+	if pg.Len() != 2 {
+		t.Errorf("Len = %d, want 2", pg.Len())
+	}
+	if !pg.Has("id") || pg.Has("missing") {
+		t.Errorf("Has incorrect")
+	}
+	if dt, ok := pg.PropertyType("firstName"); !ok || !dt.Equal(types.String()) {
+		t.Errorf("PropertyType(firstName) = %v ok=%v", dt, ok)
+	}
+	if _, ok := pg.PropertyType("missing"); ok {
+		t.Errorf("PropertyType for missing returned ok=true")
+	}
+	if !pg.IsPrimary("id") {
+		t.Errorf("IsPrimary(id) should be true")
+	}
+	if pg.IsPrimary("missing") {
+		t.Errorf("IsPrimary(missing) should be false")
+	}
+	if !pg.IsNullable("age") {
+		t.Errorf("IsNullable(age) should be true")
+	}
+	if pg.IsNullable("missing") {
+		t.Errorf("IsNullable(missing) should be false")
+	}
+
+	p, idx, ok := pg.Property("id")
+	if !ok || idx != 0 || p.Name != "id" {
+		t.Errorf("Property(id) = (%+v, %d, %v)", p, idx, ok)
+	}
+	if _, _, ok := pg.Property("nope"); ok {
+		t.Errorf("Property(nope) returned ok=true")
+	}
+
+	if g, ok := pg.GroupOf("firstName"); !ok || g.FileType != types.FileTypeParquet {
+		t.Errorf("GroupOf(firstName) = (%+v, %v)", g, ok)
+	}
+	if _, ok := pg.GroupOf("nope"); ok {
+		t.Errorf("GroupOf(nope) returned ok=true")
+	}
+
+	names := pg.Names()
+	if len(names) != 3 || names[0] != "id" || names[1] != "firstName" || names[2] != "age" {
+		t.Errorf("Names = %v", names)
+	}
+
+	groups := pg.Groups()
+	if len(groups) != 2 {
+		t.Errorf("Groups len = %d", len(groups))
+	}
+	if !pg.HasGroup(groups[0]) {
+		t.Errorf("HasGroup self-check failed")
+	}
+	stranger := PropertyGroup{Properties: []Property{makeProp("z", types.Int32(), false)}, FileType: types.FileTypeCSV}
+	if pg.HasGroup(stranger) {
+		t.Errorf("HasGroup returned true for stranger")
+	}
+}
+
+func TestPropertyGroupsDefensiveCopy(t *testing.T) {
+	t.Parallel()
+	g := PropertyGroup{
+		Properties: []Property{makeProp("id", types.Int64(), true)},
+		FileType:   types.FileTypeParquet,
+	}
+	pg, err := NewPropertyGroups([]PropertyGroup{g})
+	if err != nil {
+		t.Fatalf("NewPropertyGroups: %v", err)
+	}
+	// Mutating the returned slice must not affect the receiver.
+	out := pg.Groups()
+	out[0] = PropertyGroup{}
+	if !pg.HasGroup(g) {
+		t.Errorf("PropertyGroups was mutated via Groups() copy")
+	}
+	names := pg.Names()
+	names[0] = "mutated"
+	if pg.Names()[0] == "mutated" {
+		t.Errorf("Names() did not return a defensive copy")
+	}
+}
+
+func TestPropertyGroupsDeepCopyOnConstruct(t *testing.T) {
+	t.Parallel()
+	// Mutating the caller's input AFTER NewPropertyGroups returned must not
+	// be visible through the receiver - guards against the shallow-copy
+	// aliasing surfaced by the audit.
+	props := []Property{makeProp("id", types.Int64(), true)}
+	in := []PropertyGroup{{Properties: props, FileType: types.FileTypeParquet}}
+	pg, err := NewPropertyGroups(in)
+	if err != nil {
+		t.Fatalf("NewPropertyGroups: %v", err)
+	}
+	props[0].Name = "leaked"
+	in[0].Properties[0].IsPrimary = false
+	in[0].FileType = types.FileTypeCSV
+
+	if !pg.IsPrimary("id") {
+		t.Error("input mutation leaked through inner Properties slice")
+	}
+	if pg.Has("leaked") {
+		t.Error("input mutation introduced a name into the receiver")
+	}
+	got, _ := pg.GroupOf("id")
+	if got.FileType != types.FileTypeParquet {
+		t.Errorf("outer-group field leaked: FileType=%v", got.FileType)
+	}
+}
+
+func TestPropertyGroupsDeepCopyOnRead(t *testing.T) {
+	t.Parallel()
+	// Mutating the slice returned by Groups() - including each group's
+	// Properties - must not affect the receiver.
+	pg, err := NewPropertyGroups([]PropertyGroup{{
+		Properties: []Property{makeProp("id", types.Int64(), true)},
+		FileType:   types.FileTypeParquet,
+	}})
+	if err != nil {
+		t.Fatalf("NewPropertyGroups: %v", err)
+	}
+	out := pg.Groups()
+	out[0].Properties[0].IsPrimary = false
+	out[0].Properties[0].Name = "renamed"
+
+	if !pg.IsPrimary("id") {
+		t.Error("mutation via Groups()[0].Properties[0] leaked into receiver")
+	}
+	if pg.Has("renamed") {
+		t.Error("mutation introduced a new name into the receiver index")
+	}
+}
+
+func TestPropertyGroupsGroupOfDefensiveCopy(t *testing.T) {
+	t.Parallel()
+	// Mutating the group returned by GroupOf() - including its Properties -
+	// must not affect the receiver.
+	pg, err := NewPropertyGroups([]PropertyGroup{{
+		Properties: []Property{makeProp("id", types.Int64(), true)},
+		FileType:   types.FileTypeParquet,
+	}})
+	if err != nil {
+		t.Fatalf("NewPropertyGroups: %v", err)
+	}
+	got, ok := pg.GroupOf("id")
+	if !ok {
+		t.Fatal("GroupOf(id) returned ok=false")
+	}
+	got.Properties[0].IsPrimary = false
+	got.Properties[0].Name = "renamed"
+
+	if !pg.IsPrimary("id") {
+		t.Error("mutation via GroupOf().Properties[0] leaked into receiver")
+	}
+	if pg.Has("renamed") {
+		t.Error("mutation introduced a new name into the receiver index")
+	}
+}

--- a/go/graphar/info/property_test.go
+++ b/go/graphar/info/property_test.go
@@ -1,0 +1,163 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+func TestNewPropertyDefaults(t *testing.T) {
+	t.Parallel()
+	// Primary: not nullable.
+	p, err := NewProperty("id", types.Int64(), true)
+	if err != nil {
+		t.Fatalf("NewProperty: %v", err)
+	}
+	if p.Cardinality != types.CardinalitySingle {
+		t.Errorf("default cardinality = %v, want single", p.Cardinality)
+	}
+	if p.IsNullable {
+		t.Errorf("primary property default IsNullable should be false")
+	}
+	// Non-primary: nullable by default, matching the loader default.
+	np, err := NewProperty("name", types.String(), false)
+	if err != nil {
+		t.Fatalf("NewProperty: %v", err)
+	}
+	if !np.IsNullable {
+		t.Errorf("non-primary property default IsNullable should be true")
+	}
+}
+
+func TestPropertyValidateRejectsEmptyName(t *testing.T) {
+	t.Parallel()
+	p := Property{Type: types.Int64()}
+	err := p.Validate()
+	if !errors.Is(err, ErrInvalidProperty) {
+		t.Fatalf("expected ErrInvalidProperty, got %v", err)
+	}
+	var ve *ValidationError
+	if !errors.As(err, &ve) || ve.Field != "name" {
+		t.Errorf("expected field=name, got %+v", ve)
+	}
+}
+
+func TestPropertyValidatePrimaryNotNullable(t *testing.T) {
+	t.Parallel()
+	p := Property{Name: "id", Type: types.Int64(), IsPrimary: true, IsNullable: true}
+	err := p.Validate()
+	if !errors.Is(err, ErrInvalidProperty) {
+		t.Fatalf("expected ErrInvalidProperty, got %v", err)
+	}
+}
+
+func TestPropertyEqual(t *testing.T) {
+	t.Parallel()
+	a := Property{Name: "x", Type: types.Int32(), Cardinality: types.CardinalitySingle}
+	if !a.Equal(a) {
+		t.Error("reflexive equality failed")
+	}
+	cases := []struct {
+		mutate func(p *Property)
+		label  string
+	}{
+		{func(p *Property) { p.Name = "y" }, "name"},
+		{func(p *Property) { p.Type = types.Int64() }, "type"},
+		{func(p *Property) { p.IsPrimary = true }, "primary"},
+		{func(p *Property) { p.IsNullable = true }, "nullable"},
+		{func(p *Property) { p.Cardinality = types.CardinalityList }, "cardinality"},
+	}
+	for _, c := range cases {
+		b := a
+		c.mutate(&b)
+		if a.Equal(b) {
+			t.Errorf("equal returned true after mutating %s", c.label)
+		}
+	}
+}
+
+func TestNewPropertyValidatesEmptyName(t *testing.T) {
+	t.Parallel()
+	_, err := NewProperty("", types.Int64(), false)
+	if !errors.Is(err, ErrInvalidProperty) {
+		t.Fatalf("expected ErrInvalidProperty, got %v", err)
+	}
+}
+
+func TestPropertyValidateRejectsZeroType(t *testing.T) {
+	t.Parallel()
+	// A hand-constructed Property whose Type was never set must be rejected
+	// rather than silently serialising as "bool".
+	p := Property{Name: "id", IsPrimary: true}
+	err := p.Validate()
+	if !errors.Is(err, ErrInvalidProperty) {
+		t.Fatalf("expected ErrInvalidProperty for unset type, got %v", err)
+	}
+}
+
+func TestNewPropertyRejectsMalformedType(t *testing.T) {
+	t.Parallel()
+	bad := []struct {
+		name string
+		dt   types.DataType
+	}{
+		{"list of unset", types.List(types.DataType{})},
+		{"list of bool", types.List(types.Bool())},
+		{"list of date", types.List(types.Date())},
+		{"nested list", types.List(types.List(types.Int32()))},
+		{"empty user-defined", types.UserDefined("")},
+	}
+	for _, c := range bad {
+		if _, err := NewProperty("x", c.dt, false); !errors.Is(err, ErrInvalidProperty) {
+			t.Errorf("NewProperty(%s) = %v, want ErrInvalidProperty", c.name, err)
+		}
+	}
+}
+
+func TestNewPropertyAcceptsSupportedTypes(t *testing.T) {
+	t.Parallel()
+	ok := []types.DataType{
+		types.List(types.Int32()), types.List(types.String()),
+		types.UserDefined("geometry"),
+	}
+	for _, dt := range ok {
+		if _, err := NewProperty("x", dt, false); err != nil {
+			t.Errorf("NewProperty(%s) = %v, want nil", dt, err)
+		}
+	}
+}
+
+// TestPropertyValidateErrorChain guards that a bad data type surfaces both the
+// property sentinel and the underlying data-type sentinel via errors.Is.
+func TestPropertyValidateErrorChain(t *testing.T) {
+	t.Parallel()
+	p := Property{Name: "geo", Type: types.UserDefined("string")} // collides with builtin
+	err := p.Validate()
+	if err == nil {
+		t.Fatal("expected error for colliding user-defined type")
+	}
+	if !errors.Is(err, ErrInvalidProperty) {
+		t.Errorf("missing ErrInvalidProperty in chain: %v", err)
+	}
+	if !errors.Is(err, types.ErrInvalidDataType) {
+		t.Errorf("missing types.ErrInvalidDataType in chain: %v", err)
+	}
+}

--- a/go/graphar/info/save.go
+++ b/go/graphar/info/save.go
@@ -1,0 +1,227 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// MarshalVertexInfo serialises v to a YAML document.
+func MarshalVertexInfo(v *VertexInfo) ([]byte, error) {
+	if v == nil {
+		return nil, fmt.Errorf("%w: nil vertex info", ErrInvalidVertexInfo)
+	}
+	return encode(vertexInfoToYAML(v))
+}
+
+// MarshalEdgeInfo serialises e to a YAML document.
+func MarshalEdgeInfo(e *EdgeInfo) ([]byte, error) {
+	if e == nil {
+		return nil, fmt.Errorf("%w: nil edge info", ErrInvalidEdgeInfo)
+	}
+	return encode(edgeInfoToYAML(e))
+}
+
+// GraphFilesOption overrides the file names MarshalGraphInfo writes for a
+// graph's vertices/edges.
+type GraphFilesOption func(*graphFilesConfig)
+
+type graphFilesConfig struct {
+	vertexFiles map[string]string
+	edgeFiles   map[EdgeTriplet]string
+}
+
+// WithVertexFileNames overrides vertex file references, keyed by vertex type.
+// Entries not listed fall back to the loaded or derived name.
+func WithVertexFileNames(m map[string]string) GraphFilesOption {
+	return func(c *graphFilesConfig) { c.vertexFiles = m }
+}
+
+// WithEdgeFileNames overrides edge file references, keyed by triplet. Entries
+// not listed fall back to the loaded or derived name.
+func WithEdgeFileNames(m map[EdgeTriplet]string) GraphFilesOption {
+	return func(c *graphFilesConfig) { c.edgeFiles = m }
+}
+
+// MarshalGraphInfo serialises the top-level graph yaml referencing each
+// vertex/edge by file name. By default it reproduces the references recorded
+// when the graph was loaded, deriving "<type>.vertex.yml" /
+// "<src>_<edge>_<dst>.edge.yml" for anything without one; pass
+// WithVertexFileNames / WithEdgeFileNames to override specific names.
+//
+// Output is emitted in g.Vertices() / g.Edges() sorted order.
+func MarshalGraphInfo(g *GraphInfo, opts ...GraphFilesOption) ([]byte, error) {
+	if g == nil {
+		return nil, fmt.Errorf("%w: nil graph info", ErrInvalidGraphInfo)
+	}
+	var cfg graphFilesConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	vs := g.Vertices()
+	es := g.Edges()
+	if err := checkFileNameOverrides(vs, es, cfg); err != nil {
+		return nil, err
+	}
+	// Every reference must resolve to a distinct file; two entries pointing at
+	// one file produce a graph yaml that fails to load ("duplicate ... type").
+	seen := make(map[string]struct{}, len(vs)+len(es))
+	vNames := make([]string, len(vs))
+	for i, v := range vs {
+		name := g.resolveVertexFile(v.Type(), cfg.vertexFiles)
+		if err := validateFileRef(name); err != nil {
+			return nil, fmt.Errorf("vertex %q: %w", v.Type(), err)
+		}
+		if _, dup := seen[name]; dup {
+			return nil, fmt.Errorf("%w: duplicate file reference %q", ErrInvalidGraphInfo, name)
+		}
+		seen[name] = struct{}{}
+		vNames[i] = name
+	}
+	eNames := make([]string, len(es))
+	for i, e := range es {
+		src, edge, dst := e.Triplet()
+		key := EdgeTriplet{Src: src, Edge: edge, Dst: dst}
+		name := g.resolveEdgeFile(key, cfg.edgeFiles)
+		if err := validateFileRef(name); err != nil {
+			return nil, fmt.Errorf("edge %s: %w", key.String(), err)
+		}
+		if _, dup := seen[name]; dup {
+			return nil, fmt.Errorf("%w: duplicate file reference %q", ErrInvalidGraphInfo, name)
+		}
+		seen[name] = struct{}{}
+		eNames[i] = name
+	}
+	y := graphInfoYAML{
+		Name:    g.Name(),
+		Prefix:  g.Prefix(),
+		Version: g.Version().String(),
+	}
+	if len(vNames) > 0 {
+		y.Vertices = vNames
+	}
+	if len(eNames) > 0 {
+		y.Edges = eNames
+	}
+	if labels := g.Labels(); len(labels) > 0 {
+		y.Labels = labels
+	}
+	if extra := g.ExtraInfo(); len(extra) > 0 {
+		keys := make([]string, 0, len(extra))
+		for k := range extra {
+			keys = append(keys, k)
+		}
+		slices.Sort(keys) // deterministic output; on-disk order is not significant
+		y.ExtraInfo = make([]extraInfoYAML, len(keys))
+		for i, k := range keys {
+			y.ExtraInfo[i] = extraInfoYAML{Key: k, Value: extra[k]}
+		}
+	}
+	return encode(y)
+}
+
+// checkFileNameOverrides rejects override keys that match no vertex type or edge
+// triplet, so a mistyped key surfaces instead of being silently dropped. Keys
+// are checked in sorted order for a stable error.
+func checkFileNameOverrides(vs []*VertexInfo, es []*EdgeInfo, cfg graphFilesConfig) error {
+	if len(cfg.vertexFiles) > 0 {
+		known := make(map[string]struct{}, len(vs))
+		for _, v := range vs {
+			known[v.Type()] = struct{}{}
+		}
+		for _, k := range slices.Sorted(maps.Keys(cfg.vertexFiles)) {
+			if _, ok := known[k]; !ok {
+				return fmt.Errorf("%w: WithVertexFileNames key %q matches no vertex type",
+					ErrInvalidGraphInfo, k)
+			}
+		}
+	}
+	if len(cfg.edgeFiles) > 0 {
+		known := make(map[EdgeTriplet]struct{}, len(es))
+		for _, e := range es {
+			src, edge, dst := e.Triplet()
+			known[EdgeTriplet{Src: src, Edge: edge, Dst: dst}] = struct{}{}
+		}
+		keys := slices.SortedFunc(maps.Keys(cfg.edgeFiles), func(a, b EdgeTriplet) int {
+			return a.compare(b)
+		})
+		for _, k := range keys {
+			if _, ok := known[k]; !ok {
+				return fmt.Errorf("%w: WithEdgeFileNames key %q matches no edge triplet",
+					ErrInvalidGraphInfo, k.String())
+			}
+		}
+	}
+	return nil
+}
+
+// WriteVertexInfo encodes v to w.
+func WriteVertexInfo(w io.Writer, v *VertexInfo) error {
+	buf, err := MarshalVertexInfo(v)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(buf); err != nil {
+		return fmt.Errorf("write vertex info: %w", err)
+	}
+	return nil
+}
+
+// WriteEdgeInfo encodes e to w.
+func WriteEdgeInfo(w io.Writer, e *EdgeInfo) error {
+	buf, err := MarshalEdgeInfo(e)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(buf); err != nil {
+		return fmt.Errorf("write edge info: %w", err)
+	}
+	return nil
+}
+
+// WriteGraphInfo encodes the top-level graph yaml; see MarshalGraphInfo for
+// how file references are resolved and overridden.
+func WriteGraphInfo(w io.Writer, g *GraphInfo, opts ...GraphFilesOption) error {
+	buf, err := MarshalGraphInfo(g, opts...)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(buf); err != nil {
+		return fmt.Errorf("write graph info: %w", err)
+	}
+	return nil
+}
+
+func encode(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(v); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidYAML, err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidYAML, err)
+	}
+	return buf.Bytes(), nil
+}

--- a/go/graphar/info/save_test.go
+++ b/go/graphar/info/save_test.go
@@ -1,0 +1,257 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestMarshalNilInputs(t *testing.T) {
+	t.Parallel()
+	if _, err := MarshalVertexInfo(nil); !errors.Is(err, ErrInvalidVertexInfo) {
+		t.Errorf("expected ErrInvalidVertexInfo, got %v", err)
+	}
+	if _, err := MarshalEdgeInfo(nil); !errors.Is(err, ErrInvalidEdgeInfo) {
+		t.Errorf("expected ErrInvalidEdgeInfo, got %v", err)
+	}
+	if _, err := MarshalGraphInfo(nil); !errors.Is(err, ErrInvalidGraphInfo) {
+		t.Errorf("expected ErrInvalidGraphInfo, got %v", err)
+	}
+}
+
+func TestVertexInfoRoundTripBytes(t *testing.T) {
+	t.Parallel()
+	v, err := NewVertexInfo("person", 100, vertexGroupsOK())
+	if err != nil {
+		t.Fatalf("NewVertexInfo: %v", err)
+	}
+	data, err := MarshalVertexInfo(v)
+	if err != nil {
+		t.Fatalf("MarshalVertexInfo: %v", err)
+	}
+	v2, err := LoadVertexInfo(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("LoadVertexInfo: %v", err)
+	}
+	if v.Type() != v2.Type() || v.ChunkSize() != v2.ChunkSize() {
+		t.Errorf("round-trip lost fields")
+	}
+	if v.PropertyGroups().Len() != v2.PropertyGroups().Len() {
+		t.Errorf("round-trip group count")
+	}
+}
+
+func TestEdgeInfoRoundTripBytes(t *testing.T) {
+	t.Parallel()
+	e, err := NewEdgeInfo("person", "knows", "person", 1024, 100, 100, false, basicAdjLists())
+	if err != nil {
+		t.Fatalf("NewEdgeInfo: %v", err)
+	}
+	data, err := MarshalEdgeInfo(e)
+	if err != nil {
+		t.Fatalf("MarshalEdgeInfo: %v", err)
+	}
+	e2, err := LoadEdgeInfo(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("LoadEdgeInfo: %v", err)
+	}
+	if e.SrcType() != e2.SrcType() || e.DstType() != e2.DstType() {
+		t.Errorf("round-trip lost triplet")
+	}
+}
+
+func TestMarshalGraphInfoDefaultNames(t *testing.T) {
+	t.Parallel()
+	// A programmatic graph has no recorded references, so names are derived.
+	v := mustVertex(t, "a")
+	e := mustEdge(t, "a", "k", "a")
+	g, err := NewGraphInfo("g", WithVertices(v), WithEdges(e))
+	if err != nil {
+		t.Fatalf("NewGraphInfo: %v", err)
+	}
+	data, err := MarshalGraphInfo(g)
+	if err != nil {
+		t.Fatalf("MarshalGraphInfo: %v", err)
+	}
+	s := string(data)
+	for _, want := range []string{"a.vertex.yml", "a_k_a.edge.yml"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing derived name %q\n%s", want, s)
+		}
+	}
+}
+
+func TestMarshalGraphInfoOverride(t *testing.T) {
+	t.Parallel()
+	v := mustVertex(t, "a")
+	g, err := NewGraphInfo("g", WithVertices(v))
+	if err != nil {
+		t.Fatalf("NewGraphInfo: %v", err)
+	}
+	data, err := MarshalGraphInfo(g, WithVertexFileNames(map[string]string{"a": "custom.vertex.yml"}))
+	if err != nil {
+		t.Fatalf("MarshalGraphInfo: %v", err)
+	}
+	if s := string(data); !strings.Contains(s, "custom.vertex.yml") {
+		t.Errorf("override name not used\n%s", s)
+	}
+}
+
+func TestMarshalGraphInfoRejectsBadFileRef(t *testing.T) {
+	t.Parallel()
+	v := mustVertex(t, "a")
+	g, err := NewGraphInfo("g", WithVertices(v))
+	if err != nil {
+		t.Fatalf("NewGraphInfo: %v", err)
+	}
+	bad := []string{"", "/abs/a.vertex.yml", "../a.vertex.yml", "sub/../../a.vertex.yml"}
+	for _, name := range bad {
+		_, err := MarshalGraphInfo(g, WithVertexFileNames(map[string]string{"a": name}))
+		if !errors.Is(err, ErrInvalidGraphInfo) {
+			t.Errorf("MarshalGraphInfo(vertexFiles=%q) = %v, want ErrInvalidGraphInfo", name, err)
+		}
+	}
+}
+
+func TestMarshalGraphInfoOK(t *testing.T) {
+	t.Parallel()
+	v := mustVertex(t, "a")
+	w := mustVertex(t, "b")
+	e := mustEdge(t, "a", "k", "b")
+	g, err := NewGraphInfo("g", WithVertices(v, w), WithEdges(e), WithGraphPrefix("p/"))
+	if err != nil {
+		t.Fatalf("NewGraphInfo: %v", err)
+	}
+	data, err := MarshalGraphInfo(g,
+		WithVertexFileNames(map[string]string{
+			"a": "a.vertex.yml",
+			"b": "b.vertex.yml",
+		}),
+		WithEdgeFileNames(map[EdgeTriplet]string{
+			{Src: "a", Edge: "k", Dst: "b"}: "a_k_b.edge.yml",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("MarshalGraphInfo: %v", err)
+	}
+	s := string(data)
+	for _, want := range []string{"name: g", "p/", "a.vertex.yml", "b.vertex.yml", "a_k_b.edge.yml", "gar/v1"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("MarshalGraphInfo output missing %q\n%s", want, s)
+		}
+	}
+}
+
+func TestWriteHelpers(t *testing.T) {
+	t.Parallel()
+	v, err := NewVertexInfo("person", 100, vertexGroupsOK())
+	if err != nil {
+		t.Fatalf("NewVertexInfo: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := WriteVertexInfo(&buf, v); err != nil {
+		t.Fatalf("WriteVertexInfo: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Errorf("WriteVertexInfo produced empty output")
+	}
+
+	e, err := NewEdgeInfo("person", "knows", "person", 1024, 100, 100, false, basicAdjLists())
+	if err != nil {
+		t.Fatalf("NewEdgeInfo: %v", err)
+	}
+	buf.Reset()
+	if err := WriteEdgeInfo(&buf, e); err != nil {
+		t.Fatalf("WriteEdgeInfo: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Errorf("WriteEdgeInfo produced empty output")
+	}
+
+	g, err := NewGraphInfo("g",
+		WithVertices(mustVertex(t, "a")),
+	)
+	if err != nil {
+		t.Fatalf("NewGraphInfo: %v", err)
+	}
+	buf.Reset()
+	if err := WriteGraphInfo(&buf, g); err != nil {
+		t.Fatalf("WriteGraphInfo: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Errorf("WriteGraphInfo produced empty output")
+	}
+}
+
+func TestWriteHelpersPropagateError(t *testing.T) {
+	t.Parallel()
+	if err := WriteVertexInfo(failingWriter{}, mustVertex(t, "a")); err == nil {
+		t.Errorf("WriteVertexInfo did not propagate writer error")
+	}
+	if err := WriteEdgeInfo(failingWriter{}, mustEdge(t, "a", "k", "b")); err == nil {
+		t.Errorf("WriteEdgeInfo did not propagate writer error")
+	}
+	g, err := NewGraphInfo("g", WithVertices(mustVertex(t, "a")))
+	if err != nil {
+		t.Fatalf("NewGraphInfo: %v", err)
+	}
+	if err := WriteGraphInfo(failingWriter{}, g); err == nil {
+		t.Errorf("WriteGraphInfo did not propagate writer error")
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write(_ []byte) (int, error) { return 0, errBrokenWriter }
+
+var errBrokenWriter = errors.New("broken writer")
+
+func TestMarshalGraphInfoRejectsDuplicateFileRef(t *testing.T) {
+	t.Parallel()
+	g, err := NewGraphInfo("g", WithVertices(mustVertex(t, "a"), mustVertex(t, "b")))
+	if err != nil {
+		t.Fatalf("NewGraphInfo: %v", err)
+	}
+	_, err = MarshalGraphInfo(g, WithVertexFileNames(map[string]string{
+		"a": "same.vertex.yml",
+		"b": "same.vertex.yml",
+	}))
+	if !errors.Is(err, ErrInvalidGraphInfo) {
+		t.Errorf("expected ErrInvalidGraphInfo for duplicate file ref, got %v", err)
+	}
+}
+
+func TestMarshalGraphInfoRejectsUnmatchedOverrideKey(t *testing.T) {
+	t.Parallel()
+	g, err := NewGraphInfo("g", WithVertices(mustVertex(t, "a")), WithEdges(mustEdge(t, "a", "k", "a")))
+	if err != nil {
+		t.Fatalf("NewGraphInfo: %v", err)
+	}
+	// Vertex key typo.
+	if _, err := MarshalGraphInfo(g, WithVertexFileNames(map[string]string{"A": "x.vertex.yml"})); !errors.Is(err, ErrInvalidGraphInfo) {
+		t.Errorf("expected ErrInvalidGraphInfo for unmatched vertex key, got %v", err)
+	}
+	// Edge key typo.
+	bad := map[EdgeTriplet]string{{Src: "a", Edge: "nope", Dst: "a"}: "x.edge.yml"}
+	if _, err := MarshalGraphInfo(g, WithEdgeFileNames(bad)); !errors.Is(err, ErrInvalidGraphInfo) {
+		t.Errorf("expected ErrInvalidGraphInfo for unmatched edge key, got %v", err)
+	}
+}

--- a/go/graphar/info/vertex_info.go
+++ b/go/graphar/info/vertex_info.go
@@ -1,0 +1,199 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+// VertexInfo is the immutable metadata for one vertex type.
+type VertexInfo struct {
+	typ       string
+	chunkSize int64
+	prefix    string
+	labels    []string
+	groups    *PropertyGroups
+	version   types.InfoVersion
+}
+
+// VertexInfoOption configures a VertexInfo at construction time.
+type VertexInfoOption func(*vertexInfoConfig)
+
+type vertexInfoConfig struct {
+	prefix  string
+	labels  []string
+	version types.InfoVersion
+}
+
+// WithVertexPrefix sets the on-disk prefix for the vertex type's files. When
+// unset, the prefix defaults to "vertex/<type>/".
+func WithVertexPrefix(p string) VertexInfoOption {
+	return func(c *vertexInfoConfig) { c.prefix = p }
+}
+
+// WithVertexLabels attaches labels to the vertex type.
+func WithVertexLabels(labels ...string) VertexInfoOption {
+	return func(c *vertexInfoConfig) {
+		c.labels = slices.Clone(labels)
+	}
+}
+
+// WithVertexVersion overrides the InfoVersion (default: gar/v1).
+func WithVertexVersion(v types.InfoVersion) VertexInfoOption {
+	return func(c *vertexInfoConfig) { c.version = v.Clone() }
+}
+
+// NewVertexInfo constructs a VertexInfo and validates it. The type name and
+// chunk size are mandatory; chunk size must be positive.
+func NewVertexInfo(typ string, chunkSize int64, groups []PropertyGroup, opts ...VertexInfoOption) (*VertexInfo, error) {
+	if len(groups) == 0 {
+		return nil, fmt.Errorf("vertex_info(%q): %w", typ,
+			newValidationError(ErrInvalidPropertyGroup, "property_groups",
+				"at least one property group is required"))
+	}
+	v, err := newVertexInfoUnvalidated(typ, chunkSize, groups, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err := v.Validate(); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// newVertexInfoUnvalidated builds a VertexInfo without validating (the liberal
+// load path): groups are indexed but not validated and may be empty. Call
+// Validate to enforce the full contract.
+func newVertexInfoUnvalidated(typ string, chunkSize int64, groups []PropertyGroup, opts ...VertexInfoOption) (*VertexInfo, error) {
+	cfg := vertexInfoConfig{version: types.NewInfoVersion(types.DefaultVersion)}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	pg, err := buildPropertyGroups(groups)
+	if err != nil {
+		return nil, fmt.Errorf("vertex_info(%q): %w", typ, err)
+	}
+	prefix := cfg.prefix
+	if prefix == "" && typ != "" {
+		prefix = "vertex/" + typ + "/"
+	}
+	return &VertexInfo{
+		typ:       typ,
+		chunkSize: chunkSize,
+		prefix:    prefix,
+		labels:    cfg.labels,
+		groups:    pg,
+		version:   cfg.version,
+	}, nil
+}
+
+// Type returns the vertex type name.
+func (v *VertexInfo) Type() string { return v.typ }
+
+// ChunkSize returns the number of vertices per chunk.
+func (v *VertexInfo) ChunkSize() int64 { return v.chunkSize }
+
+// Prefix returns the on-disk prefix of vertex files.
+func (v *VertexInfo) Prefix() string { return v.prefix }
+
+// Labels returns a copy of the label list.
+func (v *VertexInfo) Labels() []string {
+	return slices.Clone(v.labels)
+}
+
+// PropertyGroups returns the property group index.
+func (v *VertexInfo) PropertyGroups() *PropertyGroups { return v.groups }
+
+// Version returns the InfoVersion.
+func (v *VertexInfo) Version() types.InfoVersion { return v.version.Clone() }
+
+// HasProperty is shorthand for v.PropertyGroups().Has(name).
+func (v *VertexInfo) HasProperty(name string) bool {
+	return v.groups != nil && v.groups.Has(name)
+}
+
+// PropertyType returns the data type of the named property.
+func (v *VertexInfo) PropertyType(name string) (types.DataType, bool) {
+	if v.groups == nil {
+		return types.DataType{}, false
+	}
+	return v.groups.PropertyType(name)
+}
+
+// Validate enforces the cross-field invariants:
+//   - non-empty type name
+//   - chunk size > 0
+//   - non-nil, valid property group index
+//   - no duplicate labels
+//
+// The number of primary properties is not constrained, to stay compatible with
+// fixtures emitted by the other SDKs; only unique property names are required,
+// which NewPropertyGroups already enforces.
+func (v *VertexInfo) Validate() error {
+	if v.typ == "" {
+		return newValidationError(ErrInvalidVertexInfo, "type", "must not be empty")
+	}
+	if v.chunkSize <= 0 {
+		return newValidationError(ErrInvalidVertexInfo, "chunk_size",
+			"must be > 0, got %d", v.chunkSize)
+	}
+	if err := v.version.Validate(); err != nil {
+		return newValidationError(ErrInvalidVertexInfo, "version", "%s", err)
+	}
+	if v.groups == nil {
+		return newValidationError(ErrInvalidVertexInfo, "property_groups",
+			"must not be nil")
+	}
+	if err := v.groups.Validate(); err != nil {
+		return err
+	}
+	if err := validateUserDefinedTypes(v.groups, v.version, ErrInvalidVertexInfo); err != nil {
+		return err
+	}
+	return validateLabels(v.labels, ErrInvalidVertexInfo)
+}
+
+// validateLabels rejects empty and duplicate labels, tagging failures with the
+// given sentinel. Shared by VertexInfo and GraphInfo.
+func validateLabels(labels []string, sentinel error) error {
+	seen := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		if l == "" {
+			return newValidationError(sentinel, "labels", "label must not be empty")
+		}
+		if _, dup := seen[l]; dup {
+			return newValidationError(sentinel, "labels", "duplicate label %q", l)
+		}
+		seen[l] = struct{}{}
+	}
+	return nil
+}
+
+// AddPropertyGroup returns a new VertexInfo with the additional group
+// appended. The receiver is unchanged.
+func (v *VertexInfo) AddPropertyGroup(g PropertyGroup) (*VertexInfo, error) {
+	current := v.groups.Groups()
+	return NewVertexInfo(v.typ, v.chunkSize, append(current, g),
+		WithVertexPrefix(v.prefix),
+		WithVertexLabels(v.labels...),
+		WithVertexVersion(v.version),
+	)
+}

--- a/go/graphar/info/vertex_info_test.go
+++ b/go/graphar/info/vertex_info_test.go
@@ -1,0 +1,267 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+func vertexGroupsOK() []PropertyGroup {
+	return []PropertyGroup{
+		{
+			Properties: []Property{
+				{Name: "id", Type: types.Int64(), IsPrimary: true, Cardinality: types.CardinalitySingle},
+			},
+			FileType: types.FileTypeParquet,
+		},
+		{
+			Properties: []Property{
+				{Name: "name", Type: types.String(), Cardinality: types.CardinalitySingle},
+			},
+			FileType: types.FileTypeParquet,
+		},
+	}
+}
+
+func TestNewVertexInfoRejectsZeroVersion(t *testing.T) {
+	t.Parallel()
+	_, err := NewVertexInfo("person", 100, vertexGroupsOK(),
+		WithVertexVersion(types.InfoVersion{}))
+	if !errors.Is(err, ErrInvalidVertexInfo) {
+		t.Errorf("expected ErrInvalidVertexInfo for zero version, got %v", err)
+	}
+}
+
+func TestNewVertexInfoDefaults(t *testing.T) {
+	t.Parallel()
+	v, err := NewVertexInfo("person", 100, vertexGroupsOK())
+	if err != nil {
+		t.Fatalf("NewVertexInfo: %v", err)
+	}
+	if v.Type() != "person" || v.ChunkSize() != 100 {
+		t.Errorf("getters mismatch: %+v", v)
+	}
+	if v.Prefix() != "vertex/person/" {
+		t.Errorf("default prefix = %q", v.Prefix())
+	}
+	if v.Version().Version != types.DefaultVersion {
+		t.Errorf("default version = %v", v.Version())
+	}
+	if !v.HasProperty("id") || !v.HasProperty("name") {
+		t.Errorf("HasProperty missing expected entries")
+	}
+	if dt, ok := v.PropertyType("id"); !ok || !dt.Equal(types.Int64()) {
+		t.Errorf("PropertyType(id) = %v ok=%v", dt, ok)
+	}
+	if _, ok := v.PropertyType("nope"); ok {
+		t.Errorf("PropertyType(nope) returned ok=true")
+	}
+}
+
+func TestNewVertexInfoOptions(t *testing.T) {
+	t.Parallel()
+	v, err := NewVertexInfo("person", 100, vertexGroupsOK(),
+		WithVertexPrefix("v/p/"),
+		WithVertexLabels("a", "b"),
+		WithVertexVersion(types.NewInfoVersion(2)),
+	)
+	if err != nil {
+		t.Fatalf("NewVertexInfo: %v", err)
+	}
+	if v.Prefix() != "v/p/" {
+		t.Errorf("prefix override failed: %q", v.Prefix())
+	}
+	labels := v.Labels()
+	if len(labels) != 2 || labels[0] != "a" || labels[1] != "b" {
+		t.Errorf("Labels = %v", labels)
+	}
+	// Labels return must be a copy.
+	labels[0] = "mutated"
+	if v.Labels()[0] != "a" {
+		t.Errorf("Labels() did not return a copy")
+	}
+	if v.Version().Version != 2 {
+		t.Errorf("version = %v", v.Version())
+	}
+}
+
+func TestNewVertexInfoValidationFailures(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		fn   func() (*VertexInfo, error)
+		want error
+	}{
+		{
+			"empty type",
+			func() (*VertexInfo, error) { return NewVertexInfo("", 100, vertexGroupsOK()) },
+			ErrInvalidVertexInfo,
+		},
+		{
+			"chunk size zero",
+			func() (*VertexInfo, error) { return NewVertexInfo("p", 0, vertexGroupsOK()) },
+			ErrInvalidVertexInfo,
+		},
+		{
+			"chunk size negative",
+			func() (*VertexInfo, error) { return NewVertexInfo("p", -1, vertexGroupsOK()) },
+			ErrInvalidVertexInfo,
+		},
+		{
+			"empty property groups",
+			func() (*VertexInfo, error) { return NewVertexInfo("p", 100, nil) },
+			ErrInvalidPropertyGroup,
+		},
+		{
+			"empty label",
+			func() (*VertexInfo, error) {
+				return NewVertexInfo("p", 100, vertexGroupsOK(), WithVertexLabels(""))
+			},
+			ErrInvalidVertexInfo,
+		},
+		{
+			"duplicate labels",
+			func() (*VertexInfo, error) {
+				return NewVertexInfo("p", 100, vertexGroupsOK(), WithVertexLabels("a", "a"))
+			},
+			ErrInvalidVertexInfo,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := c.fn()
+			if !errors.Is(err, c.want) {
+				t.Errorf("got %v, want wrap of %v", err, c.want)
+			}
+		})
+	}
+}
+
+func TestVertexInfoAcceptsZeroOrMultiplePrimaries(t *testing.T) {
+	t.Parallel()
+	// The Go SDK matches cpp VertexInfo::is_validated which imposes no
+	// "exactly one primary" rule; a vertex with zero primaries or with
+	// multiple primary properties (across groups) must be accepted to
+	// preserve cross-language interop.
+	zeroPrimary := []PropertyGroup{{
+		Properties: []Property{
+			{Name: "name", Type: types.String(), Cardinality: types.CardinalitySingle},
+		},
+		FileType: types.FileTypeParquet,
+	}}
+	if _, err := NewVertexInfo("p", 100, zeroPrimary); err != nil {
+		t.Errorf("vertex with no primary should be valid: %v", err)
+	}
+
+	twoPrimaries := []PropertyGroup{
+		{
+			Properties: []Property{{Name: "id1", Type: types.Int64(), IsPrimary: true}},
+			FileType:   types.FileTypeParquet,
+		},
+		{
+			Properties: []Property{{Name: "id2", Type: types.Int64(), IsPrimary: true}},
+			FileType:   types.FileTypeParquet,
+		},
+	}
+	if _, err := NewVertexInfo("p", 100, twoPrimaries); err != nil {
+		t.Errorf("vertex with two primaries should be valid (matches cpp): %v", err)
+	}
+}
+
+func TestVertexInfoAddPropertyGroup(t *testing.T) {
+	t.Parallel()
+	v, err := NewVertexInfo("person", 100, vertexGroupsOK())
+	if err != nil {
+		t.Fatalf("NewVertexInfo: %v", err)
+	}
+	extra := PropertyGroup{
+		Properties: []Property{{Name: "age", Type: types.Int32(), Cardinality: types.CardinalitySingle}},
+		FileType:   types.FileTypeParquet,
+	}
+	v2, err := v.AddPropertyGroup(extra)
+	if err != nil {
+		t.Fatalf("AddPropertyGroup: %v", err)
+	}
+	if v2 == v {
+		t.Error("AddPropertyGroup must return a fresh value")
+	}
+	if !v2.HasProperty("age") {
+		t.Error("new vertex info missing added property")
+	}
+	if v.HasProperty("age") {
+		t.Error("original vertex info was mutated")
+	}
+}
+
+func TestVertexInfoAddPropertyGroupRejectsDuplicate(t *testing.T) {
+	t.Parallel()
+	v, err := NewVertexInfo("person", 100, vertexGroupsOK())
+	if err != nil {
+		t.Fatalf("NewVertexInfo: %v", err)
+	}
+	dup := PropertyGroup{
+		Properties: []Property{{Name: "id", Type: types.Int64(), IsPrimary: true}},
+		FileType:   types.FileTypeParquet,
+	}
+	_, err = v.AddPropertyGroup(dup)
+	if !errors.Is(err, ErrInvalidPropertyGroup) {
+		t.Errorf("expected duplicate-property failure, got %v", err)
+	}
+}
+
+// TestWithVersionClonesUserDefinedTypes guards the setter half of the
+// immutability contract: mutating the caller's slice after construction must
+// not leak into the stored InfoVersion.
+func TestWithVersionClonesUserDefinedTypes(t *testing.T) {
+	t.Parallel()
+	check := func(name string, build func(uts []string) func() types.InfoVersion) {
+		uts := []string{"Vector"}
+		read := build(uts)
+		uts[0] = "Hacked"
+		if got := read().UserDefinedTypes; len(got) != 1 || got[0] != "Vector" {
+			t.Errorf("%s: setter did not clone, stored %v", name, got)
+		}
+	}
+	check("vertex", func(uts []string) func() types.InfoVersion {
+		v, err := NewVertexInfo("p", 1, vertexGroupsOK(),
+			WithVertexVersion(types.InfoVersion{Version: 1, UserDefinedTypes: uts}))
+		if err != nil {
+			t.Fatalf("NewVertexInfo: %v", err)
+		}
+		return v.Version
+	})
+	check("edge", func(uts []string) func() types.InfoVersion {
+		e, err := NewEdgeInfo("a", "k", "b", 1, 1, 1, false, basicAdjLists(),
+			WithEdgeVersion(types.InfoVersion{Version: 1, UserDefinedTypes: uts}))
+		if err != nil {
+			t.Fatalf("NewEdgeInfo: %v", err)
+		}
+		return e.Version
+	})
+	check("graph", func(uts []string) func() types.InfoVersion {
+		g, err := NewGraphInfo("g",
+			WithGraphVersion(types.InfoVersion{Version: 1, UserDefinedTypes: uts}))
+		if err != nil {
+			t.Fatalf("NewGraphInfo: %v", err)
+		}
+		return g.Version
+	})
+}

--- a/go/graphar/info/yaml.go
+++ b/go/graphar/info/yaml.go
@@ -1,0 +1,380 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+// The DTO types in this file are the only place where YAML field names live.
+// The exported Info types do not carry yaml tags so on-disk evolution does
+// not leak into the API.
+
+type propertyYAML struct {
+	Name     string `yaml:"name"`
+	DataType string `yaml:"data_type"`
+	// IsPrimary has no omitempty: absent and false are not interchangeable on
+	// disk, so the field is always emitted.
+	IsPrimary bool `yaml:"is_primary"`
+	// IsNullable is tri-state on the wire (present-true / present-false /
+	// absent). Absent means true for non-primary properties, so it is a *bool
+	// and the default is applied in toDomain when nil.
+	IsNullable  *bool  `yaml:"is_nullable,omitempty"`
+	Cardinality string `yaml:"cardinality,omitempty"`
+}
+
+type propertyGroupYAML struct {
+	Prefix     string         `yaml:"prefix,omitempty"`
+	FileType   string         `yaml:"file_type"`
+	Properties []propertyYAML `yaml:"properties"`
+}
+
+type vertexInfoYAML struct {
+	Type string `yaml:"type,omitempty"`
+	// Label is an alias for Type accepted on read for older fixtures that use
+	// `label`. Read-only; write always uses `type`.
+	Label          string              `yaml:"label,omitempty"`
+	ChunkSize      int64               `yaml:"chunk_size"`
+	Prefix         string              `yaml:"prefix,omitempty"`
+	Labels         []string            `yaml:"labels,omitempty"`
+	PropertyGroups []propertyGroupYAML `yaml:"property_groups"`
+	Version        string              `yaml:"version"`
+}
+
+type adjacentListYAML struct {
+	// Type is the modern explicit form ("ordered_by_source", ...). When
+	// missing, Ordered + AlignedBy are used to derive it.
+	Type      string `yaml:"type,omitempty"`
+	Ordered   *bool  `yaml:"ordered,omitempty"`
+	AlignedBy string `yaml:"aligned_by,omitempty"`
+	Prefix    string `yaml:"prefix,omitempty"`
+	FileType  string `yaml:"file_type"`
+	// IgnoredPropertyGroups names the legacy per-adj-list property_groups field
+	// (ldbc, nebula fixtures) so it is dropped explicitly rather than silently.
+	// It is not propagated to the domain model and never emitted.
+	IgnoredPropertyGroups []propertyGroupYAML `yaml:"property_groups,omitempty"`
+}
+
+type edgeInfoYAML struct {
+	SrcType  string `yaml:"src_type,omitempty"`
+	EdgeType string `yaml:"edge_type,omitempty"`
+	DstType  string `yaml:"dst_type,omitempty"`
+	// SrcLabel/EdgeLabel/DstLabel are legacy `*_label` spellings of the triplet
+	// fields, accepted on read only.
+	SrcLabel       string              `yaml:"src_label,omitempty"`
+	EdgeLabel      string              `yaml:"edge_label,omitempty"`
+	DstLabel       string              `yaml:"dst_label,omitempty"`
+	ChunkSize      int64               `yaml:"chunk_size"`
+	SrcChunkSize   int64               `yaml:"src_chunk_size"`
+	DstChunkSize   int64               `yaml:"dst_chunk_size"`
+	Directed       bool                `yaml:"directed"`
+	Prefix         string              `yaml:"prefix,omitempty"`
+	AdjLists       []adjacentListYAML  `yaml:"adj_lists"`
+	PropertyGroups []propertyGroupYAML `yaml:"property_groups,omitempty"`
+	Version        string              `yaml:"version"`
+}
+
+type graphInfoYAML struct {
+	Name      string          `yaml:"name"`
+	Prefix    string          `yaml:"prefix,omitempty"`
+	Vertices  []string        `yaml:"vertices,omitempty"`
+	Edges     []string        `yaml:"edges,omitempty"`
+	Labels    []string        `yaml:"labels,omitempty"`
+	Version   string          `yaml:"version"`
+	ExtraInfo []extraInfoYAML `yaml:"extra_info,omitempty"`
+}
+
+// extraInfoYAML is one entry of the graph document's extra_info sequence,
+// which is stored on disk as a list of {key, value} objects, not a plain map.
+type extraInfoYAML struct {
+	Key   string `yaml:"key"`
+	Value string `yaml:"value"`
+}
+
+// --- DTO → domain ---
+
+func (y propertyYAML) toDomain(field string) (Property, error) {
+	dt, err := types.ParseDataType(y.DataType)
+	if err != nil {
+		// Liberal read: an unrecognised name becomes a user-defined type, checked
+		// against the version's declared list by Validate. A name carrying < or >
+		// is a malformed list spelling, not a custom type, so keep the error.
+		name := strings.TrimSpace(y.DataType)
+		if name == "" || strings.ContainsAny(name, "<>") {
+			return Property{}, fmt.Errorf("%s.data_type: %w", field, err)
+		}
+		dt = types.UserDefined(name)
+	}
+	card := types.CardinalitySingle
+	if y.Cardinality != "" {
+		card, err = types.ParseCardinality(y.Cardinality)
+		if err != nil {
+			return Property{}, fmt.Errorf("%s.cardinality: %w", field, err)
+		}
+	}
+	// Absent is_nullable defaults to !is_primary; an explicit value is kept
+	// verbatim (even a contradictory primary+nullable, which Validate flags).
+	isNullable := !y.IsPrimary
+	if y.IsNullable != nil {
+		isNullable = *y.IsNullable
+	}
+	return Property{
+		Name:        y.Name,
+		Type:        dt,
+		IsPrimary:   y.IsPrimary,
+		IsNullable:  isNullable,
+		Cardinality: card,
+	}, nil
+}
+
+func (y propertyGroupYAML) toDomain(field string) (PropertyGroup, error) {
+	ft, err := types.ParseFileType(y.FileType)
+	if err != nil {
+		return PropertyGroup{}, fmt.Errorf("%s.file_type: %w", field, err)
+	}
+	props := make([]Property, 0, len(y.Properties))
+	for i, py := range y.Properties {
+		p, err := py.toDomain(fmt.Sprintf("%s.properties[%d]", field, i))
+		if err != nil {
+			return PropertyGroup{}, err
+		}
+		props = append(props, p)
+	}
+	return PropertyGroup{
+		Properties: props,
+		FileType:   ft,
+		Prefix:     y.Prefix,
+	}, nil
+}
+
+func (y adjacentListYAML) toDomain(field string) (AdjacentList, error) {
+	ft, err := types.ParseFileType(y.FileType)
+	if err != nil {
+		return AdjacentList{}, fmt.Errorf("%s.file_type: %w", field, err)
+	}
+	var t types.AdjListType
+	switch {
+	case y.Type != "":
+		t, err = types.ParseAdjListType(y.Type)
+		if err != nil {
+			return AdjacentList{}, fmt.Errorf("%s.type: %w", field, err)
+		}
+	case y.Ordered != nil && y.AlignedBy != "":
+		t, err = types.AdjListTypeFromOrderedAligned(*y.Ordered, y.AlignedBy)
+		if err != nil {
+			return AdjacentList{}, fmt.Errorf("%s: %w", field, err)
+		}
+	default:
+		return AdjacentList{}, newValidationError(ErrInvalidEdgeInfo, field,
+			"adj_list must specify either type or (ordered + aligned_by)")
+	}
+	return AdjacentList{Type: t, FileType: ft, Prefix: y.Prefix}, nil
+}
+
+func vertexInfoFromYAML(y vertexInfoYAML) (*VertexInfo, error) {
+	groups := make([]PropertyGroup, 0, len(y.PropertyGroups))
+	for i, gy := range y.PropertyGroups {
+		g, err := gy.toDomain(fmt.Sprintf("vertex_info.property_groups[%d]", i))
+		if err != nil {
+			return nil, err
+		}
+		groups = append(groups, g)
+	}
+	// prefer type, fall back to the legacy label field
+	typeName := y.Type
+	if typeName == "" {
+		typeName = y.Label
+	}
+	// Minimal completeness: a vertex document must name its type, otherwise the
+	// input was some other (mis-filed) document decoded into a zero DTO.
+	if typeName == "" {
+		return nil, fmt.Errorf("%w: vertex info document has no type", ErrInvalidYAML)
+	}
+	opts := []VertexInfoOption{}
+	if y.Prefix != "" {
+		opts = append(opts, WithVertexPrefix(y.Prefix))
+	}
+	if len(y.Labels) > 0 {
+		opts = append(opts, WithVertexLabels(y.Labels...))
+	}
+	if y.Version != "" {
+		ver, err := types.ParseInfoVersion(y.Version)
+		if err != nil {
+			return nil, fmt.Errorf("vertex_info.version: %w", err)
+		}
+		opts = append(opts, WithVertexVersion(ver))
+	}
+	return newVertexInfoUnvalidated(typeName, y.ChunkSize, groups, opts...)
+}
+
+func edgeInfoFromYAML(y edgeInfoYAML) (*EdgeInfo, error) {
+	adjLists := make([]AdjacentList, 0, len(y.AdjLists))
+	for i, ay := range y.AdjLists {
+		a, err := ay.toDomain(fmt.Sprintf("edge_info.adj_lists[%d]", i))
+		if err != nil {
+			return nil, err
+		}
+		adjLists = append(adjLists, a)
+	}
+	// Resolve the triplet, preferring *_type and falling back to legacy *_label.
+	src := y.SrcType
+	if src == "" {
+		src = y.SrcLabel
+	}
+	edge := y.EdgeType
+	if edge == "" {
+		edge = y.EdgeLabel
+	}
+	dst := y.DstType
+	if dst == "" {
+		dst = y.DstLabel
+	}
+	// Minimal completeness: an edge document must name its full triplet, else
+	// the input was some other (mis-filed) document decoded into a zero DTO.
+	if src == "" || edge == "" || dst == "" {
+		return nil, fmt.Errorf("%w: edge info document is missing src/edge/dst type", ErrInvalidYAML)
+	}
+	opts := []EdgeInfoOption{}
+	if y.Prefix != "" {
+		opts = append(opts, WithEdgePrefix(y.Prefix))
+	}
+	if y.Version != "" {
+		ver, err := types.ParseInfoVersion(y.Version)
+		if err != nil {
+			return nil, fmt.Errorf("edge_info.version: %w", err)
+		}
+		opts = append(opts, WithEdgeVersion(ver))
+	}
+	if len(y.PropertyGroups) > 0 {
+		groups := make([]PropertyGroup, 0, len(y.PropertyGroups))
+		for i, gy := range y.PropertyGroups {
+			g, err := gy.toDomain(fmt.Sprintf("edge_info.property_groups[%d]", i))
+			if err != nil {
+				return nil, err
+			}
+			groups = append(groups, g)
+		}
+		opts = append(opts, WithEdgePropertyGroups(groups))
+	}
+	return newEdgeInfoUnvalidated(
+		src, edge, dst,
+		y.ChunkSize, y.SrcChunkSize, y.DstChunkSize,
+		y.Directed,
+		adjLists,
+		opts...,
+	)
+}
+
+// --- domain → DTO ---
+
+func propertyToYAML(p Property) propertyYAML {
+	y := propertyYAML{
+		Name:      p.Name,
+		DataType:  p.Type.String(),
+		IsPrimary: p.IsPrimary,
+	}
+	// Emit is_nullable only when it diverges from the default (!IsPrimary), so
+	// fixtures that omit it round-trip unchanged.
+	defaultNullable := !p.IsPrimary
+	if p.IsNullable != defaultNullable {
+		v := p.IsNullable
+		y.IsNullable = &v
+	}
+	if p.Cardinality != types.CardinalitySingle {
+		y.Cardinality = p.Cardinality.String()
+	}
+	return y
+}
+
+func propertyGroupToYAML(g PropertyGroup) propertyGroupYAML {
+	props := make([]propertyYAML, len(g.Properties))
+	for i, p := range g.Properties {
+		props[i] = propertyToYAML(p)
+	}
+	return propertyGroupYAML{
+		Prefix:     g.Prefix,
+		FileType:   g.FileType.String(),
+		Properties: props,
+	}
+}
+
+func adjacentListToYAML(a AdjacentList) adjacentListYAML {
+	// Emit the (ordered, aligned_by) form: it is the only adj_list spelling the
+	// readers accept. A `type` key is ignored on read, so emitting it instead
+	// would be silently mis-decoded to unordered_by_dest.
+	ordered := a.Type.IsOrdered()
+	side, _ := a.Type.AlignedBy()
+	return adjacentListYAML{
+		Ordered:   &ordered,
+		AlignedBy: side,
+		Prefix:    a.Prefix,
+		FileType:  a.FileType.String(),
+	}
+}
+
+func vertexInfoToYAML(v *VertexInfo) vertexInfoYAML {
+	var src []PropertyGroup
+	if pg := v.PropertyGroups(); pg != nil {
+		src = pg.groups // in-package read; DTO conversion copies out
+	}
+	groups := make([]propertyGroupYAML, 0, len(src))
+	for _, g := range src {
+		groups = append(groups, propertyGroupToYAML(g))
+	}
+	return vertexInfoYAML{
+		Type:           v.Type(),
+		ChunkSize:      v.ChunkSize(),
+		Prefix:         v.Prefix(),
+		Labels:         v.Labels(),
+		PropertyGroups: groups,
+		Version:        v.Version().String(),
+	}
+}
+
+func edgeInfoToYAML(e *EdgeInfo) edgeInfoYAML {
+	adj := e.AdjLists()
+	adjLists := make([]adjacentListYAML, 0, len(adj))
+	for _, a := range adj {
+		adjLists = append(adjLists, adjacentListToYAML(a))
+	}
+	var groups []propertyGroupYAML
+	if pg := e.PropertyGroups(); pg != nil {
+		src := pg.groups // in-package read; DTO conversion copies out
+		groups = make([]propertyGroupYAML, 0, len(src))
+		for _, g := range src {
+			groups = append(groups, propertyGroupToYAML(g))
+		}
+	}
+	src, edge, dst := e.Triplet()
+	return edgeInfoYAML{
+		SrcType:        src,
+		EdgeType:       edge,
+		DstType:        dst,
+		ChunkSize:      e.ChunkSize(),
+		SrcChunkSize:   e.SrcChunkSize(),
+		DstChunkSize:   e.DstChunkSize(),
+		Directed:       e.Directed(),
+		Prefix:         e.Prefix(),
+		AdjLists:       adjLists,
+		PropertyGroups: groups,
+		Version:        e.Version().String(),
+	}
+}

--- a/go/graphar/info/yaml_test.go
+++ b/go/graphar/info/yaml_test.go
@@ -1,0 +1,934 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package info
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	yaml "gopkg.in/yaml.v3"
+
+	"github.com/apache/incubator-graphar/go/graphar/types"
+)
+
+func TestLoadVertexInfoRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := `type: person
+chunk_size: 100
+prefix: vertex/person/
+property_groups:
+  - properties:
+      - name: id
+        data_type: int64
+        is_primary: true
+    file_type: parquet
+  - properties:
+      - name: firstName
+        data_type: string
+        is_primary: false
+      - name: lastName
+        data_type: string
+        is_primary: false
+    file_type: parquet
+version: gar/v1
+`
+	v, err := LoadVertexInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadVertexInfo: %v", err)
+	}
+	if v.Type() != "person" || v.ChunkSize() != 100 {
+		t.Errorf("getters mismatch: %+v", v)
+	}
+	if !v.HasProperty("id") || !v.HasProperty("firstName") {
+		t.Errorf("missing expected properties")
+	}
+	// Re-marshal and re-load: must produce equivalent in-memory state.
+	out, err := MarshalVertexInfo(v)
+	if err != nil {
+		t.Fatalf("MarshalVertexInfo: %v", err)
+	}
+	v2, err := LoadVertexInfo(strings.NewReader(string(out)))
+	if err != nil {
+		t.Fatalf("second LoadVertexInfo: %v", err)
+	}
+	if v2.Type() != v.Type() || v2.ChunkSize() != v.ChunkSize() {
+		t.Errorf("round-trip mismatch")
+	}
+	if v2.PropertyGroups().Len() != v.PropertyGroups().Len() {
+		t.Errorf("group count mismatch after round-trip")
+	}
+}
+
+func TestLoadVertexInfoCardinalityAndNullable(t *testing.T) {
+	t.Parallel()
+	in := `type: person
+chunk_size: 100
+property_groups:
+  - file_type: parquet
+    properties:
+      - name: id
+        data_type: int64
+        is_primary: true
+  - file_type: parquet
+    properties:
+      - name: emails
+        data_type: string
+        is_primary: false
+        cardinality: list
+      - name: nickname
+        data_type: string
+        is_primary: false
+        is_nullable: true
+version: gar/v1
+`
+	v, err := LoadVertexInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadVertexInfo: %v", err)
+	}
+	p, _, ok := v.PropertyGroups().Property("emails")
+	if !ok || p.Cardinality != types.CardinalityList {
+		t.Errorf("emails cardinality not parsed: %+v", p)
+	}
+	if !v.PropertyGroups().IsNullable("nickname") {
+		t.Errorf("nickname should be nullable")
+	}
+}
+
+func TestLoadEdgeInfoLegacyAdjList(t *testing.T) {
+	t.Parallel()
+	// adj_lists without explicit type, only ordered + aligned_by.
+	in := `src_type: person
+edge_type: knows
+dst_type: person
+chunk_size: 1024
+src_chunk_size: 100
+dst_chunk_size: 100
+directed: false
+prefix: edge/person_knows_person/
+adj_lists:
+  - ordered: true
+    aligned_by: src
+    file_type: parquet
+  - ordered: true
+    aligned_by: dst
+    file_type: parquet
+version: gar/v1
+`
+	e, err := LoadEdgeInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadEdgeInfo: %v", err)
+	}
+	if _, ok := e.AdjList(types.OrderedBySource); !ok {
+		t.Errorf("OrderedBySource missing")
+	}
+	if _, ok := e.AdjList(types.OrderedByDest); !ok {
+		t.Errorf("OrderedByDest missing")
+	}
+}
+
+func TestLoadEdgeInfoExplicitAdjList(t *testing.T) {
+	t.Parallel()
+	in := `src_type: person
+edge_type: knows
+dst_type: person
+chunk_size: 1
+src_chunk_size: 1
+dst_chunk_size: 1
+directed: false
+adj_lists:
+  - type: ordered_by_source
+    file_type: parquet
+version: gar/v1
+`
+	e, err := LoadEdgeInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadEdgeInfo: %v", err)
+	}
+	if _, ok := e.AdjList(types.OrderedBySource); !ok {
+		t.Errorf("explicit-type adj_list not parsed")
+	}
+}
+
+func TestLoadEdgeInfoMissingAdjListTypeRejected(t *testing.T) {
+	t.Parallel()
+	in := `src_type: s
+edge_type: k
+dst_type: d
+chunk_size: 1
+src_chunk_size: 1
+dst_chunk_size: 1
+directed: false
+adj_lists:
+  - file_type: parquet
+version: gar/v1
+`
+	_, err := LoadEdgeInfo(strings.NewReader(in))
+	if !errors.Is(err, ErrInvalidEdgeInfo) {
+		t.Errorf("expected ErrInvalidEdgeInfo, got %v", err)
+	}
+}
+
+func TestLoadVertexInfoUnknownDataTypeAsUserDefined(t *testing.T) {
+	t.Parallel()
+	// Liberal read: an unrecognised type name loads as a user-defined type.
+	in := `type: p
+chunk_size: 1
+property_groups:
+  - properties:
+      - name: id
+        data_type: myType
+        is_primary: true
+    file_type: parquet
+version: gar/v1
+`
+	v, err := LoadVertexInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadVertexInfo: %v", err)
+	}
+	got, ok := v.PropertyType("id")
+	if !ok || !got.Equal(types.UserDefined("myType")) {
+		t.Errorf("PropertyType(id) = %v ok=%v, want UserDefined(myType)", got, ok)
+	}
+}
+
+func TestUserDefinedTypeRoundTrip(t *testing.T) {
+	t.Parallel()
+	v, err := NewVertexInfo("person", 100, []PropertyGroup{{
+		Properties: []Property{
+			{Name: "id", Type: types.Int64(), IsPrimary: true},
+			{Name: "geo", Type: types.UserDefined("myType")},
+		},
+		FileType: types.FileTypeParquet,
+	}}, WithVertexVersion(types.NewInfoVersion(1, "myType")))
+	if err != nil {
+		t.Fatalf("NewVertexInfo with declared user-defined type: %v", err)
+	}
+	data, err := MarshalVertexInfo(v)
+	if err != nil {
+		t.Fatalf("MarshalVertexInfo: %v", err)
+	}
+	v2, err := LoadVertexInfo(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("LoadVertexInfo: %v", err)
+	}
+	if err := v2.Validate(); err != nil {
+		t.Fatalf("reloaded Validate: %v", err)
+	}
+	got, ok := v2.PropertyType("geo")
+	if !ok || !got.Equal(types.UserDefined("myType")) {
+		t.Errorf("PropertyType(geo) = %v ok=%v, want UserDefined(myType)", got, ok)
+	}
+	if !v2.Version().Equal(v.Version()) {
+		t.Errorf("version lost on round-trip: %v vs %v", v2.Version(), v.Version())
+	}
+}
+
+func TestUserDefinedTypeUndeclaredRejected(t *testing.T) {
+	t.Parallel()
+	// A user-defined type not listed in the version must fail Validate.
+	_, err := NewVertexInfo("person", 100, []PropertyGroup{{
+		Properties: []Property{{Name: "geo", Type: types.UserDefined("myType"), IsPrimary: true}},
+		FileType:   types.FileTypeParquet,
+	}})
+	if !errors.Is(err, ErrInvalidVertexInfo) {
+		t.Errorf("expected ErrInvalidVertexInfo for undeclared user-defined type, got %v", err)
+	}
+}
+
+func TestLoadVertexInfoEmptyDataTypeRejected(t *testing.T) {
+	t.Parallel()
+	in := `type: p
+chunk_size: 1
+property_groups:
+  - properties:
+      - name: id
+        data_type: ""
+        is_primary: true
+    file_type: parquet
+version: gar/v1
+`
+	_, err := LoadVertexInfo(strings.NewReader(in))
+	if !errors.Is(err, types.ErrInvalidDataType) {
+		t.Errorf("expected types.ErrInvalidDataType for empty data_type, got %v", err)
+	}
+}
+
+func TestLoadVertexInfoMalformedListRejected(t *testing.T) {
+	t.Parallel()
+	// A missing closing bracket is a typo, not a custom type name.
+	in := `type: p
+chunk_size: 1
+property_groups:
+  - properties:
+      - name: id
+        data_type: list<int32
+        is_primary: true
+    file_type: parquet
+version: gar/v1
+`
+	_, err := LoadVertexInfo(strings.NewReader(in))
+	if !errors.Is(err, types.ErrInvalidDataType) {
+		t.Errorf("expected types.ErrInvalidDataType for malformed list, got %v", err)
+	}
+}
+
+func TestLoadVertexInfoUserDefinedTrimmed(t *testing.T) {
+	t.Parallel()
+	// A padded unknown name is trimmed before becoming a user-defined type, so
+	// it validates against a declared name without surrounding whitespace.
+	in := `type: p
+chunk_size: 1
+property_groups:
+  - properties:
+      - name: geo
+        data_type: "  Vector  "
+    file_type: parquet
+version: gar/v1 (Vector)
+`
+	v, err := LoadVertexInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadVertexInfo: %v", err)
+	}
+	got, ok := v.PropertyType("geo")
+	if !ok || !got.Equal(types.UserDefined("Vector")) {
+		t.Errorf("PropertyType(geo) = %v ok=%v, want UserDefined(Vector)", got, ok)
+	}
+	if err := v.Validate(); err != nil {
+		t.Errorf("Validate after trim = %v, want nil", err)
+	}
+}
+
+func TestLoadVertexInfoMissingTypeRejected(t *testing.T) {
+	t.Parallel()
+	// An edge document mis-filed under a vertex reference decodes to a zero type.
+	in := `src_type: a
+edge_type: k
+dst_type: b
+chunk_size: 1
+`
+	_, err := LoadVertexInfo(strings.NewReader(in))
+	if !errors.Is(err, ErrInvalidYAML) {
+		t.Errorf("expected ErrInvalidYAML for vertex with no type, got %v", err)
+	}
+}
+
+func TestLoadEdgeInfoMissingTripletRejected(t *testing.T) {
+	t.Parallel()
+	// A vertex document mis-filed under an edge reference lacks the triplet.
+	in := `type: p
+chunk_size: 1
+`
+	_, err := LoadEdgeInfo(strings.NewReader(in))
+	if !errors.Is(err, ErrInvalidYAML) {
+		t.Errorf("expected ErrInvalidYAML for edge with no triplet, got %v", err)
+	}
+}
+
+func TestLoadVertexInfoIgnoresUnknownField(t *testing.T) {
+	t.Parallel()
+	// Unknown fields are ignored so documents written by newer SDKs still load.
+	in := `type: p
+chunk_size: 1
+new_field: surprise
+property_groups:
+  - properties:
+      - name: id
+        data_type: int64
+        is_primary: true
+    file_type: parquet
+version: gar/v1
+`
+	v, err := LoadVertexInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadVertexInfo should ignore unknown field, got %v", err)
+	}
+	if v.Type() != "p" {
+		t.Errorf("Type() = %q, want p", v.Type())
+	}
+}
+
+func TestLoadVertexInfoBadFileType(t *testing.T) {
+	t.Parallel()
+	in := `type: p
+chunk_size: 1
+property_groups:
+  - properties:
+      - name: id
+        data_type: int64
+        is_primary: true
+    file_type: tsv
+version: gar/v1
+`
+	_, err := LoadVertexInfo(strings.NewReader(in))
+	if !errors.Is(err, types.ErrInvalidFileType) {
+		t.Errorf("expected ErrInvalidFileType, got %v", err)
+	}
+}
+
+func TestLoadVertexInfoBadCardinality(t *testing.T) {
+	t.Parallel()
+	in := `type: p
+chunk_size: 1
+property_groups:
+  - properties:
+      - name: id
+        data_type: int64
+        is_primary: true
+      - name: tags
+        data_type: string
+        is_primary: false
+        cardinality: many
+    file_type: parquet
+version: gar/v1
+`
+	_, err := LoadVertexInfo(strings.NewReader(in))
+	if !errors.Is(err, types.ErrInvalidCardinality) {
+		t.Errorf("expected ErrInvalidCardinality, got %v", err)
+	}
+}
+
+func TestLoadVertexInfoBadVersion(t *testing.T) {
+	t.Parallel()
+	in := `type: p
+chunk_size: 1
+property_groups:
+  - properties:
+      - name: id
+        data_type: int64
+        is_primary: true
+    file_type: parquet
+version: not-a-version
+`
+	_, err := LoadVertexInfo(strings.NewReader(in))
+	if !errors.Is(err, types.ErrInvalidVersion) {
+		t.Errorf("expected ErrInvalidVersion, got %v", err)
+	}
+}
+
+func TestLoadVertexInfoMalformedYAML(t *testing.T) {
+	t.Parallel()
+	_, err := LoadVertexInfo(strings.NewReader("type: ["))
+	if !errors.Is(err, ErrInvalidYAML) {
+		t.Errorf("expected ErrInvalidYAML, got %v", err)
+	}
+}
+
+func TestLoadVertexInfoPreservesYAMLErrorChain(t *testing.T) {
+	t.Parallel()
+	// Decoder errors must remain in the Unwrap chain so callers can pin
+	// line numbers via errors.As(yaml.TypeError) - the original "%w + %s"
+	// wrap broke this.
+	in := `type: p
+chunk_size: not_an_int
+property_groups:
+  - properties:
+      - name: id
+        data_type: int64
+        is_primary: true
+    file_type: parquet
+version: gar/v1
+`
+	_, err := LoadVertexInfo(strings.NewReader(in))
+	if err == nil {
+		t.Fatal("expected error for non-int chunk_size")
+	}
+	if !errors.Is(err, ErrInvalidYAML) {
+		t.Errorf("missing ErrInvalidYAML in chain: %v", err)
+	}
+	var typeErr *yaml.TypeError
+	if !errors.As(err, &typeErr) {
+		t.Errorf("expected yaml.TypeError reachable via errors.As, got %v", err)
+	}
+}
+
+func TestLoadEdgeInfoBadAlignedBy(t *testing.T) {
+	t.Parallel()
+	in := `src_type: s
+edge_type: k
+dst_type: d
+chunk_size: 1
+src_chunk_size: 1
+dst_chunk_size: 1
+directed: false
+adj_lists:
+  - ordered: true
+    aligned_by: nowhere
+    file_type: parquet
+version: gar/v1
+`
+	_, err := LoadEdgeInfo(strings.NewReader(in))
+	if !errors.Is(err, types.ErrInvalidAdjListType) {
+		t.Errorf("expected ErrInvalidAdjListType, got %v", err)
+	}
+}
+
+func TestLoadEdgeInfoBadAdjListFileType(t *testing.T) {
+	t.Parallel()
+	in := `src_type: s
+edge_type: k
+dst_type: d
+chunk_size: 1
+src_chunk_size: 1
+dst_chunk_size: 1
+directed: false
+adj_lists:
+  - type: ordered_by_source
+    file_type: tsv
+version: gar/v1
+`
+	_, err := LoadEdgeInfo(strings.NewReader(in))
+	if !errors.Is(err, types.ErrInvalidFileType) {
+		t.Errorf("expected ErrInvalidFileType, got %v", err)
+	}
+}
+
+func TestLoadEdgeInfoBadAdjListType(t *testing.T) {
+	t.Parallel()
+	in := `src_type: s
+edge_type: k
+dst_type: d
+chunk_size: 1
+src_chunk_size: 1
+dst_chunk_size: 1
+directed: false
+adj_lists:
+  - type: csr
+    file_type: parquet
+version: gar/v1
+`
+	_, err := LoadEdgeInfo(strings.NewReader(in))
+	if !errors.Is(err, types.ErrInvalidAdjListType) {
+		t.Errorf("expected ErrInvalidAdjListType, got %v", err)
+	}
+}
+
+func TestLoadEdgeInfoUnknownDataTypeAsUserDefined(t *testing.T) {
+	t.Parallel()
+	in := `src_type: s
+edge_type: k
+dst_type: d
+chunk_size: 1
+src_chunk_size: 1
+dst_chunk_size: 1
+directed: false
+adj_lists:
+  - type: ordered_by_source
+    file_type: parquet
+property_groups:
+  - file_type: parquet
+    properties:
+      - name: weight
+        data_type: bogus
+        is_primary: false
+version: gar/v1
+`
+	// Liberal read: "bogus" loads as a user-defined type.
+	e, err := LoadEdgeInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadEdgeInfo: %v", err)
+	}
+	got, ok := e.PropertyGroups().PropertyType("weight")
+	if !ok || !got.Equal(types.UserDefined("bogus")) {
+		t.Errorf("PropertyType(weight) = %v ok=%v, want UserDefined(bogus)", got, ok)
+	}
+}
+
+func TestLoadEdgeInfoBadVersion(t *testing.T) {
+	t.Parallel()
+	in := `src_type: s
+edge_type: k
+dst_type: d
+chunk_size: 1
+src_chunk_size: 1
+dst_chunk_size: 1
+directed: false
+adj_lists:
+  - type: ordered_by_source
+    file_type: parquet
+version: not-a-version
+`
+	_, err := LoadEdgeInfo(strings.NewReader(in))
+	if !errors.Is(err, types.ErrInvalidVersion) {
+		t.Errorf("expected ErrInvalidVersion, got %v", err)
+	}
+}
+
+func TestLoadEdgeInfoMalformedYAML(t *testing.T) {
+	t.Parallel()
+	_, err := LoadEdgeInfo(strings.NewReader(":\n  -\n}"))
+	if !errors.Is(err, ErrInvalidYAML) {
+		t.Errorf("expected ErrInvalidYAML, got %v", err)
+	}
+}
+
+func TestPropertyToYAMLEmitsNonDefaultCardinality(t *testing.T) {
+	t.Parallel()
+	in := `type: p
+chunk_size: 1
+property_groups:
+  - file_type: parquet
+    properties:
+      - name: id
+        data_type: int64
+        is_primary: true
+      - name: tags
+        data_type: string
+        is_primary: false
+        cardinality: list
+version: gar/v1
+`
+	v, err := LoadVertexInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadVertexInfo: %v", err)
+	}
+	out, err := MarshalVertexInfo(v)
+	if err != nil {
+		t.Fatalf("MarshalVertexInfo: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "cardinality: list") {
+		t.Errorf("non-default cardinality was not emitted:\n%s", s)
+	}
+}
+
+func TestLoadVertexInfoLabelFallback(t *testing.T) {
+	t.Parallel()
+	// Older fixtures use "label" instead of "type"; load.go must
+	// accept the alias to preserve cross-language interop.
+	in := `label: person
+chunk_size: 100
+property_groups:
+  - properties:
+      - name: id
+        data_type: int64
+        is_primary: true
+    file_type: parquet
+version: gar/v1
+`
+	v, err := LoadVertexInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadVertexInfo with label alias: %v", err)
+	}
+	if v.Type() != "person" {
+		t.Errorf("label alias not honoured: got %q", v.Type())
+	}
+}
+
+func TestLoadEdgeInfoTripletLabelFallback(t *testing.T) {
+	t.Parallel()
+	in := `src_label: person
+edge_label: knows
+dst_label: person
+chunk_size: 1
+src_chunk_size: 1
+dst_chunk_size: 1
+directed: false
+adj_lists:
+  - type: ordered_by_source
+    file_type: parquet
+version: gar/v1
+`
+	e, err := LoadEdgeInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadEdgeInfo with *_label alias: %v", err)
+	}
+	src, edge, dst := e.Triplet()
+	if src != "person" || edge != "knows" || dst != "person" {
+		t.Errorf("triplet from labels = %s/%s/%s", src, edge, dst)
+	}
+}
+
+func TestLoadEdgeInfoIgnoresNestedPropertyGroups(t *testing.T) {
+	t.Parallel()
+	// Some older fixtures (ldbc, nebula) attach a property_groups subtree
+	// to each adj_list entry. It is ignored on read: the per-layout subtree
+	// must not surface in the domain model.
+	in := `src_type: s
+edge_type: k
+dst_type: d
+chunk_size: 1
+src_chunk_size: 1
+dst_chunk_size: 1
+directed: false
+adj_lists:
+  - type: ordered_by_source
+    file_type: parquet
+    property_groups:
+      - file_type: parquet
+        properties:
+          - name: w
+            data_type: int64
+            is_primary: false
+version: gar/v1
+`
+	e, err := LoadEdgeInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadEdgeInfo with nested property_groups: %v", err)
+	}
+	if e.PropertyGroups() != nil {
+		t.Errorf("nested property_groups leaked into domain model")
+	}
+}
+
+func TestEdgeInfoToYAMLEmitsPropertyGroups(t *testing.T) {
+	t.Parallel()
+	in := `src_type: s
+edge_type: k
+dst_type: d
+chunk_size: 1
+src_chunk_size: 1
+dst_chunk_size: 1
+directed: false
+adj_lists:
+  - type: ordered_by_source
+    file_type: parquet
+property_groups:
+  - file_type: parquet
+    properties:
+      - name: weight
+        data_type: double
+        is_primary: false
+version: gar/v1
+`
+	e, err := LoadEdgeInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadEdgeInfo: %v", err)
+	}
+	out, err := MarshalEdgeInfo(e)
+	if err != nil {
+		t.Fatalf("MarshalEdgeInfo: %v", err)
+	}
+	s := string(out)
+	for _, want := range []string{"property_groups:", "name: weight", "data_type: double"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("MarshalEdgeInfo missing %q\n%s", want, s)
+		}
+	}
+}
+
+// TestIsNullableTriState covers the liberal-read contract: absent is_nullable
+// on a non-primary defaults to true; an explicit is_nullable:true on a primary
+// is preserved verbatim on load (the readers do not coerce); and Validate -
+// not Load - is what flags the contradiction.
+func TestIsNullableTriState(t *testing.T) {
+	t.Parallel()
+	in := `type: person
+chunk_size: 100
+property_groups:
+  - file_type: parquet
+    properties:
+      - name: id
+        data_type: int64
+        is_primary: true
+        is_nullable: true
+      - name: firstName
+        data_type: string
+        is_primary: false
+version: gar/v1
+`
+	v, err := LoadVertexInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadVertexInfo: %v", err)
+	}
+	pg := v.PropertyGroups()
+	if !pg.IsNullable("firstName") {
+		t.Error("absent is_nullable on non-primary must default to true")
+	}
+	if !pg.IsNullable("id") {
+		t.Error("explicit is_nullable:true on a primary must be preserved on load")
+	}
+	// Load is liberal; Validate is where the primary+nullable contradiction
+	// surfaces.
+	if err := v.Validate(); !errors.Is(err, ErrInvalidProperty) {
+		t.Errorf("Validate should reject primary+nullable, got %v", err)
+	}
+}
+
+// TestLoadVertexInfoLiberal covers the liberal-read contract at the vertex
+// level: a chunk_size<=0 document LOADS but fails Validate, while a
+// zero-property-group vertex both loads and validates (readers accept it;
+// Go used to reject it at load).
+func TestLoadVertexInfoLiberal(t *testing.T) {
+	t.Parallel()
+	bad := `type: person
+chunk_size: 0
+property_groups:
+  - file_type: parquet
+    properties:
+      - name: id
+        data_type: int64
+        is_primary: true
+version: gar/v1
+`
+	v, err := LoadVertexInfo(strings.NewReader(bad))
+	if err != nil {
+		t.Fatalf("liberal load should accept chunk_size:0, got %v", err)
+	}
+	if err := v.Validate(); !errors.Is(err, ErrInvalidVertexInfo) {
+		t.Errorf("Validate should reject chunk_size:0, got %v", err)
+	}
+
+	empty := `type: person
+chunk_size: 100
+version: gar/v1
+`
+	v2, err := LoadVertexInfo(strings.NewReader(empty))
+	if err != nil {
+		t.Fatalf("liberal load should accept zero property groups, got %v", err)
+	}
+	if err := v2.Validate(); err != nil {
+		t.Errorf("zero property groups should validate, got %v", err)
+	}
+}
+
+// TestIsNullableDefaultsNotEmitted asserts byte-stable, divergence-only write:
+// a file where every property sits at its default nullability round-trips
+// without re-introducing an is_nullable field.
+func TestIsNullableDefaultsNotEmitted(t *testing.T) {
+	t.Parallel()
+	in := `type: person
+chunk_size: 100
+property_groups:
+  - file_type: parquet
+    properties:
+      - name: id
+        data_type: int64
+        is_primary: true
+      - name: firstName
+        data_type: string
+        is_primary: false
+version: gar/v1
+`
+	v, err := LoadVertexInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadVertexInfo: %v", err)
+	}
+	out, err := MarshalVertexInfo(v)
+	if err != nil {
+		t.Fatalf("MarshalVertexInfo: %v", err)
+	}
+	if strings.Contains(string(out), "is_nullable") {
+		t.Errorf("default nullability should not be emitted:\n%s", out)
+	}
+}
+
+// TestIsNullableFalseNonPrimaryEmitted asserts an explicit non-default
+// is_nullable:false on a non-primary property survives and is re-emitted.
+func TestIsNullableFalseNonPrimaryEmitted(t *testing.T) {
+	t.Parallel()
+	in := `type: person
+chunk_size: 100
+property_groups:
+  - file_type: parquet
+    properties:
+      - name: id
+        data_type: int64
+        is_primary: true
+      - name: score
+        data_type: int64
+        is_primary: false
+        is_nullable: false
+version: gar/v1
+`
+	v, err := LoadVertexInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadVertexInfo: %v", err)
+	}
+	if v.PropertyGroups().IsNullable("score") {
+		t.Error("explicit is_nullable:false must be preserved")
+	}
+	out, err := MarshalVertexInfo(v)
+	if err != nil {
+		t.Fatalf("MarshalVertexInfo: %v", err)
+	}
+	if !strings.Contains(string(out), "is_nullable: false") {
+		t.Errorf("non-default is_nullable:false must be emitted:\n%s", out)
+	}
+}
+
+// TestAdjacentListMarshalUsesOrderedAlignedBy guards the adjacency-list write
+// format: adj_list must be written in the (ordered, aligned_by) form
+// that the readers accept - never the `type:` spelling, which those
+// readers ignore (silently mis-decoding every adj_list to unordered_by_dest).
+// Also serves as a full edge round-trip.
+func TestAdjacentListMarshalUsesOrderedAlignedBy(t *testing.T) {
+	t.Parallel()
+	in := `src_type: person
+edge_type: knows
+dst_type: person
+chunk_size: 1024
+src_chunk_size: 100
+dst_chunk_size: 100
+directed: false
+prefix: edge/person_knows_person/
+adj_lists:
+  - ordered: true
+    aligned_by: src
+    file_type: parquet
+  - ordered: true
+    aligned_by: dst
+    file_type: parquet
+property_groups:
+  - file_type: parquet
+    properties:
+      - name: since
+        data_type: int64
+        is_primary: false
+version: gar/v1
+`
+	e, err := LoadEdgeInfo(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("LoadEdgeInfo: %v", err)
+	}
+	out, err := MarshalEdgeInfo(e)
+	if err != nil {
+		t.Fatalf("MarshalEdgeInfo: %v", err)
+	}
+	s := string(out)
+	if n := strings.Count(s, "aligned_by:"); n != 2 {
+		t.Errorf("expected 2 aligned_by entries (expected form), got %d:\n%s", n, s)
+	}
+	if !strings.Contains(s, "ordered:") {
+		t.Errorf("marshalled adj_list missing `ordered:`:\n%s", s)
+	}
+	if strings.Contains(s, "type: ordered_by") {
+		t.Errorf("adj_list emitted the `type:` form readers ignore:\n%s", s)
+	}
+	// Full round-trip: re-load must preserve adjacency types and properties.
+	e2, err := LoadEdgeInfo(strings.NewReader(s))
+	if err != nil {
+		t.Fatalf("re-LoadEdgeInfo: %v", err)
+	}
+	got, want := e2.AdjListTypes(), e.AdjListTypes()
+	if len(got) != len(want) {
+		t.Fatalf("adj list count changed after round-trip: %v vs %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("adj list type[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+	if pt, ok := e2.PropertyGroups().PropertyType("since"); !ok || !pt.Equal(types.Int64()) {
+		t.Errorf("property `since` not preserved: (%v, %v)", pt, ok)
+	}
+	if e2.ChunkSize() != e.ChunkSize() || e2.Directed() != e.Directed() {
+		t.Errorf("edge scalar fields changed after round-trip")
+	}
+}

--- a/go/graphar/types/adjlist.go
+++ b/go/graphar/types/adjlist.go
@@ -1,0 +1,118 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import "fmt"
+
+// AdjListType is the layout of an edge type's adjacency list. The two
+// dimensions are alignment side (source or destination vertex) and ordering
+// (ordered or not). Values are bit flags; equality is the only relation
+// callers should depend on.
+type AdjListType uint8
+
+// AdjListType values.
+const (
+	// UnorderedBySource groups edges by source vertex, source side unordered
+	// (COO layout).
+	UnorderedBySource AdjListType = 1 << iota
+	// UnorderedByDest groups edges by destination vertex, dest side unordered.
+	UnorderedByDest
+	// OrderedBySource groups edges by source vertex, sorted by source (CSR).
+	OrderedBySource
+	// OrderedByDest groups edges by destination vertex, sorted by dest (CSC).
+	OrderedByDest
+)
+
+// alignedBySrc / alignedByDst are the on-disk aligned_by values, shared by
+// AlignedBy (write) and AdjListTypeFromOrderedAligned (read).
+const (
+	alignedBySrc = "src"
+	alignedByDst = "dst"
+)
+
+// String returns the on-disk spelling.
+func (a AdjListType) String() string {
+	switch a {
+	case UnorderedBySource:
+		return "unordered_by_source"
+	case UnorderedByDest:
+		return "unordered_by_dest"
+	case OrderedBySource:
+		return "ordered_by_source"
+	case OrderedByDest:
+		return "ordered_by_dest"
+	default:
+		return "unknown"
+	}
+}
+
+// IsOrdered reports whether the layout is ordered.
+func (a AdjListType) IsOrdered() bool {
+	return a == OrderedBySource || a == OrderedByDest
+}
+
+// AlignedBy reports the vertex side ("src" or "dst") the layout is aligned by.
+// For unknown values, it returns the empty string and false.
+func (a AdjListType) AlignedBy() (side string, ok bool) {
+	switch a {
+	case UnorderedBySource, OrderedBySource:
+		return alignedBySrc, true
+	case UnorderedByDest, OrderedByDest:
+		return alignedByDst, true
+	default:
+		return "", false
+	}
+}
+
+// ParseAdjListType parses the on-disk spelling produced by AdjListType.String.
+func ParseAdjListType(s string) (AdjListType, error) {
+	switch s {
+	case "unordered_by_source":
+		return UnorderedBySource, nil
+	case "unordered_by_dest":
+		return UnorderedByDest, nil
+	case "ordered_by_source":
+		return OrderedBySource, nil
+	case "ordered_by_dest":
+		return OrderedByDest, nil
+	default:
+		return 0, fmt.Errorf("%w: %q", ErrInvalidAdjListType, s)
+	}
+}
+
+// AdjListTypeFromOrderedAligned derives an AdjListType from the legacy
+// (ordered, aligned_by) pair used by older yaml fixtures. The aligned argument
+// must be "src" or "dst"; any other value returns an error wrapping
+// ErrInvalidAdjListType. This is the inverse of (IsOrdered, AlignedBy).
+func AdjListTypeFromOrderedAligned(ordered bool, aligned string) (AdjListType, error) {
+	switch aligned {
+	case alignedBySrc:
+		if ordered {
+			return OrderedBySource, nil
+		}
+		return UnorderedBySource, nil
+	case alignedByDst:
+		if ordered {
+			return OrderedByDest, nil
+		}
+		return UnorderedByDest, nil
+	default:
+		return 0, fmt.Errorf("%w: aligned_by must be %q or %q, got %q",
+			ErrInvalidAdjListType, alignedBySrc, alignedByDst, aligned)
+	}
+}

--- a/go/graphar/types/adjlist_test.go
+++ b/go/graphar/types/adjlist_test.go
@@ -1,0 +1,123 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAdjListTypeRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		v       AdjListType
+		s       string
+		ordered bool
+		side    string
+	}{
+		{UnorderedBySource, "unordered_by_source", false, "src"},
+		{UnorderedByDest, "unordered_by_dest", false, "dst"},
+		{OrderedBySource, "ordered_by_source", true, "src"},
+		{OrderedByDest, "ordered_by_dest", true, "dst"},
+	}
+	for _, c := range cases {
+		if c.v.String() != c.s {
+			t.Errorf("String() = %q, want %q", c.v.String(), c.s)
+		}
+		got, err := ParseAdjListType(c.s)
+		if err != nil {
+			t.Errorf("ParseAdjListType(%q): %v", c.s, err)
+			continue
+		}
+		if got != c.v {
+			t.Errorf("ParseAdjListType(%q) = %v, want %v", c.s, got, c.v)
+		}
+		if c.v.IsOrdered() != c.ordered {
+			t.Errorf("%v IsOrdered() = %v, want %v", c.v, c.v.IsOrdered(), c.ordered)
+		}
+		side, ok := c.v.AlignedBy()
+		if !ok || side != c.side {
+			t.Errorf("%v AlignedBy() = (%q,%v), want (%q,true)", c.v, side, ok, c.side)
+		}
+	}
+}
+
+func TestAdjListTypeUnknown(t *testing.T) {
+	t.Parallel()
+	bad := AdjListType(0xff)
+	if bad.String() != "unknown" {
+		t.Errorf("unknown String = %q", bad.String())
+	}
+	if bad.IsOrdered() {
+		t.Errorf("unknown should not report IsOrdered")
+	}
+	if side, ok := bad.AlignedBy(); ok || side != "" {
+		t.Errorf("unknown AlignedBy = (%q,%v)", side, ok)
+	}
+}
+
+func TestParseAdjListTypeErrors(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"", "ordered_by_src", "csr", "ordered"} {
+		_, err := ParseAdjListType(in)
+		if err == nil {
+			t.Errorf("ParseAdjListType(%q) succeeded, want error", in)
+			continue
+		}
+		if !errors.Is(err, ErrInvalidAdjListType) {
+			t.Errorf("ParseAdjListType(%q) error %v not wrapped", in, err)
+		}
+	}
+}
+
+func TestAdjListTypeFromOrderedAligned(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		ordered bool
+		aligned string
+		want    AdjListType
+	}{
+		{true, "src", OrderedBySource},
+		{true, "dst", OrderedByDest},
+		{false, "src", UnorderedBySource},
+		{false, "dst", UnorderedByDest},
+	}
+	for _, c := range cases {
+		got, err := AdjListTypeFromOrderedAligned(c.ordered, c.aligned)
+		if err != nil {
+			t.Errorf("AdjListTypeFromOrderedAligned(%v,%q): %v", c.ordered, c.aligned, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("AdjListTypeFromOrderedAligned(%v,%q) = %v, want %v", c.ordered, c.aligned, got, c.want)
+		}
+		// Reciprocal property: (IsOrdered, AlignedBy) must yield the same value.
+		side, ok := got.AlignedBy()
+		if !ok {
+			t.Errorf("AlignedBy returned ok=false for %v", got)
+			continue
+		}
+		round, err := AdjListTypeFromOrderedAligned(got.IsOrdered(), side)
+		if err != nil || round != got {
+			t.Errorf("round-trip failed: round=%v err=%v", round, err)
+		}
+	}
+	if _, err := AdjListTypeFromOrderedAligned(true, "other"); !errors.Is(err, ErrInvalidAdjListType) {
+		t.Errorf("expected ErrInvalidAdjListType for bogus aligned, got %v", err)
+	}
+}

--- a/go/graphar/types/cardinality.go
+++ b/go/graphar/types/cardinality.go
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import "fmt"
+
+// Cardinality is the multiplicity of a property's value. SINGLE is the default
+// for newly constructed properties; LIST and SET are only legal on vertex
+// properties (edge properties must be single-valued).
+type Cardinality uint8
+
+// Cardinality values.
+const (
+	// CardinalitySingle is one value per record.
+	CardinalitySingle Cardinality = iota
+	// CardinalityList is an ordered, possibly repeating list of values per record.
+	CardinalityList
+	// CardinalitySet is an unordered set of distinct values per record.
+	CardinalitySet
+)
+
+// String returns the on-disk spelling.
+func (c Cardinality) String() string {
+	switch c {
+	case CardinalitySingle:
+		return "single"
+	case CardinalityList:
+		return "list"
+	case CardinalitySet:
+		return "set"
+	default:
+		return "unknown"
+	}
+}
+
+// ParseCardinality parses the on-disk spelling produced by Cardinality.String.
+func ParseCardinality(s string) (Cardinality, error) {
+	switch s {
+	case "single":
+		return CardinalitySingle, nil
+	case "list":
+		return CardinalityList, nil
+	case "set":
+		return CardinalitySet, nil
+	default:
+		return 0, fmt.Errorf("%w: %q", ErrInvalidCardinality, s)
+	}
+}

--- a/go/graphar/types/cardinality_test.go
+++ b/go/graphar/types/cardinality_test.go
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCardinalityRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, c := range []Cardinality{CardinalitySingle, CardinalityList, CardinalitySet} {
+		s := c.String()
+		got, err := ParseCardinality(s)
+		if err != nil {
+			t.Errorf("ParseCardinality(%q): %v", s, err)
+			continue
+		}
+		if got != c {
+			t.Errorf("round-trip %v: got %v", c, got)
+		}
+	}
+}
+
+func TestCardinalityStringUnknown(t *testing.T) {
+	t.Parallel()
+	if (Cardinality(0xff)).String() != "unknown" {
+		t.Errorf("unknown Cardinality string mismatch")
+	}
+}
+
+func TestParseCardinalityErrors(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"", "Single", "many", "list "} {
+		_, err := ParseCardinality(in)
+		if err == nil {
+			t.Errorf("ParseCardinality(%q) succeeded, want error", in)
+			continue
+		}
+		if !errors.Is(err, ErrInvalidCardinality) {
+			t.Errorf("ParseCardinality(%q) not wrapped: %v", in, err)
+		}
+	}
+}

--- a/go/graphar/types/datatype.go
+++ b/go/graphar/types/datatype.go
@@ -1,0 +1,266 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TypeID enumerates the primitive categories of DataType. The on-disk contract
+// is the string form (ParseDataType / DataType.String); do not rely on the
+// numeric ID for interchange.
+type TypeID uint8
+
+// TypeID values.
+const (
+	BoolType TypeID = iota
+	Int32Type
+	Int64Type
+	FloatType
+	DoubleType
+	StringType
+	ListType
+	DateType
+	TimestampType
+	UserDefinedType
+)
+
+// listPrefix / listSuffix delimit the on-disk spelling of a list type
+// ("list<int32>"). Shared by String (write) and ParseDataType (read).
+const (
+	listPrefix = "list<"
+	listSuffix = ">"
+)
+
+// DataType is the value-typed description of a GraphAr property's data type.
+//
+// Simple types are constructed with the helpers (Bool, Int32, Int64, Float,
+// Double, String, Date, Timestamp). List types wrap a child DataType via List.
+// UserDefined carries a free-form name.
+//
+// DataType is immutable: the Child pointer is treated as read-only and is
+// never mutated after construction.
+//
+// The zero value is the unset sentinel: IsZero() reports it, and String()
+// renders it as "unset" (which ParseDataType rejects), so a forgotten Type
+// gets caught instead of passing as a real one.
+type DataType struct {
+	id    TypeID
+	valid bool      // true when constructed via any factory or ParseDataType
+	child *DataType // only meaningful when id == ListType
+	name  string    // only meaningful when id == UserDefinedType
+}
+
+// Bool returns the boolean DataType.
+func Bool() DataType { return DataType{id: BoolType, valid: true} }
+
+// Int32 returns the 32-bit signed integer DataType.
+func Int32() DataType { return DataType{id: Int32Type, valid: true} }
+
+// Int64 returns the 64-bit signed integer DataType.
+func Int64() DataType { return DataType{id: Int64Type, valid: true} }
+
+// Float returns the 32-bit floating point DataType.
+func Float() DataType { return DataType{id: FloatType, valid: true} }
+
+// Double returns the 64-bit floating point DataType.
+func Double() DataType { return DataType{id: DoubleType, valid: true} }
+
+// String returns the UTF-8 string DataType.
+func String() DataType { return DataType{id: StringType, valid: true} }
+
+// Date returns the date DataType (days since the Unix epoch).
+func Date() DataType { return DataType{id: DateType, valid: true} }
+
+// Timestamp returns the timestamp DataType (milliseconds since the Unix epoch).
+func Timestamp() DataType { return DataType{id: TimestampType, valid: true} }
+
+// List returns a list DataType with the given element type.
+func List(child DataType) DataType {
+	c := child
+	return DataType{id: ListType, valid: true, child: &c}
+}
+
+// UserDefined returns a user-defined DataType with the given name.
+// The name is the on-disk spelling and must be non-empty.
+func UserDefined(name string) DataType {
+	return DataType{id: UserDefinedType, valid: true, name: name}
+}
+
+// ID returns the type category.
+func (d DataType) ID() TypeID { return d.id }
+
+// ValueType returns the element type for ListType; the zero DataType and
+// false for non-list types.
+func (d DataType) ValueType() (DataType, bool) {
+	if d.id != ListType || d.child == nil {
+		return DataType{}, false
+	}
+	return *d.child, true
+}
+
+// UserDefinedName returns the user-defined type name when ID() ==
+// UserDefinedType; otherwise the empty string.
+func (d DataType) UserDefinedName() string {
+	if d.id != UserDefinedType {
+		return ""
+	}
+	return d.name
+}
+
+// IsZero reports whether d is the zero (unset) DataType - never produced by a
+// constructor; use it to detect a forgotten Property.Type.
+func (d DataType) IsZero() bool { return !d.valid }
+
+// Equal reports whether two DataTypes describe the same logical type. The unset
+// zero value equals only another unset value, never a constructed type.
+func (d DataType) Equal(other DataType) bool {
+	if d.valid != other.valid {
+		return false
+	}
+	if d.id != other.id || d.name != other.name {
+		return false
+	}
+	if d.id != ListType {
+		return true
+	}
+	if d.child == nil || other.child == nil {
+		return d.child == other.child
+	}
+	return d.child.Equal(*other.child)
+}
+
+// String returns the on-disk spelling (the inverse of ParseDataType for the
+// supported set). The unset zero value renders as "unset" (not parseable) and
+// unrecognised IDs as "unknown".
+func (d DataType) String() string {
+	if !d.valid {
+		return "unset"
+	}
+	switch d.id {
+	case BoolType:
+		return "bool"
+	case Int32Type:
+		return "int32"
+	case Int64Type:
+		return "int64"
+	case FloatType:
+		return "float"
+	case DoubleType:
+		return "double"
+	case StringType:
+		return "string"
+	case DateType:
+		return "date"
+	case TimestampType:
+		return "timestamp"
+	case ListType:
+		if d.child == nil {
+			return listPrefix + "unknown" + listSuffix
+		}
+		return listPrefix + d.child.String() + listSuffix
+	case UserDefinedType:
+		return d.name
+	default:
+		return "unknown"
+	}
+}
+
+// Validate reports whether d is well-formed for a strict (write) path. It
+// recurses into list elements: a list may only hold a scalar element type from
+// the shared subset int32/int64/float/double/string (bool, date, timestamp and
+// nested lists are rejected, matching what the readers accept), and a
+// user-defined type must carry a non-empty name. The zero value is invalid.
+func (d DataType) Validate() error {
+	if !d.valid {
+		return fmt.Errorf("%w: unset data type", ErrInvalidDataType)
+	}
+	switch d.id {
+	case ListType:
+		if d.child == nil || !d.child.valid {
+			return fmt.Errorf("%w: list has no element type", ErrInvalidDataType)
+		}
+		switch d.child.id {
+		case Int32Type, Int64Type, FloatType, DoubleType, StringType:
+			return nil
+		default:
+			return fmt.Errorf("%w: list element %q must be int32, int64, float, double or string",
+				ErrInvalidDataType, d.child.String())
+		}
+	case UserDefinedType:
+		if err := validateUserDefinedName(d.name); err != nil {
+			return fmt.Errorf("%w: %s", ErrInvalidDataType, err)
+		}
+	}
+	return nil
+}
+
+// validateUserDefinedName reports why name is unusable as a user-defined type
+// name, or nil when it is fine. On top of the validateTypeName character
+// rules, the name must not be a spelling ParseDataType already claims for a
+// built-in. Callers wrap the result with their own sentinel.
+func validateUserDefinedName(name string) error {
+	if err := validateTypeName(name); err != nil {
+		return err
+	}
+	if _, err := ParseDataType(name); err == nil {
+		return fmt.Errorf("user-defined type name %q collides with a built-in type spelling", name)
+	}
+	return nil
+}
+
+// ParseDataType parses the on-disk spelling produced by DataType.String: the
+// closed set bool/int32/int64/float/double/string/date/timestamp and list<...>
+// over them. Anything else - including user-defined names, which are
+// indistinguishable from typos here - errors with ErrInvalidDataType; build
+// user-defined types explicitly with UserDefined.
+func ParseDataType(s string) (DataType, error) {
+	trimmed := strings.TrimSpace(s)
+	switch trimmed {
+	case "bool":
+		return Bool(), nil
+	case "int32":
+		return Int32(), nil
+	case "int64":
+		return Int64(), nil
+	case "float":
+		return Float(), nil
+	case "double":
+		return Double(), nil
+	case "string":
+		return String(), nil
+	case "date":
+		return Date(), nil
+	case "timestamp":
+		return Timestamp(), nil
+	}
+	if strings.HasPrefix(trimmed, listPrefix) && strings.HasSuffix(trimmed, listSuffix) {
+		inner := trimmed[len(listPrefix) : len(trimmed)-len(listSuffix)]
+		// Reject empty <> and nested user-defined.
+		if inner == "" {
+			return DataType{}, fmt.Errorf("%w: empty list element type", ErrInvalidDataType)
+		}
+		child, err := ParseDataType(inner)
+		if err != nil {
+			return DataType{}, fmt.Errorf("%w: invalid list element %q", ErrInvalidDataType, inner)
+		}
+		return List(child), nil
+	}
+	return DataType{}, fmt.Errorf("%w: %q", ErrInvalidDataType, s)
+}

--- a/go/graphar/types/datatype_test.go
+++ b/go/graphar/types/datatype_test.go
@@ -1,0 +1,272 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDataTypeStringPrimitives(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		dt   DataType
+		want string
+		id   TypeID
+	}{
+		{Bool(), "bool", BoolType},
+		{Int32(), "int32", Int32Type},
+		{Int64(), "int64", Int64Type},
+		{Float(), "float", FloatType},
+		{Double(), "double", DoubleType},
+		{String(), "string", StringType},
+		{Date(), "date", DateType},
+		{Timestamp(), "timestamp", TimestampType},
+	}
+	for _, c := range cases {
+		if got := c.dt.String(); got != c.want {
+			t.Errorf("String() = %q, want %q", got, c.want)
+		}
+		if c.dt.ID() != c.id {
+			t.Errorf("ID() = %d, want %d (for %s)", c.dt.ID(), c.id, c.want)
+		}
+		if _, ok := c.dt.ValueType(); ok {
+			t.Errorf("ValueType ok=true for primitive %s", c.want)
+		}
+		if c.dt.UserDefinedName() != "" {
+			t.Errorf("UserDefinedName non-empty for primitive %s", c.want)
+		}
+	}
+}
+
+func TestDataTypeListNested(t *testing.T) {
+	t.Parallel()
+	li := List(Int32())
+	if got := li.String(); got != "list<int32>" {
+		t.Fatalf("String() = %q, want list<int32>", got)
+	}
+	child, ok := li.ValueType()
+	if !ok || !child.Equal(Int32()) {
+		t.Fatalf("ValueType() = %v ok=%v, want int32", child, ok)
+	}
+
+	nested := List(List(String()))
+	if got := nested.String(); got != "list<list<string>>" {
+		t.Fatalf("nested = %q", got)
+	}
+	if !nested.Equal(List(List(String()))) {
+		t.Fatalf("nested not equal to itself")
+	}
+}
+
+func TestDataTypeListNilChild(t *testing.T) {
+	t.Parallel()
+	// A list constructed in-package without going through List() (valid=true
+	// but child==nil) - defensive String form still degrades gracefully.
+	d := DataType{id: ListType, valid: true}
+	if got := d.String(); got != "list<unknown>" {
+		t.Errorf("nil-child list String() = %q", got)
+	}
+	if _, ok := d.ValueType(); ok {
+		t.Errorf("ValueType on nil-child list returned ok=true")
+	}
+}
+
+func TestDataTypeUnknownID(t *testing.T) {
+	t.Parallel()
+	// A constructed-but-out-of-range ID (e.g. forward-compat decoding) must
+	// not crash; it stringifies to "unknown".
+	d := DataType{id: TypeID(0xff), valid: true}
+	if got := d.String(); got != "unknown" {
+		t.Errorf("unknown ID String() = %q", got)
+	}
+}
+
+func TestDataTypeZero(t *testing.T) {
+	t.Parallel()
+	// The zero value is the "unset" sentinel: IsZero is true and String
+	// returns "unset", which is not parseable by ParseDataType so an
+	// accidentally-emitted zero value fails downstream.
+	var d DataType
+	if !d.IsZero() {
+		t.Error("zero DataType IsZero should be true")
+	}
+	if got := d.String(); got != "unset" {
+		t.Errorf("zero DataType String() = %q, want unset", got)
+	}
+	if _, err := ParseDataType(d.String()); err == nil {
+		t.Error("ParseDataType(\"unset\") should return error")
+	}
+	// Any constructed DataType - including Bool() which shares the BoolType
+	// underlying id - is not equal to the zero value.
+	if d.Equal(Bool()) {
+		t.Error("zero DataType should not equal Bool()")
+	}
+	if Bool().IsZero() {
+		t.Error("Bool() must not report IsZero")
+	}
+}
+
+func TestDataTypeUserDefined(t *testing.T) {
+	t.Parallel()
+	d := UserDefined("geometry")
+	if d.String() != "geometry" {
+		t.Errorf("UserDefined String = %q", d.String())
+	}
+	if d.UserDefinedName() != "geometry" {
+		t.Errorf("UserDefinedName = %q", d.UserDefinedName())
+	}
+	if d.ID() != UserDefinedType {
+		t.Errorf("ID = %d, want UserDefinedType", d.ID())
+	}
+	// Equality across user-defined depends on the name.
+	if !d.Equal(UserDefined("geometry")) {
+		t.Errorf("Equal failed for same user-defined name")
+	}
+	if d.Equal(UserDefined("polygon")) {
+		t.Errorf("Equal succeeded for different user-defined names")
+	}
+}
+
+func TestDataTypeValidate(t *testing.T) {
+	t.Parallel()
+	valid := []DataType{
+		Bool(), Int32(), Int64(), Float(), Double(), String(), Date(), Timestamp(),
+		List(Int32()), List(Int64()), List(Float()), List(Double()), List(String()),
+		UserDefined("geometry"),
+	}
+	for _, d := range valid {
+		if err := d.Validate(); err != nil {
+			t.Errorf("Validate(%s) = %v, want nil", d, err)
+		}
+	}
+
+	invalid := []struct {
+		name string
+		dt   DataType
+	}{
+		{"unset", DataType{}},
+		{"list of bool", List(Bool())},
+		{"list of date", List(Date())},
+		{"list of timestamp", List(Timestamp())},
+		{"nested list", List(List(Int32()))},
+		{"list of unset", List(DataType{})},
+		{"empty user-defined", UserDefined("")},
+		{"user-defined collides with builtin", UserDefined("string")},
+		{"user-defined collides with list", UserDefined("list<int32>")},
+		{"user-defined with comma", UserDefined("my,type")},
+		{"user-defined with angle bracket", UserDefined("vec<3>")},
+		{"user-defined with surrounding space", UserDefined(" Vector ")},
+	}
+	for _, c := range invalid {
+		if err := c.dt.Validate(); !errors.Is(err, ErrInvalidDataType) {
+			t.Errorf("Validate(%s) = %v, want ErrInvalidDataType", c.name, err)
+		}
+	}
+}
+
+func TestDataTypeEqualMixedCategories(t *testing.T) {
+	t.Parallel()
+	if Int32().Equal(Int64()) {
+		t.Error("Int32 should not equal Int64")
+	}
+	if List(Int32()).Equal(List(Int64())) {
+		t.Error("list<int32> should not equal list<int64>")
+	}
+	if List(Int32()).Equal(Int32()) {
+		t.Error("list<int32> should not equal int32")
+	}
+	// One list with nil child, the other with a real child: must not be equal.
+	a := DataType{id: ListType} // nil child
+	b := List(Int32())
+	if a.Equal(b) || b.Equal(a) {
+		t.Error("nil-child list equal to populated list")
+	}
+	// Both nil children: equal.
+	c := DataType{id: ListType}
+	if !a.Equal(c) {
+		t.Error("two nil-child lists should be equal")
+	}
+}
+
+func TestParseDataTypeOK(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want DataType
+	}{
+		{"bool", Bool()},
+		{"int32", Int32()},
+		{"int64", Int64()},
+		{"float", Float()},
+		{"double", Double()},
+		{"string", String()},
+		{"date", Date()},
+		{"timestamp", Timestamp()},
+		{"list<int32>", List(Int32())},
+		{"list<int64>", List(Int64())},
+		{"list<float>", List(Float())},
+		{"list<double>", List(Double())},
+		{"list<string>", List(String())},
+		{"list<list<int32>>", List(List(Int32()))},
+		// Surrounding whitespace tolerated.
+		{"  int32  ", Int32()},
+	}
+	for _, c := range cases {
+		got, err := ParseDataType(c.in)
+		if err != nil {
+			t.Errorf("ParseDataType(%q) error: %v", c.in, err)
+			continue
+		}
+		if !got.Equal(c.want) {
+			t.Errorf("ParseDataType(%q) = %v, want %v", c.in, got, c.want)
+		}
+		// Round-trip: simple primitives + list of primitives must String-round-trip.
+		if s := got.String(); s != "list<list<int32>>" && c.in != "  int32  " {
+			// Avoid testing whitespace round-trip on padded input.
+			if _, err := ParseDataType(s); err != nil {
+				t.Errorf("round-trip ParseDataType(String()) failed for %q: %v", c.in, err)
+			}
+		}
+	}
+}
+
+func TestParseDataTypeErrors(t *testing.T) {
+	t.Parallel()
+	bad := []string{
+		"",
+		"  ",
+		"int128",
+		"List<int32>", // case-sensitive
+		"list<>",
+		"list<unknown>",
+		"list<int32",
+		"foo",
+		"list<list<>>",
+	}
+	for _, in := range bad {
+		_, err := ParseDataType(in)
+		if err == nil {
+			t.Errorf("ParseDataType(%q) succeeded, want error", in)
+			continue
+		}
+		if !errors.Is(err, ErrInvalidDataType) {
+			t.Errorf("ParseDataType(%q) error %v not wrapped by ErrInvalidDataType", in, err)
+		}
+	}
+}

--- a/go/graphar/types/doc.go
+++ b/go/graphar/types/doc.go
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package types holds the primitive value types shared across the GraphAr Go
+// SDK: DataType, FileType, AdjListType, Cardinality, and InfoVersion.
+//
+// All types in this package are value-semantic (no hidden state, safe to copy)
+// and have no external dependencies, so any other package in the SDK may
+// import them without risk of cycles.
+//
+// Parsing helpers (e.g. ParseDataType, ParseFileType) accept the on-disk
+// spellings used by the GraphAr YAML schema, so values round-trip across
+// implementations.
+package types

--- a/go/graphar/types/errors.go
+++ b/go/graphar/types/errors.go
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import "errors"
+
+// Sentinel errors returned by the parsers in this package. Wrap with %w when
+// adding context so callers can keep using errors.Is.
+var (
+	ErrInvalidDataType    = errors.New("graphar/types: invalid data type")
+	ErrInvalidFileType    = errors.New("graphar/types: invalid file type")
+	ErrInvalidAdjListType = errors.New("graphar/types: invalid adj list type")
+	ErrInvalidCardinality = errors.New("graphar/types: invalid cardinality")
+	ErrInvalidVersion     = errors.New("graphar/types: invalid info version")
+)

--- a/go/graphar/types/filetype.go
+++ b/go/graphar/types/filetype.go
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import "fmt"
+
+// FileType is the on-disk physical format of a property group or adjacency
+// list: csv / parquet / orc / json. (json parses but is rejected at validation
+// time; see FileTypeJSON.)
+type FileType uint8
+
+// FileType values. Zero value is unset; constructed values are non-zero so
+// callers can detect a forgotten assignment via IsZero().
+const (
+	// fileTypeUnset is the zero / unset sentinel. Not exported because it
+	// is never a valid on-disk format.
+	fileTypeUnset FileType = iota
+	// FileTypeCSV is the comma-separated values text format.
+	FileTypeCSV
+	// FileTypeParquet is the Apache Parquet columnar format.
+	FileTypeParquet
+	// FileTypeORC is the Apache ORC columnar format.
+	FileTypeORC
+	// FileTypeJSON is the JSON text format. Parseable for read-only fixture
+	// compatibility but rejected by PropertyGroup.Validate.
+	FileTypeJSON
+)
+
+// IsZero reports whether f is the zero (unset) FileType.
+func (f FileType) IsZero() bool { return f == fileTypeUnset }
+
+// String returns the on-disk spelling. The unset zero value stringifies to
+// "unset" (not a valid file type).
+func (f FileType) String() string {
+	switch f {
+	case fileTypeUnset:
+		return "unset"
+	case FileTypeCSV:
+		return "csv"
+	case FileTypeParquet:
+		return "parquet"
+	case FileTypeORC:
+		return "orc"
+	case FileTypeJSON:
+		return "json"
+	default:
+		return "unknown"
+	}
+}
+
+// ParseFileType parses the on-disk spelling produced by FileType.String.
+func ParseFileType(s string) (FileType, error) {
+	switch s {
+	case "csv":
+		return FileTypeCSV, nil
+	case "parquet":
+		return FileTypeParquet, nil
+	case "orc":
+		return FileTypeORC, nil
+	case "json":
+		return FileTypeJSON, nil
+	default:
+		return fileTypeUnset, fmt.Errorf("%w: %q", ErrInvalidFileType, s)
+	}
+}

--- a/go/graphar/types/filetype_test.go
+++ b/go/graphar/types/filetype_test.go
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFileTypeRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, ft := range []FileType{FileTypeCSV, FileTypeParquet, FileTypeORC, FileTypeJSON} {
+		s := ft.String()
+		got, err := ParseFileType(s)
+		if err != nil {
+			t.Errorf("ParseFileType(%q): %v", s, err)
+			continue
+		}
+		if got != ft {
+			t.Errorf("round-trip %v: got %v", ft, got)
+		}
+	}
+}
+
+func TestFileTypeIsZeroAndStringUnset(t *testing.T) {
+	t.Parallel()
+	var f FileType
+	if !f.IsZero() {
+		t.Error("zero FileType should report IsZero")
+	}
+	if got := f.String(); got != "unset" {
+		t.Errorf("zero FileType String() = %q, want unset", got)
+	}
+	if _, err := ParseFileType("unset"); err == nil {
+		t.Error("ParseFileType(\"unset\") should be rejected")
+	}
+	if FileTypeCSV.IsZero() {
+		t.Error("FileTypeCSV must not report IsZero")
+	}
+}
+
+func TestFileTypeStringUnknown(t *testing.T) {
+	t.Parallel()
+	if (FileType(0xff)).String() != "unknown" {
+		t.Errorf("unknown FileType should stringify to %q", "unknown")
+	}
+}
+
+func TestParseFileTypeErrors(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"", "CSV", "tsv", "parquette"} {
+		_, err := ParseFileType(in)
+		if err == nil {
+			t.Errorf("ParseFileType(%q) succeeded, want error", in)
+			continue
+		}
+		if !errors.Is(err, ErrInvalidFileType) {
+			t.Errorf("ParseFileType(%q) error %v not wrapped by ErrInvalidFileType", in, err)
+		}
+	}
+}

--- a/go/graphar/types/version.go
+++ b/go/graphar/types/version.go
@@ -1,0 +1,173 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// DefaultVersion is the version assumed for Info objects that do not specify
+// one explicitly. It is the on-disk default for the GraphAr format.
+const DefaultVersion = 1
+
+// versionPrefix is the on-disk marker every version string starts with. Shared
+// by String (write) and ParseInfoVersion (read) so the two never drift.
+const versionPrefix = "gar/v"
+
+// InfoVersion is the on-disk schema version of an Info document.
+//
+// The string form is "gar/vN" (e.g. "gar/v1"). An optional user-defined type
+// list may follow in parentheses: "gar/v1 (foo,bar)". UserDefinedTypes are
+// recorded in declaration order and duplicates are kept; surrounding
+// whitespace on each entry is trimmed on parse (so "gar/v1 (a, b)" round-trips
+// as "gar/v1 (a,b)").
+type InfoVersion struct {
+	Version          int
+	UserDefinedTypes []string
+}
+
+// NewInfoVersion returns an InfoVersion with the given version and user-defined
+// type names (copied defensively). A non-positive version is clamped to
+// DefaultVersion; use TryNewInfoVersion to get an error instead.
+func NewInfoVersion(version int, userDefinedTypes ...string) InfoVersion {
+	if version <= 0 {
+		version = DefaultVersion
+	}
+	if len(userDefinedTypes) == 0 {
+		return InfoVersion{Version: version}
+	}
+	return InfoVersion{Version: version, UserDefinedTypes: slices.Clone(userDefinedTypes)}
+}
+
+// TryNewInfoVersion is like NewInfoVersion but returns an error wrapping
+// ErrInvalidVersion for non-positive versions instead of clamping.
+func TryNewInfoVersion(version int, userDefinedTypes ...string) (InfoVersion, error) {
+	if version <= 0 {
+		return InfoVersion{}, fmt.Errorf("%w: version must be positive, got %d", ErrInvalidVersion, version)
+	}
+	return NewInfoVersion(version, userDefinedTypes...), nil
+}
+
+// String returns the on-disk spelling.
+func (v InfoVersion) String() string {
+	if len(v.UserDefinedTypes) == 0 {
+		return fmt.Sprintf("%s%d", versionPrefix, v.Version)
+	}
+	return fmt.Sprintf("%s%d (%s)", versionPrefix, v.Version, strings.Join(v.UserDefinedTypes, ","))
+}
+
+// Clone returns a deep copy of v, independent of the source's UserDefinedTypes
+// slice; getters that hand out a stored InfoVersion should return v.Clone().
+func (v InfoVersion) Clone() InfoVersion {
+	if len(v.UserDefinedTypes) == 0 {
+		return InfoVersion{Version: v.Version}
+	}
+	return InfoVersion{Version: v.Version, UserDefinedTypes: slices.Clone(v.UserDefinedTypes)}
+}
+
+// Validate reports whether v is well-formed: a positive version number and
+// user-defined type names that round-trip through String / ParseInfoVersion.
+func (v InfoVersion) Validate() error {
+	if v.Version <= 0 {
+		return fmt.Errorf("%w: version must be positive, got %d", ErrInvalidVersion, v.Version)
+	}
+	for _, name := range v.UserDefinedTypes {
+		if err := validateTypeName(name); err != nil {
+			return fmt.Errorf("%w: %s", ErrInvalidVersion, err)
+		}
+	}
+	return nil
+}
+
+// validateTypeName reports why name cannot survive a String / ParseInfoVersion
+// round trip: it must be non-empty, carry no surrounding whitespace and avoid
+// the delimiters the version string and list syntax rely on (, ( ) < >).
+func validateTypeName(name string) error {
+	switch {
+	case name == "":
+		return errors.New("user-defined type name must not be empty")
+	case strings.TrimSpace(name) != name:
+		return fmt.Errorf("user-defined type name %q has leading or trailing whitespace", name)
+	case strings.ContainsAny(name, ",()<>"):
+		return fmt.Errorf("user-defined type name %q must not contain any of , ( ) < >", name)
+	}
+	return nil
+}
+
+// IsZero reports whether v is the zero InfoVersion.
+func (v InfoVersion) IsZero() bool {
+	return v.Version == 0 && len(v.UserDefinedTypes) == 0
+}
+
+// Equal reports whether two InfoVersions are equivalent.
+func (v InfoVersion) Equal(other InfoVersion) bool {
+	return v.Version == other.Version &&
+		slices.Equal(v.UserDefinedTypes, other.UserDefinedTypes)
+}
+
+// ParseInfoVersion parses a version string in either the bare form "gar/vN" or
+// the user-defined-types form "gar/vN (t1,t2,...)". An empty input is rejected.
+func ParseInfoVersion(s string) (InfoVersion, error) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return InfoVersion{}, fmt.Errorf("%w: empty version string", ErrInvalidVersion)
+	}
+	if !strings.HasPrefix(trimmed, versionPrefix) {
+		return InfoVersion{}, fmt.Errorf("%w: must start with %q, got %q", ErrInvalidVersion, versionPrefix, s)
+	}
+	rest := trimmed[len(versionPrefix):]
+
+	// Split numeric prefix from optional "(types)" suffix.
+	var (
+		numStr   string
+		typesStr string
+	)
+	if i := strings.IndexByte(rest, '('); i >= 0 {
+		numStr = strings.TrimSpace(rest[:i])
+		// Must end with ')'.
+		if !strings.HasSuffix(rest, ")") {
+			return InfoVersion{}, fmt.Errorf("%w: unterminated %q in %q", ErrInvalidVersion, "(", s)
+		}
+		typesStr = rest[i+1 : len(rest)-1]
+	} else {
+		numStr = rest
+	}
+
+	n, err := strconv.Atoi(numStr)
+	if err != nil || n <= 0 {
+		return InfoVersion{}, fmt.Errorf("%w: bad version number in %q", ErrInvalidVersion, s)
+	}
+
+	out := InfoVersion{Version: n}
+	if typesStr != "" {
+		parts := strings.Split(typesStr, ",")
+		out.UserDefinedTypes = make([]string, 0, len(parts))
+		for _, p := range parts {
+			t := strings.TrimSpace(p)
+			if t == "" {
+				return InfoVersion{}, fmt.Errorf("%w: empty user-defined type entry in %q", ErrInvalidVersion, s)
+			}
+			out.UserDefinedTypes = append(out.UserDefinedTypes, t)
+		}
+	}
+	return out, nil
+}

--- a/go/graphar/types/version_test.go
+++ b/go/graphar/types/version_test.go
@@ -1,0 +1,261 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewInfoVersion(t *testing.T) {
+	t.Parallel()
+	v := NewInfoVersion(1)
+	if v.Version != 1 || len(v.UserDefinedTypes) != 0 {
+		t.Errorf("NewInfoVersion(1) = %+v", v)
+	}
+	v2 := NewInfoVersion(2, "geometry", "point")
+	if v2.Version != 2 || len(v2.UserDefinedTypes) != 2 ||
+		v2.UserDefinedTypes[0] != "geometry" || v2.UserDefinedTypes[1] != "point" {
+		t.Errorf("NewInfoVersion(2, ...) = %+v", v2)
+	}
+	// Mutating the input slice must not affect the stored value.
+	orig := []string{"geometry"}
+	v3 := NewInfoVersion(3, orig...)
+	orig[0] = "mutated"
+	if v3.UserDefinedTypes[0] != "geometry" {
+		t.Errorf("UserDefinedTypes was not defensively copied")
+	}
+}
+
+func TestInfoVersionString(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		v    InfoVersion
+		want string
+	}{
+		{NewInfoVersion(1), "gar/v1"},
+		{NewInfoVersion(2, "geometry"), "gar/v2 (geometry)"},
+		{NewInfoVersion(3, "geometry", "point"), "gar/v3 (geometry,point)"},
+	}
+	for _, c := range cases {
+		if got := c.v.String(); got != c.want {
+			t.Errorf("String() = %q, want %q", got, c.want)
+		}
+	}
+}
+
+func TestInfoVersionEqualAndZero(t *testing.T) {
+	t.Parallel()
+	if !(InfoVersion{}).IsZero() {
+		t.Error("zero InfoVersion should report IsZero")
+	}
+	if NewInfoVersion(1).IsZero() {
+		t.Error("v1 should not report IsZero")
+	}
+	a := NewInfoVersion(1, "g")
+	b := NewInfoVersion(1, "g")
+	if !a.Equal(b) {
+		t.Error("identical InfoVersions not equal")
+	}
+	if a.Equal(NewInfoVersion(2, "g")) {
+		t.Error("different version reported equal")
+	}
+	if a.Equal(NewInfoVersion(1)) {
+		t.Error("different type lists reported equal")
+	}
+	if a.Equal(NewInfoVersion(1, "h")) {
+		t.Error("different type names reported equal")
+	}
+}
+
+func TestParseInfoVersionOK(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want InfoVersion
+	}{
+		{"gar/v1", NewInfoVersion(1)},
+		{"  gar/v2  ", NewInfoVersion(2)},
+		{"gar/v3 (geometry)", NewInfoVersion(3, "geometry")},
+		{"gar/v4 (geometry, point)", NewInfoVersion(4, "geometry", "point")},
+		{"gar/v5(a,b,c)", NewInfoVersion(5, "a", "b", "c")},
+	}
+	for _, c := range cases {
+		got, err := ParseInfoVersion(c.in)
+		if err != nil {
+			t.Errorf("ParseInfoVersion(%q): %v", c.in, err)
+			continue
+		}
+		if !got.Equal(c.want) {
+			t.Errorf("ParseInfoVersion(%q) = %+v, want %+v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseInfoVersionErrors(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"",
+		"   ",
+		"gar/v",
+		"gar/v0",        // version must be > 0
+		"gar/v-1",       // negative
+		"gar/vabc",      // not numeric
+		"gar/v1 (",      // unterminated
+		"gar/v1 (a,,b)", // empty element
+		"foo/v1",        // wrong prefix
+		"v1",
+	}
+	for _, in := range cases {
+		_, err := ParseInfoVersion(in)
+		if err == nil {
+			t.Errorf("ParseInfoVersion(%q) succeeded, want error", in)
+			continue
+		}
+		if !errors.Is(err, ErrInvalidVersion) {
+			t.Errorf("ParseInfoVersion(%q) error %v not wrapped", in, err)
+		}
+	}
+}
+
+func TestParseInfoVersionRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"gar/v1", "gar/v2 (geometry,point)"} {
+		v, err := ParseInfoVersion(in)
+		if err != nil {
+			t.Fatalf("ParseInfoVersion(%q): %v", in, err)
+		}
+		if v.String() != in {
+			t.Errorf("round-trip failed: ParseInfoVersion(%q).String() = %q", in, v.String())
+		}
+	}
+}
+
+func TestDefaultVersionConstant(t *testing.T) {
+	t.Parallel()
+	if DefaultVersion != 1 {
+		t.Errorf("DefaultVersion changed to %d; cross-language fixtures still ship gar/v1", DefaultVersion)
+	}
+}
+
+func TestNewInfoVersionNonPositiveClamps(t *testing.T) {
+	t.Parallel()
+	// NewInfoVersion must keep the result round-trippable: a 0 or negative
+	// argument is clamped to DefaultVersion so MarshalInfoVersion/ParseInfoVersion
+	// are inverses on every produced value.
+	for _, v := range []int{0, -1, -1000} {
+		got := NewInfoVersion(v)
+		if got.Version != DefaultVersion {
+			t.Errorf("NewInfoVersion(%d) = %d, want clamped to %d", v, got.Version, DefaultVersion)
+		}
+		// Verify round-trip.
+		parsed, err := ParseInfoVersion(got.String())
+		if err != nil {
+			t.Errorf("clamped NewInfoVersion(%d) fails round-trip: %v", v, err)
+		}
+		if !parsed.Equal(got) {
+			t.Errorf("round-trip mismatch for NewInfoVersion(%d): %v vs %v", v, parsed, got)
+		}
+	}
+}
+
+func TestTryNewInfoVersion(t *testing.T) {
+	t.Parallel()
+	v, err := TryNewInfoVersion(2, "geometry")
+	if err != nil {
+		t.Fatalf("TryNewInfoVersion(2,...): %v", err)
+	}
+	if v.Version != 2 || len(v.UserDefinedTypes) != 1 {
+		t.Errorf("got %+v", v)
+	}
+	for _, bad := range []int{0, -1} {
+		if _, err := TryNewInfoVersion(bad); !errors.Is(err, ErrInvalidVersion) {
+			t.Errorf("TryNewInfoVersion(%d): expected ErrInvalidVersion, got %v", bad, err)
+		}
+	}
+}
+
+// TestInfoVersionCloneIndependent guards the immutability contract: Clone must
+// return a version whose UserDefinedTypes slice is independent of the source,
+// so a value handed out by an Info's Version() getter cannot mutate stored
+// state.
+func TestInfoVersionCloneIndependent(t *testing.T) {
+	t.Parallel()
+	orig := NewInfoVersion(1, "geometry", "point")
+	clone := orig.Clone()
+	if !clone.Equal(orig) {
+		t.Fatalf("Clone not equal to source: %+v vs %+v", clone, orig)
+	}
+	clone.UserDefinedTypes[0] = "hacked"
+	if orig.UserDefinedTypes[0] != "geometry" {
+		t.Errorf("mutating clone leaked into source: %v", orig.UserDefinedTypes)
+	}
+	// Empty case must not panic and stays independent.
+	if got := NewInfoVersion(2).Clone(); len(got.UserDefinedTypes) != 0 || got.Version != 2 {
+		t.Errorf("empty clone wrong: %+v", got)
+	}
+}
+
+func TestInfoVersionValidate(t *testing.T) {
+	t.Parallel()
+	valid := []InfoVersion{
+		NewInfoVersion(1),
+		NewInfoVersion(2, "geometry", "point"),
+	}
+	for _, v := range valid {
+		if err := v.Validate(); err != nil {
+			t.Errorf("Validate(%q) = %v, want nil", v, err)
+		}
+	}
+
+	invalid := []struct {
+		name string
+		v    InfoVersion
+	}{
+		{"zero version", InfoVersion{Version: 0}},
+		{"negative version", InfoVersion{Version: -1}},
+		{"name with comma", InfoVersion{Version: 1, UserDefinedTypes: []string{"my,type"}}},
+		{"name with surrounding space", InfoVersion{Version: 1, UserDefinedTypes: []string{" geometry "}}},
+		{"empty name", InfoVersion{Version: 1, UserDefinedTypes: []string{""}}},
+	}
+	for _, c := range invalid {
+		if err := c.v.Validate(); !errors.Is(err, ErrInvalidVersion) {
+			t.Errorf("Validate(%s) = %v, want ErrInvalidVersion", c.name, err)
+		}
+	}
+}
+
+// TestInfoVersionCommaNameRejected pins the round-trip hazard: a name with a
+// comma would split into two on ParseInfoVersion, so Validate must reject it
+// before it reaches String.
+func TestInfoVersionCommaNameRejected(t *testing.T) {
+	t.Parallel()
+	v := InfoVersion{Version: 1, UserDefinedTypes: []string{"a,b"}}
+	if err := v.Validate(); !errors.Is(err, ErrInvalidVersion) {
+		t.Fatalf("Validate = %v, want ErrInvalidVersion", err)
+	}
+	// A validated (single, clean) name must survive String -> ParseInfoVersion.
+	ok := NewInfoVersion(1, "geometry")
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("Validate = %v, want nil", err)
+	}
+	back, err := ParseInfoVersion(ok.String())
+	if err != nil || !back.Equal(ok) {
+		t.Errorf("round-trip %q -> %+v (err %v)", ok.String(), back, err)
+	}
+}

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -62,6 +62,14 @@ excludes = [
   "**/*.json",
   "**/*.lock",
   "**/*.svg",
+  "**/go.sum",
   "cli/*.yml",
   "cli/*.toml",
 ]
+
+# Go uses // line comments for license headers by convention (matching
+# Apache Arrow Go, Apache Beam Go SDK, Kubernetes etc.). Without this
+# override hawkeye defaults *.go to JAVADOC_STYLE (/* ... */) and would
+# reject the canonical Go header form.
+[mapping.DOUBLESLASH_STYLE]
+extensions = ["go"]


### PR DESCRIPTION
### Reason for this PR

This draft PR shows the complete Go SDK metadata implementation direction for
#828.

The Go SDK should be able to represent GraphAr info metadata in Go, load and
save the same YAML schema used by the existing implementations, and validate
that the metadata layer interoperates with the repository fixtures.

This PR is stacked on top of the Go SDK bootstrap PR so reviewers can first
review the small module/CI foundation and then inspect the metadata API design
separately.

Refs #828.

### What changes are included in this PR?

This PR adds the Go SDK metadata layer:

- add primitive metadata types, including `FileType`, `Cardinality`,
  `AdjListType`, `InfoVersion`, and `DataType`
- add GraphAr info model types, including `Property`, `PropertyGroup`,
  `AdjacentList`, `VertexInfo`, `EdgeInfo`, and `GraphInfo`
- add YAML load/save support for GraphAr info files
- add validation paths aligned with the existing GraphAr metadata rules
- add cross-language interoperability and end-to-end tests over GraphAr
  fixtures

Stacking setup:

- base branch: `828-go-sdk-module-bootstrap`
- head branch: `828-go-sdk-info`

After the bootstrap PR is merged, this branch should be rebased onto the updated
`main` branch. Because GraphAr squash-merges PRs, the duplicate bootstrap commit
should be removed during that rebase.

### Are these changes tested?

The intended local and CI checks are:

- `cd go/graphar && go mod tidy`
- `cd go/graphar && go test ./...`
- `cd go/graphar && go test -race ./...`
- `cd go/graphar && make ci`
- `pre-commit run --files <changed files>`

The interop test is expected to use the repository `testing/` fixtures when the
submodule is available.

### Are there any user-facing changes?

Yes. This adds new Go SDK metadata APIs for GraphAr info files. It does not
change the existing C++, Java, Rust, Spark, or PySpark APIs.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my own code using `make cpplint` before submitting when changed files are in the `cpp` directory. (Not applicable: this PR does not change files in the `cpp` directory.)
- [x] I have performed `pre-commit run` before commit the changed files.
- [x] I have added tests to prove my changes are effective.