### PR TITLE
feat(go,types): add FileType, Cardinality, AdjListType

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -118,7 +118,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          # golangci-lint v1.64.8 cannot decode export data from newer Go
+          # stable releases; keep the lint job on the go.mod floor.
+          go-version: "1.23"
           cache-dependency-path: go/graphar/go.sum
 
       - name: golangci-lint

--- a/go/graphar/types/adjlist.go
+++ b/go/graphar/types/adjlist.go
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import "fmt"
+
+// AdjListType is the layout of an edge type's adjacency list, combining
+// alignment side (source or destination vertex) with ordering (ordered or not).
+// Compare with ==; the numeric values carry no meaning.
+type AdjListType uint8
+
+// AdjListType values. The zero value is not a valid layout.
+const (
+	_ AdjListType = iota
+	// UnorderedBySource groups edges by source vertex, source side unordered
+	// (COO layout).
+	UnorderedBySource
+	// UnorderedByDest groups edges by destination vertex, dest side unordered.
+	UnorderedByDest
+	// OrderedBySource groups edges by source vertex, sorted by source (CSR).
+	OrderedBySource
+	// OrderedByDest groups edges by destination vertex, sorted by dest (CSC).
+	OrderedByDest
+)
+
+// alignedBySrc / alignedByDst are the on-disk aligned_by values, shared by
+// AlignedBy (write) and AdjListTypeFromOrderedAligned (read).
+const (
+	alignedBySrc = "src"
+	alignedByDst = "dst"
+)
+
+// On-disk spellings, shared by String (write) and ParseAdjListType (read) so the
+// two cannot drift.
+const (
+	adjListUnorderedBySourceName = "unordered_by_source"
+	adjListUnorderedByDestName   = "unordered_by_dest"
+	adjListOrderedBySourceName   = "ordered_by_source"
+	adjListOrderedByDestName     = "ordered_by_dest"
+)
+
+// String returns the on-disk spelling.
+func (a AdjListType) String() string {
+	switch a {
+	case UnorderedBySource:
+		return adjListUnorderedBySourceName
+	case UnorderedByDest:
+		return adjListUnorderedByDestName
+	case OrderedBySource:
+		return adjListOrderedBySourceName
+	case OrderedByDest:
+		return adjListOrderedByDestName
+	default:
+		return "unknown"
+	}
+}
+
+// IsOrdered reports whether the layout is ordered.
+func (a AdjListType) IsOrdered() bool {
+	return a == OrderedBySource || a == OrderedByDest
+}
+
+// AlignedBy reports the vertex side ("src" or "dst") the layout is aligned by.
+// For unknown values, it returns the empty string and false.
+func (a AdjListType) AlignedBy() (side string, ok bool) {
+	switch a {
+	case UnorderedBySource, OrderedBySource:
+		return alignedBySrc, true
+	case UnorderedByDest, OrderedByDest:
+		return alignedByDst, true
+	default:
+		return "", false
+	}
+}
+
+// ParseAdjListType parses the on-disk spelling produced by AdjListType.String.
+func ParseAdjListType(s string) (AdjListType, error) {
+	switch s {
+	case adjListUnorderedBySourceName:
+		return UnorderedBySource, nil
+	case adjListUnorderedByDestName:
+		return UnorderedByDest, nil
+	case adjListOrderedBySourceName:
+		return OrderedBySource, nil
+	case adjListOrderedByDestName:
+		return OrderedByDest, nil
+	default:
+		return 0, fmt.Errorf("%w: %q", ErrInvalidAdjListType, s)
+	}
+}
+
+// AdjListTypeFromOrderedAligned derives an AdjListType from the legacy
+// (ordered, aligned_by) pair used by older yaml fixtures. The aligned argument
+// must be "src" or "dst"; any other value returns an error wrapping
+// ErrInvalidAdjListType. This is the inverse of (IsOrdered, AlignedBy).
+func AdjListTypeFromOrderedAligned(ordered bool, aligned string) (AdjListType, error) {
+	switch aligned {
+	case alignedBySrc:
+		if ordered {
+			return OrderedBySource, nil
+		}
+		return UnorderedBySource, nil
+	case alignedByDst:
+		if ordered {
+			return OrderedByDest, nil
+		}
+		return UnorderedByDest, nil
+	default:
+		return 0, fmt.Errorf("%w: aligned_by must be %q or %q, got %q",
+			ErrInvalidAdjListType, alignedBySrc, alignedByDst, aligned)
+	}
+}

--- a/go/graphar/types/adjlist_test.go
+++ b/go/graphar/types/adjlist_test.go
@@ -1,0 +1,123 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAdjListTypeRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		v       AdjListType
+		s       string
+		ordered bool
+		side    string
+	}{
+		{UnorderedBySource, "unordered_by_source", false, "src"},
+		{UnorderedByDest, "unordered_by_dest", false, "dst"},
+		{OrderedBySource, "ordered_by_source", true, "src"},
+		{OrderedByDest, "ordered_by_dest", true, "dst"},
+	}
+	for _, c := range cases {
+		if c.v.String() != c.s {
+			t.Errorf("String() = %q, want %q", c.v.String(), c.s)
+		}
+		got, err := ParseAdjListType(c.s)
+		if err != nil {
+			t.Errorf("ParseAdjListType(%q): %v", c.s, err)
+			continue
+		}
+		if got != c.v {
+			t.Errorf("ParseAdjListType(%q) = %v, want %v", c.s, got, c.v)
+		}
+		if c.v.IsOrdered() != c.ordered {
+			t.Errorf("%v IsOrdered() = %v, want %v", c.v, c.v.IsOrdered(), c.ordered)
+		}
+		side, ok := c.v.AlignedBy()
+		if !ok || side != c.side {
+			t.Errorf("%v AlignedBy() = (%q,%v), want (%q,true)", c.v, side, ok, c.side)
+		}
+	}
+}
+
+func TestAdjListTypeUnknown(t *testing.T) {
+	t.Parallel()
+	bad := AdjListType(0xff)
+	if bad.String() != "unknown" {
+		t.Errorf("unknown String = %q", bad.String())
+	}
+	if bad.IsOrdered() {
+		t.Errorf("unknown should not report IsOrdered")
+	}
+	if side, ok := bad.AlignedBy(); ok || side != "" {
+		t.Errorf("unknown AlignedBy = (%q,%v)", side, ok)
+	}
+}
+
+func TestParseAdjListTypeErrors(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"", "ordered_by_src", "csr", "ordered"} {
+		_, err := ParseAdjListType(in)
+		if err == nil {
+			t.Errorf("ParseAdjListType(%q) succeeded, want error", in)
+			continue
+		}
+		if !errors.Is(err, ErrInvalidAdjListType) {
+			t.Errorf("ParseAdjListType(%q) error %v not wrapped", in, err)
+		}
+	}
+}
+
+func TestAdjListTypeFromOrderedAligned(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		ordered bool
+		aligned string
+		want    AdjListType
+	}{
+		{true, "src", OrderedBySource},
+		{true, "dst", OrderedByDest},
+		{false, "src", UnorderedBySource},
+		{false, "dst", UnorderedByDest},
+	}
+	for _, c := range cases {
+		got, err := AdjListTypeFromOrderedAligned(c.ordered, c.aligned)
+		if err != nil {
+			t.Errorf("AdjListTypeFromOrderedAligned(%v,%q): %v", c.ordered, c.aligned, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("AdjListTypeFromOrderedAligned(%v,%q) = %v, want %v", c.ordered, c.aligned, got, c.want)
+		}
+		// Round-tripping back through (IsOrdered, AlignedBy) must return the same value.
+		side, ok := got.AlignedBy()
+		if !ok {
+			t.Errorf("AlignedBy returned ok=false for %v", got)
+			continue
+		}
+		round, err := AdjListTypeFromOrderedAligned(got.IsOrdered(), side)
+		if err != nil || round != got {
+			t.Errorf("round-trip failed: round=%v err=%v", round, err)
+		}
+	}
+	if _, err := AdjListTypeFromOrderedAligned(true, "other"); !errors.Is(err, ErrInvalidAdjListType) {
+		t.Errorf("expected ErrInvalidAdjListType for bogus aligned, got %v", err)
+	}
+}

--- a/go/graphar/types/cardinality.go
+++ b/go/graphar/types/cardinality.go
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import "fmt"
+
+// Cardinality is the multiplicity of a property's value. SINGLE is the default
+// for newly constructed properties; LIST and SET are only legal on vertex
+// properties (edge properties must be single-valued).
+type Cardinality uint8
+
+// Cardinality values.
+const (
+	// CardinalitySingle is one value per record.
+	CardinalitySingle Cardinality = iota
+	// CardinalityList is an ordered, possibly repeating list of values per record.
+	CardinalityList
+	// CardinalitySet is an unordered set of distinct values per record.
+	CardinalitySet
+)
+
+// On-disk spellings, shared by String (write) and ParseCardinality (read) so
+// the two cannot drift.
+const (
+	cardinalitySingleName = "single"
+	cardinalityListName   = "list"
+	cardinalitySetName    = "set"
+)
+
+// String returns the on-disk spelling.
+func (c Cardinality) String() string {
+	switch c {
+	case CardinalitySingle:
+		return cardinalitySingleName
+	case CardinalityList:
+		return cardinalityListName
+	case CardinalitySet:
+		return cardinalitySetName
+	default:
+		return "unknown"
+	}
+}
+
+// ParseCardinality parses the on-disk spelling produced by Cardinality.String.
+func ParseCardinality(s string) (Cardinality, error) {
+	switch s {
+	case cardinalitySingleName:
+		return CardinalitySingle, nil
+	case cardinalityListName:
+		return CardinalityList, nil
+	case cardinalitySetName:
+		return CardinalitySet, nil
+	default:
+		return 0, fmt.Errorf("%w: %q", ErrInvalidCardinality, s)
+	}
+}

--- a/go/graphar/types/cardinality_test.go
+++ b/go/graphar/types/cardinality_test.go
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCardinalityRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, c := range []Cardinality{CardinalitySingle, CardinalityList, CardinalitySet} {
+		s := c.String()
+		got, err := ParseCardinality(s)
+		if err != nil {
+			t.Errorf("ParseCardinality(%q): %v", s, err)
+			continue
+		}
+		if got != c {
+			t.Errorf("round-trip %v: got %v", c, got)
+		}
+	}
+}
+
+func TestCardinalityStringUnknown(t *testing.T) {
+	t.Parallel()
+	if (Cardinality(0xff)).String() != "unknown" {
+		t.Errorf("unknown Cardinality string mismatch")
+	}
+}
+
+func TestParseCardinalityErrors(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"", "Single", "many", "list "} {
+		_, err := ParseCardinality(in)
+		if err == nil {
+			t.Errorf("ParseCardinality(%q) succeeded, want error", in)
+			continue
+		}
+		if !errors.Is(err, ErrInvalidCardinality) {
+			t.Errorf("ParseCardinality(%q) not wrapped: %v", in, err)
+		}
+	}
+}

--- a/go/graphar/types/doc.go
+++ b/go/graphar/types/doc.go
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package types holds the primitive value types shared across the GraphAr Go
+// SDK: FileType, AdjListType, Cardinality, and InfoVersion.
+//
+// All types in this package are value-semantic (no hidden state, safe to copy)
+// and have no external dependencies, so any other package in the SDK may
+// import them without risk of cycles.
+//
+// Parsing helpers (e.g. ParseFileType) accept the on-disk spellings used by the
+// GraphAr YAML schema, so values round-trip across implementations.
+package types

--- a/go/graphar/types/errors.go
+++ b/go/graphar/types/errors.go
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import "errors"
+
+// Sentinel errors returned by the parsers in this package. Wrap with %w when
+// adding context so callers can keep using errors.Is.
+var (
+	ErrInvalidFileType    = errors.New("graphar/types: invalid file type")
+	ErrInvalidAdjListType = errors.New("graphar/types: invalid adj list type")
+	ErrInvalidCardinality = errors.New("graphar/types: invalid cardinality")
+	ErrInvalidVersion     = errors.New("graphar/types: invalid info version")
+)

--- a/go/graphar/types/filetype.go
+++ b/go/graphar/types/filetype.go
@@ -36,8 +36,8 @@ const (
 	FileTypeParquet
 	// FileTypeORC is the Apache ORC columnar format.
 	FileTypeORC
-	// FileTypeJSON is the JSON text format. Parseable for read-only fixture
-	// compatibility but rejected by PropertyGroup.Validate.
+	// FileTypeJSON is the JSON text format. Parsing accepts it only for
+	// read-only fixture compatibility; it is not a supported output format.
 	FileTypeJSON
 )
 

--- a/go/graphar/types/filetype.go
+++ b/go/graphar/types/filetype.go
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import "fmt"
+
+// FileType is the on-disk physical format of a property group or adjacency
+// list: csv / parquet / orc / json. (json parses but is rejected at validation
+// time; see FileTypeJSON.)
+type FileType uint8
+
+// FileType values. Zero value is unset; constructed values are non-zero so
+// callers can detect a forgotten assignment via IsZero().
+const (
+	// fileTypeUnset is the zero / unset sentinel. Not exported because it
+	// is never a valid on-disk format.
+	fileTypeUnset FileType = iota
+	// FileTypeCSV is the comma-separated values text format.
+	FileTypeCSV
+	// FileTypeParquet is the Apache Parquet columnar format.
+	FileTypeParquet
+	// FileTypeORC is the Apache ORC columnar format.
+	FileTypeORC
+	// FileTypeJSON is the JSON text format. Parseable for read-only fixture
+	// compatibility but rejected by PropertyGroup.Validate.
+	FileTypeJSON
+)
+
+// On-disk spellings, shared by String (write) and ParseFileType (read) so the
+// two cannot drift.
+const (
+	fileTypeCSVName     = "csv"
+	fileTypeParquetName = "parquet"
+	fileTypeORCName     = "orc"
+	fileTypeJSONName    = "json"
+)
+
+// IsZero reports whether f is the zero (unset) FileType.
+func (f FileType) IsZero() bool { return f == fileTypeUnset }
+
+// String returns the on-disk spelling. The unset zero value stringifies to
+// "unset" (not a valid file type).
+func (f FileType) String() string {
+	switch f {
+	case fileTypeUnset:
+		return "unset"
+	case FileTypeCSV:
+		return fileTypeCSVName
+	case FileTypeParquet:
+		return fileTypeParquetName
+	case FileTypeORC:
+		return fileTypeORCName
+	case FileTypeJSON:
+		return fileTypeJSONName
+	default:
+		return "unknown"
+	}
+}
+
+// ParseFileType parses the on-disk spelling produced by FileType.String.
+func ParseFileType(s string) (FileType, error) {
+	switch s {
+	case fileTypeCSVName:
+		return FileTypeCSV, nil
+	case fileTypeParquetName:
+		return FileTypeParquet, nil
+	case fileTypeORCName:
+		return FileTypeORC, nil
+	case fileTypeJSONName:
+		return FileTypeJSON, nil
+	default:
+		return fileTypeUnset, fmt.Errorf("%w: %q", ErrInvalidFileType, s)
+	}
+}

--- a/go/graphar/types/filetype_test.go
+++ b/go/graphar/types/filetype_test.go
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFileTypeRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, ft := range []FileType{FileTypeCSV, FileTypeParquet, FileTypeORC, FileTypeJSON} {
+		s := ft.String()
+		got, err := ParseFileType(s)
+		if err != nil {
+			t.Errorf("ParseFileType(%q): %v", s, err)
+			continue
+		}
+		if got != ft {
+			t.Errorf("round-trip %v: got %v", ft, got)
+		}
+	}
+}
+
+func TestFileTypeIsZeroAndStringUnset(t *testing.T) {
+	t.Parallel()
+	var f FileType
+	if !f.IsZero() {
+		t.Error("zero FileType should report IsZero")
+	}
+	if got := f.String(); got != "unset" {
+		t.Errorf("zero FileType String() = %q, want unset", got)
+	}
+	if _, err := ParseFileType("unset"); err == nil {
+		t.Error("ParseFileType(\"unset\") should be rejected")
+	}
+	if FileTypeCSV.IsZero() {
+		t.Error("FileTypeCSV must not report IsZero")
+	}
+}
+
+func TestFileTypeStringUnknown(t *testing.T) {
+	t.Parallel()
+	if (FileType(0xff)).String() != "unknown" {
+		t.Errorf("unknown FileType should stringify to %q", "unknown")
+	}
+}
+
+func TestParseFileTypeErrors(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"", "CSV", "tsv", "parquette"} {
+		_, err := ParseFileType(in)
+		if err == nil {
+			t.Errorf("ParseFileType(%q) succeeded, want error", in)
+			continue
+		}
+		if !errors.Is(err, ErrInvalidFileType) {
+			t.Errorf("ParseFileType(%q) error %v not wrapped by ErrInvalidFileType", in, err)
+		}
+	}
+}

--- a/go/graphar/types/version.go
+++ b/go/graphar/types/version.go
@@ -52,17 +52,19 @@ var version2types = map[int][]string{
 	1: {"bool", "int32", "int64", "float", "double", "string"},
 }
 
-// NewInfoVersion returns an InfoVersion with the given version and user-defined
-// type names (copied defensively). A non-positive version is clamped to
-// DefaultVersion.
-func NewInfoVersion(version int, userDefinedTypes ...string) InfoVersion {
+// NewInfoVersion returns an InfoVersion for a supported schema version,
+// copying userDefinedTypes defensively.
+func NewInfoVersion(version int, userDefinedTypes ...string) (InfoVersion, error) {
 	if version <= 0 {
-		version = DefaultVersion
+		return InfoVersion{}, fmt.Errorf("%w: version must be positive, got %d", ErrInvalidVersion, version)
+	}
+	if _, ok := version2types[version]; !ok {
+		return InfoVersion{}, fmt.Errorf("%w: unsupported version %d", ErrInvalidVersion, version)
 	}
 	if len(userDefinedTypes) == 0 {
-		return InfoVersion{version: version}
+		return InfoVersion{version: version}, nil
 	}
-	return InfoVersion{version: version, userDefinedTypes: slices.Clone(userDefinedTypes)}
+	return InfoVersion{version: version, userDefinedTypes: slices.Clone(userDefinedTypes)}, nil
 }
 
 // Version returns the schema version number.
@@ -77,7 +79,7 @@ func (v InfoVersion) UserDefinedTypes() []string {
 // CheckType reports whether typeStr is a property type this version supports,
 // either a built-in type of the version or one of its user-defined types.
 func (v InfoVersion) CheckType(typeStr string) bool {
-	if slices.Contains(version2types[v.version], typeStr) {
+	if supported, ok := version2types[v.version]; ok && slices.Contains(supported, typeStr) {
 		return true
 	}
 	return slices.Contains(v.userDefinedTypes, typeStr)
@@ -105,6 +107,9 @@ func (v InfoVersion) Clone() InfoVersion {
 func (v InfoVersion) Validate() error {
 	if v.version <= 0 {
 		return fmt.Errorf("%w: version must be positive, got %d", ErrInvalidVersion, v.version)
+	}
+	if _, ok := version2types[v.version]; !ok {
+		return fmt.Errorf("%w: unsupported version %d", ErrInvalidVersion, v.version)
 	}
 	for _, name := range v.userDefinedTypes {
 		if err := validateTypeName(name); err != nil {
@@ -135,33 +140,37 @@ func (v InfoVersion) Equal(other InfoVersion) bool {
 		slices.Equal(v.userDefinedTypes, other.userDefinedTypes)
 }
 
-// ParseInfoVersion parses "gar/vN" or "gar/vN (t1,t2,...)". Parsing is lenient,
-// leaving strictness to Validate: the version is the leading digits after the
-// prefix and any trailing text is ignored, the type list is whatever sits
-// between the first '(' and the last ')' split on ',' with blank entries
-// skipped, and a '(' with no closing ')' drops the list rather than failing.
-// The tolerances match the C++ parser so both read the same on-disk strings.
+// ParseInfoVersion parses "gar/vN" or "gar/vN (t1,t2,...)".
+//
+// The version must be one the package supports. The type list is recognized
+// only when '(' follows the version number directly, with spaces allowed in
+// between; trailing text elsewhere is ignored. Entries are trimmed, blank
+// entries are skipped, and an unterminated list is dropped.
 func ParseInfoVersion(s string) (InfoVersion, error) {
-	trimmed := strings.TrimSpace(s)
-	if !strings.HasPrefix(trimmed, versionPrefix) {
+	if !strings.HasPrefix(s, versionPrefix) {
 		return InfoVersion{}, fmt.Errorf("%w: must start with %q, got %q", ErrInvalidVersion, versionPrefix, s)
 	}
-	rest := trimmed[len(versionPrefix):]
+	rest := s[len(versionPrefix):]
 
-	// Leading digits are the version number; anything after them is ignored.
 	end := 0
 	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
 		end++
 	}
-	n, err := strconv.Atoi(rest[:end])
-	if err != nil || n <= 0 {
+	if end == 0 {
 		return InfoVersion{}, fmt.Errorf("%w: bad version number in %q", ErrInvalidVersion, s)
+	}
+	n, err := strconv.Atoi(rest[:end])
+	if err != nil {
+		return InfoVersion{}, fmt.Errorf("%w: bad version number in %q", ErrInvalidVersion, s)
+	}
+	if _, ok := version2types[n]; !ok {
+		return InfoVersion{}, fmt.Errorf("%w: unsupported version %d in %q", ErrInvalidVersion, n, s)
 	}
 
 	out := InfoVersion{version: n}
-	// Optional "(t1,t2,...)": take everything between the first '(' and the last
-	// ')'. A '(' without a later ')' is ignored.
-	if lparen := strings.IndexByte(rest, '('); lparen >= 0 {
+	// "(t1,t2,...)" list: only when '(' starts right after the digits, with at
+	// most spaces in between. A '(' without a later ')' is ignored.
+	if lparen := strings.IndexByte(rest, '('); lparen >= 0 && strings.Trim(rest[end:lparen], " ") == "" {
 		if rparen := strings.LastIndexByte(rest, ')'); rparen > lparen {
 			for _, p := range strings.Split(rest[lparen+1:rparen], ",") {
 				if t := strings.TrimSpace(p); t != "" {

--- a/go/graphar/types/version.go
+++ b/go/graphar/types/version.go
@@ -1,0 +1,174 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// DefaultVersion is the version assumed for Info objects that do not specify
+// one explicitly. It is the on-disk default for the GraphAr format.
+const DefaultVersion = 1
+
+// versionPrefix is the on-disk marker every version string starts with. Shared
+// by String (write) and ParseInfoVersion (read) so the two never drift.
+const versionPrefix = "gar/v"
+
+// InfoVersion is the on-disk schema version of an Info document.
+//
+// The string form is "gar/vN" (e.g. "gar/v1"). An optional user-defined type
+// list may follow in parentheses: "gar/v1 (foo,bar)". User-defined types are
+// recorded in declaration order and duplicates are kept; surrounding
+// whitespace on each entry is trimmed on parse (so "gar/v1 (a, b)" round-trips
+// as "gar/v1 (a,b)"). The zero value is not usable; build one with
+// NewInfoVersion or ParseInfoVersion.
+type InfoVersion struct {
+	version          int
+	userDefinedTypes []string
+}
+
+// version2types lists the built-in property type names each schema version
+// supports, kept in step with the other GraphAr implementations.
+var version2types = map[int][]string{
+	1: {"bool", "int32", "int64", "float", "double", "string"},
+}
+
+// NewInfoVersion returns an InfoVersion with the given version and user-defined
+// type names (copied defensively). A non-positive version is clamped to
+// DefaultVersion.
+func NewInfoVersion(version int, userDefinedTypes ...string) InfoVersion {
+	if version <= 0 {
+		version = DefaultVersion
+	}
+	if len(userDefinedTypes) == 0 {
+		return InfoVersion{version: version}
+	}
+	return InfoVersion{version: version, userDefinedTypes: slices.Clone(userDefinedTypes)}
+}
+
+// Version returns the schema version number.
+func (v InfoVersion) Version() int { return v.version }
+
+// UserDefinedTypes returns a copy of the user-defined type names in declaration
+// order.
+func (v InfoVersion) UserDefinedTypes() []string {
+	return slices.Clone(v.userDefinedTypes)
+}
+
+// CheckType reports whether typeStr is a property type this version supports,
+// either a built-in type of the version or one of its user-defined types.
+func (v InfoVersion) CheckType(typeStr string) bool {
+	if slices.Contains(version2types[v.version], typeStr) {
+		return true
+	}
+	return slices.Contains(v.userDefinedTypes, typeStr)
+}
+
+// String returns the on-disk spelling.
+func (v InfoVersion) String() string {
+	if len(v.userDefinedTypes) == 0 {
+		return fmt.Sprintf("%s%d", versionPrefix, v.version)
+	}
+	return fmt.Sprintf("%s%d (%s)", versionPrefix, v.version, strings.Join(v.userDefinedTypes, ","))
+}
+
+// Clone returns a deep copy of v, independent of the source's user-defined type
+// slice; getters that hand out a stored InfoVersion should return v.Clone().
+func (v InfoVersion) Clone() InfoVersion {
+	if len(v.userDefinedTypes) == 0 {
+		return InfoVersion{version: v.version}
+	}
+	return InfoVersion{version: v.version, userDefinedTypes: slices.Clone(v.userDefinedTypes)}
+}
+
+// Validate reports whether v is well-formed: a positive version number and
+// user-defined type names that round-trip through String / ParseInfoVersion.
+func (v InfoVersion) Validate() error {
+	if v.version <= 0 {
+		return fmt.Errorf("%w: version must be positive, got %d", ErrInvalidVersion, v.version)
+	}
+	for _, name := range v.userDefinedTypes {
+		if err := validateTypeName(name); err != nil {
+			return fmt.Errorf("%w: %s", ErrInvalidVersion, err)
+		}
+	}
+	return nil
+}
+
+// validateTypeName reports why name cannot survive a String / ParseInfoVersion
+// round trip: it must be non-empty, carry no surrounding whitespace and avoid
+// the delimiters the version string and list syntax rely on (, ( ) < >).
+func validateTypeName(name string) error {
+	switch {
+	case name == "":
+		return errors.New("user-defined type name must not be empty")
+	case strings.TrimSpace(name) != name:
+		return fmt.Errorf("user-defined type name %q has leading or trailing whitespace", name)
+	case strings.ContainsAny(name, ",()<>"):
+		return fmt.Errorf("user-defined type name %q must not contain any of , ( ) < >", name)
+	}
+	return nil
+}
+
+// Equal reports whether two InfoVersions are equivalent.
+func (v InfoVersion) Equal(other InfoVersion) bool {
+	return v.version == other.version &&
+		slices.Equal(v.userDefinedTypes, other.userDefinedTypes)
+}
+
+// ParseInfoVersion parses "gar/vN" or "gar/vN (t1,t2,...)". Parsing is lenient,
+// leaving strictness to Validate: the version is the leading digits after the
+// prefix and any trailing text is ignored, the type list is whatever sits
+// between the first '(' and the last ')' split on ',' with blank entries
+// skipped, and a '(' with no closing ')' drops the list rather than failing.
+// The tolerances match the C++ parser so both read the same on-disk strings.
+func ParseInfoVersion(s string) (InfoVersion, error) {
+	trimmed := strings.TrimSpace(s)
+	if !strings.HasPrefix(trimmed, versionPrefix) {
+		return InfoVersion{}, fmt.Errorf("%w: must start with %q, got %q", ErrInvalidVersion, versionPrefix, s)
+	}
+	rest := trimmed[len(versionPrefix):]
+
+	// Leading digits are the version number; anything after them is ignored.
+	end := 0
+	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+		end++
+	}
+	n, err := strconv.Atoi(rest[:end])
+	if err != nil || n <= 0 {
+		return InfoVersion{}, fmt.Errorf("%w: bad version number in %q", ErrInvalidVersion, s)
+	}
+
+	out := InfoVersion{version: n}
+	// Optional "(t1,t2,...)": take everything between the first '(' and the last
+	// ')'. A '(' without a later ')' is ignored.
+	if lparen := strings.IndexByte(rest, '('); lparen >= 0 {
+		if rparen := strings.LastIndexByte(rest, ')'); rparen > lparen {
+			for _, p := range strings.Split(rest[lparen+1:rparen], ",") {
+				if t := strings.TrimSpace(p); t != "" {
+					out.userDefinedTypes = append(out.userDefinedTypes, t)
+				}
+			}
+		}
+	}
+	return out, nil
+}

--- a/go/graphar/types/version_test.go
+++ b/go/graphar/types/version_test.go
@@ -22,20 +22,38 @@ import (
 	"testing"
 )
 
+func mustNewInfoVersion(t *testing.T, version int, names ...string) InfoVersion {
+	t.Helper()
+	v, err := NewInfoVersion(version, names...)
+	if err != nil {
+		t.Fatalf("NewInfoVersion(%d, %q) = %v", version, names, err)
+	}
+	return v
+}
+
 func TestNewInfoVersion(t *testing.T) {
 	t.Parallel()
-	v := NewInfoVersion(1)
+	v, err := NewInfoVersion(1)
+	if err != nil {
+		t.Fatalf("NewInfoVersion(1): %v", err)
+	}
 	if v.Version() != 1 || len(v.UserDefinedTypes()) != 0 {
 		t.Errorf("NewInfoVersion(1) = %+v", v)
 	}
-	v2 := NewInfoVersion(2, "geometry", "point")
-	if v2.Version() != 2 || len(v2.UserDefinedTypes()) != 2 ||
+	v2, err := NewInfoVersion(1, "geometry", "point")
+	if err != nil {
+		t.Fatalf("NewInfoVersion(1, ...): %v", err)
+	}
+	if v2.Version() != 1 || len(v2.UserDefinedTypes()) != 2 ||
 		v2.UserDefinedTypes()[0] != "geometry" || v2.UserDefinedTypes()[1] != "point" {
-		t.Errorf("NewInfoVersion(2, ...) = %+v", v2)
+		t.Errorf("NewInfoVersion(1, ...) = %+v", v2)
 	}
 	// Mutating the input slice must not affect the stored value.
 	orig := []string{"geometry"}
-	v3 := NewInfoVersion(3, orig...)
+	v3, err := NewInfoVersion(1, orig...)
+	if err != nil {
+		t.Fatalf("NewInfoVersion(1, ...): %v", err)
+	}
 	orig[0] = "mutated"
 	if v3.UserDefinedTypes()[0] != "geometry" {
 		t.Errorf("UserDefinedTypes was not defensively copied")
@@ -48,15 +66,29 @@ func TestNewInfoVersion(t *testing.T) {
 	}
 }
 
+func TestNewInfoVersionRejectsUnsupportedVersions(t *testing.T) {
+	t.Parallel()
+	for _, version := range []int{0, -1, 2, 99} {
+		_, err := NewInfoVersion(version)
+		if err == nil {
+			t.Errorf("NewInfoVersion(%d) succeeded, want error", version)
+			continue
+		}
+		if !errors.Is(err, ErrInvalidVersion) {
+			t.Errorf("NewInfoVersion(%d) error %v not wrapped", version, err)
+		}
+	}
+}
+
 func TestInfoVersionString(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		v    InfoVersion
 		want string
 	}{
-		{NewInfoVersion(1), "gar/v1"},
-		{NewInfoVersion(2, "geometry"), "gar/v2 (geometry)"},
-		{NewInfoVersion(3, "geometry", "point"), "gar/v3 (geometry,point)"},
+		{mustNewInfoVersion(t, 1), "gar/v1"},
+		{mustNewInfoVersion(t, 1, "geometry"), "gar/v1 (geometry)"},
+		{mustNewInfoVersion(t, 1, "geometry", "point"), "gar/v1 (geometry,point)"},
 	}
 	for _, c := range cases {
 		if got := c.v.String(); got != c.want {
@@ -67,18 +99,19 @@ func TestInfoVersionString(t *testing.T) {
 
 func TestInfoVersionEqual(t *testing.T) {
 	t.Parallel()
-	a := NewInfoVersion(1, "g")
-	b := NewInfoVersion(1, "g")
+	a := mustNewInfoVersion(t, 1, "g")
+	b := mustNewInfoVersion(t, 1, "g")
 	if !a.Equal(b) {
 		t.Error("identical InfoVersions not equal")
 	}
-	if a.Equal(NewInfoVersion(2, "g")) {
+	// Only version 1 is supported, so build the differing version directly.
+	if a.Equal(InfoVersion{version: 2, userDefinedTypes: []string{"g"}}) {
 		t.Error("different version reported equal")
 	}
-	if a.Equal(NewInfoVersion(1)) {
+	if a.Equal(mustNewInfoVersion(t, 1)) {
 		t.Error("different type lists reported equal")
 	}
-	if a.Equal(NewInfoVersion(1, "h")) {
+	if a.Equal(mustNewInfoVersion(t, 1, "h")) {
 		t.Error("different type names reported equal")
 	}
 }
@@ -89,18 +122,21 @@ func TestParseInfoVersionOK(t *testing.T) {
 		in   string
 		want InfoVersion
 	}{
-		{"gar/v1", NewInfoVersion(1)},
-		{"  gar/v2  ", NewInfoVersion(2)},
-		{"gar/v3 (geometry)", NewInfoVersion(3, "geometry")},
-		{"gar/v4 (geometry, point)", NewInfoVersion(4, "geometry", "point")},
-		{"gar/v5(a,b,c)", NewInfoVersion(5, "a", "b", "c")},
-		// Lenient parsing: trailing text (after the number or ')') is ignored,
-		// an unterminated '(' drops the list, and blank entries are skipped.
-		{"gar/v1abc", NewInfoVersion(1)},
-		{"gar/v2 (foo)trailing", NewInfoVersion(2, "foo")},
-		{"gar/v1 (", NewInfoVersion(1)},
-		{"gar/v1 ()", NewInfoVersion(1)},
-		{"gar/v1 (a,,b)", NewInfoVersion(1, "a", "b")},
+		{"gar/v1", mustNewInfoVersion(t, 1)},
+		{"gar/v1  ", mustNewInfoVersion(t, 1)},
+		{"gar/v1 (geometry)", mustNewInfoVersion(t, 1, "geometry")},
+		{"gar/v1 (geometry, point)", mustNewInfoVersion(t, 1, "geometry", "point")},
+		{"gar/v1(a,b,c)", mustNewInfoVersion(t, 1, "a", "b", "c")},
+		// Trailing text is ignored; a list is read only when '(' directly
+		// follows the version number.
+		{"gar/v1abc", mustNewInfoVersion(t, 1)},
+		{"gar/v1 xyz", mustNewInfoVersion(t, 1)},
+		{"gar/v1 xyz(a,b)", mustNewInfoVersion(t, 1)},
+		{"gar/v1 (foo)trailing", mustNewInfoVersion(t, 1, "foo")},
+		{"gar/v1 (", mustNewInfoVersion(t, 1)},
+		{"gar/v1 (foo", mustNewInfoVersion(t, 1)},
+		{"gar/v1 ()", mustNewInfoVersion(t, 1)},
+		{"gar/v1 (a,,b)", mustNewInfoVersion(t, 1, "a", "b")},
 	}
 	for _, c := range cases {
 		got, err := ParseInfoVersion(c.in)
@@ -120,11 +156,15 @@ func TestParseInfoVersionErrors(t *testing.T) {
 		"",
 		"   ",
 		"gar/v",
-		"gar/v0",   // version must be > 0
-		"gar/v-1",  // negative
-		"gar/vabc", // not numeric
-		"foo/v1",   // wrong prefix
+		"gar/vabc",
+		"gar/v-1",
+		"gar/v99999999999999999999999999999999999999999999999999", // overflows int
+		"foo/v1",
 		"v1",
+		" gar/v1", // leading whitespace is not part of the format
+		"gar/v0",  // unsupported version
+		"gar/v2",  // unsupported version
+		"gar/v99", // unsupported version
 	}
 	for _, in := range cases {
 		_, err := ParseInfoVersion(in)
@@ -140,7 +180,7 @@ func TestParseInfoVersionErrors(t *testing.T) {
 
 func TestParseInfoVersionRoundTrip(t *testing.T) {
 	t.Parallel()
-	for _, in := range []string{"gar/v1", "gar/v2 (geometry,point)"} {
+	for _, in := range []string{"gar/v1", "gar/v1 (geometry,point)"} {
 		v, err := ParseInfoVersion(in)
 		if err != nil {
 			t.Fatalf("ParseInfoVersion(%q): %v", in, err)
@@ -158,34 +198,13 @@ func TestDefaultVersionConstant(t *testing.T) {
 	}
 }
 
-func TestNewInfoVersionNonPositiveClamps(t *testing.T) {
-	t.Parallel()
-	// NewInfoVersion must keep the result round-trippable: a 0 or negative
-	// argument is clamped to DefaultVersion so String/ParseInfoVersion are
-	// inverses on every produced value.
-	for _, v := range []int{0, -1, -1000} {
-		got := NewInfoVersion(v)
-		if got.Version() != DefaultVersion {
-			t.Errorf("NewInfoVersion(%d) = %d, want clamped to %d", v, got.Version(), DefaultVersion)
-		}
-		// Verify round-trip.
-		parsed, err := ParseInfoVersion(got.String())
-		if err != nil {
-			t.Errorf("clamped NewInfoVersion(%d) fails round-trip: %v", v, err)
-		}
-		if !parsed.Equal(got) {
-			t.Errorf("round-trip mismatch for NewInfoVersion(%d): %v vs %v", v, parsed, got)
-		}
-	}
-}
-
 // TestInfoVersionCloneIndependent guards the immutability contract: Clone must
 // return a version whose UserDefinedTypes slice is independent of the source,
 // so a value handed out by an Info's Version() getter cannot mutate stored
 // state.
 func TestInfoVersionCloneIndependent(t *testing.T) {
 	t.Parallel()
-	orig := NewInfoVersion(1, "geometry", "point")
+	orig := mustNewInfoVersion(t, 1, "geometry", "point")
 	clone := orig.Clone()
 	if !clone.Equal(orig) {
 		t.Fatalf("Clone not equal to source: %+v vs %+v", clone, orig)
@@ -195,7 +214,8 @@ func TestInfoVersionCloneIndependent(t *testing.T) {
 		t.Errorf("mutating clone leaked into source: %v", orig.userDefinedTypes)
 	}
 	// Empty case must not panic and stays independent.
-	if got := NewInfoVersion(2).Clone(); len(got.userDefinedTypes) != 0 || got.version != 2 {
+	empty := mustNewInfoVersion(t, 1)
+	if got := empty.Clone(); len(got.userDefinedTypes) != 0 || got.version != 1 {
 		t.Errorf("empty clone wrong: %+v", got)
 	}
 }
@@ -203,8 +223,8 @@ func TestInfoVersionCloneIndependent(t *testing.T) {
 func TestInfoVersionValidate(t *testing.T) {
 	t.Parallel()
 	valid := []InfoVersion{
-		NewInfoVersion(1),
-		NewInfoVersion(2, "geometry", "point"),
+		mustNewInfoVersion(t, 1),
+		mustNewInfoVersion(t, 1, "geometry", "point"),
 	}
 	for _, v := range valid {
 		if err := v.Validate(); err != nil {
@@ -218,6 +238,7 @@ func TestInfoVersionValidate(t *testing.T) {
 	}{
 		{"zero version", InfoVersion{version: 0}},
 		{"negative version", InfoVersion{version: -1}},
+		{"unsupported version", InfoVersion{version: 2}},
 		{"name with comma", InfoVersion{version: 1, userDefinedTypes: []string{"my,type"}}},
 		{"name with surrounding space", InfoVersion{version: 1, userDefinedTypes: []string{" geometry "}}},
 		{"empty name", InfoVersion{version: 1, userDefinedTypes: []string{""}}},
@@ -239,7 +260,7 @@ func TestInfoVersionCommaNameRejected(t *testing.T) {
 		t.Fatalf("Validate = %v, want ErrInvalidVersion", err)
 	}
 	// A validated (single, clean) name must survive String -> ParseInfoVersion.
-	ok := NewInfoVersion(1, "geometry")
+	ok := mustNewInfoVersion(t, 1, "geometry")
 	if err := ok.Validate(); err != nil {
 		t.Fatalf("Validate = %v, want nil", err)
 	}
@@ -251,7 +272,7 @@ func TestInfoVersionCommaNameRejected(t *testing.T) {
 
 func TestInfoVersionCheckType(t *testing.T) {
 	t.Parallel()
-	v := NewInfoVersion(1, "geometry")
+	v := mustNewInfoVersion(t, 1, "geometry")
 	cases := []struct {
 		typeStr string
 		want    bool
@@ -266,12 +287,7 @@ func TestInfoVersionCheckType(t *testing.T) {
 			t.Errorf("CheckType(%q) = %v, want %v", c.typeStr, got, c.want)
 		}
 	}
-	// A version with no built-in table still resolves its user-defined types.
-	future := NewInfoVersion(99, "geometry")
-	if future.CheckType("int32") {
-		t.Error("CheckType(int32) on a version without a built-in table should be false")
-	}
-	if !future.CheckType("geometry") {
-		t.Error("CheckType should still find a user-defined type")
+	if got := (InfoVersion{}).CheckType("int32"); got {
+		t.Error("zero InfoVersion must not report built-in types")
 	}
 }

--- a/go/graphar/types/version_test.go
+++ b/go/graphar/types/version_test.go
@@ -1,0 +1,277 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package types
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewInfoVersion(t *testing.T) {
+	t.Parallel()
+	v := NewInfoVersion(1)
+	if v.Version() != 1 || len(v.UserDefinedTypes()) != 0 {
+		t.Errorf("NewInfoVersion(1) = %+v", v)
+	}
+	v2 := NewInfoVersion(2, "geometry", "point")
+	if v2.Version() != 2 || len(v2.UserDefinedTypes()) != 2 ||
+		v2.UserDefinedTypes()[0] != "geometry" || v2.UserDefinedTypes()[1] != "point" {
+		t.Errorf("NewInfoVersion(2, ...) = %+v", v2)
+	}
+	// Mutating the input slice must not affect the stored value.
+	orig := []string{"geometry"}
+	v3 := NewInfoVersion(3, orig...)
+	orig[0] = "mutated"
+	if v3.UserDefinedTypes()[0] != "geometry" {
+		t.Errorf("UserDefinedTypes was not defensively copied")
+	}
+	// The getter must also hand back a copy, not the stored slice.
+	got := v3.UserDefinedTypes()
+	got[0] = "mutated"
+	if v3.UserDefinedTypes()[0] != "geometry" {
+		t.Errorf("UserDefinedTypes() leaked the internal slice")
+	}
+}
+
+func TestInfoVersionString(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		v    InfoVersion
+		want string
+	}{
+		{NewInfoVersion(1), "gar/v1"},
+		{NewInfoVersion(2, "geometry"), "gar/v2 (geometry)"},
+		{NewInfoVersion(3, "geometry", "point"), "gar/v3 (geometry,point)"},
+	}
+	for _, c := range cases {
+		if got := c.v.String(); got != c.want {
+			t.Errorf("String() = %q, want %q", got, c.want)
+		}
+	}
+}
+
+func TestInfoVersionEqual(t *testing.T) {
+	t.Parallel()
+	a := NewInfoVersion(1, "g")
+	b := NewInfoVersion(1, "g")
+	if !a.Equal(b) {
+		t.Error("identical InfoVersions not equal")
+	}
+	if a.Equal(NewInfoVersion(2, "g")) {
+		t.Error("different version reported equal")
+	}
+	if a.Equal(NewInfoVersion(1)) {
+		t.Error("different type lists reported equal")
+	}
+	if a.Equal(NewInfoVersion(1, "h")) {
+		t.Error("different type names reported equal")
+	}
+}
+
+func TestParseInfoVersionOK(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want InfoVersion
+	}{
+		{"gar/v1", NewInfoVersion(1)},
+		{"  gar/v2  ", NewInfoVersion(2)},
+		{"gar/v3 (geometry)", NewInfoVersion(3, "geometry")},
+		{"gar/v4 (geometry, point)", NewInfoVersion(4, "geometry", "point")},
+		{"gar/v5(a,b,c)", NewInfoVersion(5, "a", "b", "c")},
+		// Lenient parsing: trailing text (after the number or ')') is ignored,
+		// an unterminated '(' drops the list, and blank entries are skipped.
+		{"gar/v1abc", NewInfoVersion(1)},
+		{"gar/v2 (foo)trailing", NewInfoVersion(2, "foo")},
+		{"gar/v1 (", NewInfoVersion(1)},
+		{"gar/v1 ()", NewInfoVersion(1)},
+		{"gar/v1 (a,,b)", NewInfoVersion(1, "a", "b")},
+	}
+	for _, c := range cases {
+		got, err := ParseInfoVersion(c.in)
+		if err != nil {
+			t.Errorf("ParseInfoVersion(%q): %v", c.in, err)
+			continue
+		}
+		if !got.Equal(c.want) {
+			t.Errorf("ParseInfoVersion(%q) = %+v, want %+v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseInfoVersionErrors(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"",
+		"   ",
+		"gar/v",
+		"gar/v0",   // version must be > 0
+		"gar/v-1",  // negative
+		"gar/vabc", // not numeric
+		"foo/v1",   // wrong prefix
+		"v1",
+	}
+	for _, in := range cases {
+		_, err := ParseInfoVersion(in)
+		if err == nil {
+			t.Errorf("ParseInfoVersion(%q) succeeded, want error", in)
+			continue
+		}
+		if !errors.Is(err, ErrInvalidVersion) {
+			t.Errorf("ParseInfoVersion(%q) error %v not wrapped", in, err)
+		}
+	}
+}
+
+func TestParseInfoVersionRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"gar/v1", "gar/v2 (geometry,point)"} {
+		v, err := ParseInfoVersion(in)
+		if err != nil {
+			t.Fatalf("ParseInfoVersion(%q): %v", in, err)
+		}
+		if v.String() != in {
+			t.Errorf("round-trip failed: ParseInfoVersion(%q).String() = %q", in, v.String())
+		}
+	}
+}
+
+func TestDefaultVersionConstant(t *testing.T) {
+	t.Parallel()
+	if DefaultVersion != 1 {
+		t.Errorf("DefaultVersion changed to %d; cross-language fixtures still ship gar/v1", DefaultVersion)
+	}
+}
+
+func TestNewInfoVersionNonPositiveClamps(t *testing.T) {
+	t.Parallel()
+	// NewInfoVersion must keep the result round-trippable: a 0 or negative
+	// argument is clamped to DefaultVersion so String/ParseInfoVersion are
+	// inverses on every produced value.
+	for _, v := range []int{0, -1, -1000} {
+		got := NewInfoVersion(v)
+		if got.Version() != DefaultVersion {
+			t.Errorf("NewInfoVersion(%d) = %d, want clamped to %d", v, got.Version(), DefaultVersion)
+		}
+		// Verify round-trip.
+		parsed, err := ParseInfoVersion(got.String())
+		if err != nil {
+			t.Errorf("clamped NewInfoVersion(%d) fails round-trip: %v", v, err)
+		}
+		if !parsed.Equal(got) {
+			t.Errorf("round-trip mismatch for NewInfoVersion(%d): %v vs %v", v, parsed, got)
+		}
+	}
+}
+
+// TestInfoVersionCloneIndependent guards the immutability contract: Clone must
+// return a version whose UserDefinedTypes slice is independent of the source,
+// so a value handed out by an Info's Version() getter cannot mutate stored
+// state.
+func TestInfoVersionCloneIndependent(t *testing.T) {
+	t.Parallel()
+	orig := NewInfoVersion(1, "geometry", "point")
+	clone := orig.Clone()
+	if !clone.Equal(orig) {
+		t.Fatalf("Clone not equal to source: %+v vs %+v", clone, orig)
+	}
+	clone.userDefinedTypes[0] = "hacked"
+	if orig.userDefinedTypes[0] != "geometry" {
+		t.Errorf("mutating clone leaked into source: %v", orig.userDefinedTypes)
+	}
+	// Empty case must not panic and stays independent.
+	if got := NewInfoVersion(2).Clone(); len(got.userDefinedTypes) != 0 || got.version != 2 {
+		t.Errorf("empty clone wrong: %+v", got)
+	}
+}
+
+func TestInfoVersionValidate(t *testing.T) {
+	t.Parallel()
+	valid := []InfoVersion{
+		NewInfoVersion(1),
+		NewInfoVersion(2, "geometry", "point"),
+	}
+	for _, v := range valid {
+		if err := v.Validate(); err != nil {
+			t.Errorf("Validate(%q) = %v, want nil", v, err)
+		}
+	}
+
+	invalid := []struct {
+		name string
+		v    InfoVersion
+	}{
+		{"zero version", InfoVersion{version: 0}},
+		{"negative version", InfoVersion{version: -1}},
+		{"name with comma", InfoVersion{version: 1, userDefinedTypes: []string{"my,type"}}},
+		{"name with surrounding space", InfoVersion{version: 1, userDefinedTypes: []string{" geometry "}}},
+		{"empty name", InfoVersion{version: 1, userDefinedTypes: []string{""}}},
+	}
+	for _, c := range invalid {
+		if err := c.v.Validate(); !errors.Is(err, ErrInvalidVersion) {
+			t.Errorf("Validate(%s) = %v, want ErrInvalidVersion", c.name, err)
+		}
+	}
+}
+
+// TestInfoVersionCommaNameRejected pins the round-trip hazard: a name with a
+// comma would split into two on ParseInfoVersion, so Validate must reject it
+// before it reaches String.
+func TestInfoVersionCommaNameRejected(t *testing.T) {
+	t.Parallel()
+	v := InfoVersion{version: 1, userDefinedTypes: []string{"a,b"}}
+	if err := v.Validate(); !errors.Is(err, ErrInvalidVersion) {
+		t.Fatalf("Validate = %v, want ErrInvalidVersion", err)
+	}
+	// A validated (single, clean) name must survive String -> ParseInfoVersion.
+	ok := NewInfoVersion(1, "geometry")
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("Validate = %v, want nil", err)
+	}
+	back, err := ParseInfoVersion(ok.String())
+	if err != nil || !back.Equal(ok) {
+		t.Errorf("round-trip %q -> %+v (err %v)", ok.String(), back, err)
+	}
+}
+
+func TestInfoVersionCheckType(t *testing.T) {
+	t.Parallel()
+	v := NewInfoVersion(1, "geometry")
+	cases := []struct {
+		typeStr string
+		want    bool
+	}{
+		{"int32", true},    // built-in type of v1
+		{"string", true},   // built-in type of v1
+		{"geometry", true}, // user-defined type
+		{"point", false},   // neither built-in nor user-defined
+	}
+	for _, c := range cases {
+		if got := v.CheckType(c.typeStr); got != c.want {
+			t.Errorf("CheckType(%q) = %v, want %v", c.typeStr, got, c.want)
+		}
+	}
+	// A version with no built-in table still resolves its user-defined types.
+	future := NewInfoVersion(99, "geometry")
+	if future.CheckType("int32") {
+		t.Error("CheckType(int32) on a version without a built-in table should be false")
+	}
+	if !future.CheckType("geometry") {
+		t.Error("CheckType should still find a user-defined type")
+	}
+}


### PR DESCRIPTION
### Reason for this PR

Part of the pure-Go GraphAr SDK (tracking issus #828), following the bootstrap PR #937.
This is the foundational `types` package: the primitive value enums every higher
layer (info, reader/writer) depends on. Kept separate from `DataType` (next PR) so
each PR stays a single, reviewable module. The diff is a bit over the usual size,
but about half is table-driven tests and the four enums are one cohesive,
dependency-free unit; splitting them further would fragment the value layer.

### What changes are included in this PR?

New package `go/graphar/types` with four on-disk value types plus their string
parse/serialize and sentinel errors:

- `FileType` — csv / parquet / orc / json
- `Cardinality` — single / list / set
- `AdjListType` — unordered/ordered × by_source/by_dest, with helpers to convert
  to/from the legacy `(ordered, aligned_by)` form (`src`/`dst`)

Enum members and on-disk spellings match the C++ and Java SDKs (verified
member-by-member); Rust and Python are FFI/bindings over C++. No Arrow or
third-party dependency.

### Are these changes tested?

Yes. Table-driven unit tests cover round-trips, error paths, defensive copying,
and the lenient/strict version-string cases.

### Are there any user-facing changes?

Yes — this adds the public `types` package. No breaking changes (new code only).