### PR TITLE
[Java] Align pure-Java edge metadata with GraphAr layout

### DIFF
--- a/docs/libraries/java/architecture.md
+++ b/docs/libraries/java/architecture.md
@@ -1,0 +1,79 @@
+---
+id: java-architecture
+title: Pure-Java SDK Architecture
+sidebar_position: 3
+---
+
+# Pure-Java GraphAr SDK architecture
+
+The legacy `maven-projects/java` FastFFI binding is deprecated. The pure-Java
+SDK extends the existing `graphar-info` metadata module without copying the
+C++ runtime or its dependency graph. C++ and Spark are format-semantic
+oracles, not Java API templates.
+
+## Design rules
+
+1. `graphar-info` stays dependency-light: no Parquet, Hadoop, Arrow, or
+   object-store dependency.
+2. GraphAr layout/path resolution sits above physical file IO.
+3. Physical readers receive projection, row-range, predicate, and limit hints;
+   declined capabilities must be explicit and preserve results.
+4. The graph API is not a query engine. Graph algorithms, Gremlin execution,
+   and application caches stay outside SDK core.
+5. IDs, counts, chunk indexes, and offsets are `long` values throughout.
+6. Every supported capability has a cross-language fixture.
+
+## Module boundaries
+
+| Module | Responsibility | Must not depend on |
+| --- | --- | --- |
+| `graphar-info` | YAML metadata, schema, types, versions | storage and physical IO |
+| `graphar-storage-api` | input/output files, seekable streams, capabilities | Parquet and GraphAr layout |
+| `graphar-storage-local` | local-URI storage implementation | reader/writer |
+| `graphar-io-api` | neutral batches and IO requests | GraphAr metadata semantics |
+| `graphar-io-parquet` | Parquet projection/range/predicate execution | graph-facing API |
+| `graphar-core` | chunk math and layout resolution | Parquet/Hadoop/Arrow |
+| `graphar-reader` | vertex, property, adjacency, and bulk reads | writer/query engine |
+| `graphar-writer` | chunking, offsets, properties, metadata publish | reader cache/query engine |
+| `graphar-api` | stable graph-facing facade | physical backend implementation |
+
+Hadoop, S3, Spark, TinkerPop, and Iceberg are adapters. They must not become
+transitive requirements of `graphar-core` or `graphar-info`.
+
+## Reader flow
+
+```text
+GraphInfo + EdgeInfo + requested adjacency layout
+  -> GraphAr layout resolver
+  -> offset chunk and [start, end) edge range
+  -> ReadRequest(uri, projection, range, predicate, limit)
+  -> physical backend
+  -> cursor or primitive batch
+```
+
+The first reader vertical supports Parquet and `ordered_by_source`. It exposes
+two distinct operations: `neighbors(vertexId)` resolves a small offset range;
+`scanEdges()` streams source/destination batches. A `limit` is pushed down as
+a hint rather than materializing a whole high-degree adjacency list in Java.
+
+## Writer flow
+
+```text
+logical records -> ID assignment -> chunk partition -> layout ordering
+-> offsets/property groups -> physical files -> validation -> metadata publish
+```
+
+Writers publish only after staged files validate and metadata is finalized.
+This is a publish protocol, not a claim of distributed ACID transactions.
+
+## First-release non-goals
+
+* FastFFI/JNI and a C++ runtime.
+* Custom Parquet or mandatory Arrow.
+* General query AST, SQL/Gremlin engine, or graph algorithms.
+* ORC/CSV, unordered layouts, cloud storage, and Iceberg in the first reader
+  vertical.
+
+The GraphAr specification is normative. C++ acts as an executable oracle for
+ambiguous path, chunk, and offset behavior; Java compatibility fixtures make
+each interpretation observable.

--- a/docs/libraries/java/compatibility.md
+++ b/docs/libraries/java/compatibility.md
@@ -1,0 +1,54 @@
+---
+id: java-compatibility
+title: Pure-Java Compatibility Contract
+sidebar_position: 5
+---
+
+# Pure-Java GraphAr compatibility contract
+
+Java compatibility means that Java, C++, and Spark preserve the same GraphAr
+meaning. It does not require matching object models or runtime dependencies.
+
+## Release 0.1 target matrix
+
+| Capability | Java | C++ | Spark | Gate |
+| --- | --- | --- | --- | --- |
+| Graph metadata load/save | target | reference | reference | semantic YAML round trip |
+| Vertex metadata/property groups | target | reference | reference | labels, paths, types, nullability |
+| Edge metadata/layouts | target | reference | reference | triplets and chunk semantics |
+| Parquet vertices/properties | target | reference | reference | projected fixture read/write |
+| `ordered_by_source` | target | reference | reference | offset range and neighbors |
+| `ordered_by_dest` | after 0.1 core | reference | reference | incoming neighbors |
+| Unordered layouts | deferred | reference | reference | 0.2 gate |
+| Local storage | target | reference | reference | file URI fixture |
+| Hadoop/S3 storage | deferred | reference | reference | adapter integration test |
+
+`target` becomes a release promise only when a corresponding fixture and gate
+exist. Unsupported layouts and types fail fast; they are not emulated through a
+different physical layout.
+
+## Initial compatibility slice
+
+Before adding a physical reader, `graphar-info` must agree with C++ on suffixes
+for vertex property/count, edge vertex/edge counts, offset chunks, topology
+chunks, and edge property chunks. Tests use the Parquet fixture under
+`testing/ldbc_sample/parquet`, not self-derived URI expectations.
+
+The slice also covers relative and absolute paths, prefixes without a trailing
+slash, all four adjacency declarations, empty partitions, and a nonzero
+`part{vertexChunk}/chunk{edgeChunk}` pair.
+
+## Golden datasets and tests
+
+The suite grows from canonical datasets: `empty`, `boundary-chunks`,
+`properties`, `nulls`, `multi-property-group`, ordered/unordered source and
+destination, and `high-degree`.
+
+Test levels are unit (math/path), format (external fixture), round trip, local
+backend integration, and performance. The first reader vertical proves both
+`neighbors(vertexId)` and sequential `scanEdges()`; passing after reading all
+edge data does not establish the random-read contract.
+
+Before release, tests verify no metadata loss, no nullability/row-alignment
+loss, equal neighbor sets and ranges, `long`-safe counts/offsets, and external
+reader acceptance of Java writer output.

--- a/docs/libraries/java/format-invariants.md
+++ b/docs/libraries/java/format-invariants.md
@@ -1,0 +1,81 @@
+---
+id: java-format-invariants
+title: Pure-Java Format Invariants
+sidebar_position: 4
+---
+
+# Pure-Java GraphAr format invariants
+
+This is the implementation contract for the Java SDK. It supplements the
+[GraphAr format specification](/docs/specification/format).
+
+## Metadata and identity
+
+* A graph is `graph.yml` plus referenced vertex and edge metadata. References
+  resolve relative to the graph metadata URI.
+* Vertex types use labels; edge types use the `(source, edge, destination)`
+  triplet.
+* Load/save preserves prefixes, file types, chunk sizes, versions, nullability,
+  property types, labels, and extra metadata.
+* GraphAr format version and Java SDK version are independent.
+
+## IDs and chunks
+
+* Internal vertex IDs are non-negative, zero-based `long` values.
+* A vertex chunk index is `vertexId / vertexChunkSize`; local position is
+  `vertexId % vertexChunkSize`.
+* Edge data is first partitioned by source or destination vertex chunk, then
+  divided into edge chunks. Chunk counts round up; final chunks may be partial.
+* Source-oriented layouts use `src_chunk_size`; destination-oriented layouts
+  use `dst_chunk_size`.
+* Range endpoints are half-open: `[begin, end)`.
+
+## Layouts and offsets
+
+| Layout | Partition key | Ordering | Offset table |
+| --- | --- | --- | --- |
+| `ordered_by_source` | source ID | source ordered | required |
+| `ordered_by_dest` | destination ID | destination ordered | required |
+| `unordered_by_source` | source ID | unordered | absent |
+| `unordered_by_dest` | destination ID | unordered | absent |
+
+For every ordered vertex partition of size `V`, its offset chunk has `V + 1`
+`INT64` values. It begins at zero; values are non-negative and monotonic; the
+range of local vertex `i` is `[offset[i], offset[i + 1])`; the final value
+equals that partition's edge count. Ordered-source and ordered-destination are
+storage-level CSR-like and CSC-like layouts respectively, not a promise of one
+fully materialized JVM array.
+
+## Canonical relative paths
+
+The C++ `VertexInfo` and `EdgeInfo` methods are the executable oracle. Physical
+file names have no extension; metadata `file_type` selects the decoder.
+
+```text
+vertex property: {vertex.prefix}/{property.prefix}/chunk{vertexChunk}
+vertex count:    {vertex.prefix}/vertex_count
+
+edge vertex count: {edge.prefix}/{adj.prefix}/vertex_count
+edge count:        {edge.prefix}/{adj.prefix}/edge_count{vertexChunk}
+adjacency:         {edge.prefix}/{adj.prefix}/adj_list/part{vertexChunk}/chunk{edgeChunk}
+offset:            {edge.prefix}/{adj.prefix}/offset/chunk{vertexChunk}
+edge property:     {edge.prefix}/{adj.prefix}/{property.prefix}/part{vertexChunk}/chunk{edgeChunk}
+```
+
+No Java API may omit adjacency type, vertex chunk index, or edge chunk index
+when resolving edge topology/property chunks. Path joining normalizes separators
+and handles a dataset root plus relative or absolute overrides; raw
+`URI.resolve` with an unchecked non-trailing-slash base is insufficient.
+
+## Properties and validation
+
+* Property-group rows align with their vertex or edge rows.
+* Nulls are preserved; Java defaults must not replace physical nulls.
+* Unsupported property types fail before returning a partial result.
+* Primary properties are never nullable.
+* Validation checks referenced files, counts, offset semantics, ID bounds,
+  ordered layout order, row alignment, schemas, and supported format/file type.
+
+Every invariant gets a fixture under `testing/`. A Java writer is accepted only
+after both `C++/Spark write -> Java read` and `Java write -> C++/Spark read`
+work for the declared capability.

--- a/docs/libraries/java/java.md
+++ b/docs/libraries/java/java.md
@@ -17,3 +17,10 @@ This version is implemented using FastFFI to bridge Java and C++ code. While fun
 This is the next generation of the GraphAr Java library, being actively developed to provide a pure Java implementation without native dependencies.
 
 Currently, only the `graphar-info` module has been implemented in pure Java, which provides the ability to parse graph info (schema). Additional modules such as IO and high level API will be provided progressively.
+
+The implementation initiative is governed by these documents:
+
+- [Architecture](./architecture.md)
+- [Format invariants](./format-invariants.md)
+- [Compatibility contract](./compatibility.md)
+- [Roadmap](./roadmap.md)

--- a/docs/libraries/java/roadmap.md
+++ b/docs/libraries/java/roadmap.md
@@ -1,0 +1,59 @@
+---
+id: java-roadmap
+title: Pure-Java SDK Roadmap
+sidebar_position: 6
+---
+
+# Pure-Java GraphAr SDK roadmap
+
+## Delivery model
+
+The product fork moves independently of upstream review. Commits remain small,
+tested, and layered so reusable parts can be proposed upstream. Repository work
+does not post external issues, discussions, or pull requests without explicit
+authorization.
+
+## Milestones
+
+| Phase | Deliverable | Exit evidence |
+| --- | --- | --- |
+| 0 | architecture, invariants, compatibility, roadmap | these pages checked against local spec/C++ |
+| 1 | `graphar-info` URI/type/metadata parity fixtures and fixes | C++ suffix parity, C++ -> Java -> C++ metadata round trip |
+| 2 | storage API and local implementation | core has no physical-format dependency |
+| 3 | IO request/capability API and Parquet backend | projection/range tests report used capabilities |
+| 4 | ordered-source reader | graph.yml -> offsets -> Parquet -> `neighbors` and `scanEdges` |
+| 5 | writer and validator vertical | Java write <-> C++/Spark read gates |
+| 6 | remaining layouts and adapters | expanded matrix and benchmarks |
+
+## First code slice
+
+The first upstreamable PR fixes the existing Java metadata contract before new
+modules exist:
+
+1. Add C++-equivalent edge URI methods for counts, offsets, adjacency, and
+   edge properties.
+2. Require `(adjacency type, vertex chunk, edge chunk)` for topology/property
+   chunks.
+3. Replace incompatible Java URI expectations with C++/fixture parity tests.
+4. Add a nonzero `part/chunk` and no-trailing-slash path test.
+
+Only then does the first reader vertical begin:
+
+```text
+GraphAr v1 metadata + local storage + Parquet + ordered_by_source
+  -> offset range -> destination projection -> neighbors(vertexId)
+  -> sequential src/dst scanEdges()
+```
+
+## Upstream sequence
+
+1. Compatibility fixtures and focused `graphar-info` fixes.
+2. IO-neutral storage interfaces and local storage.
+3. IO request/capability API.
+4. Parquet projection reader.
+5. Chunk/layout resolution, offsets, adjacency, reader facade.
+6. Writer, validator, remaining layouts, and adapters.
+
+The design proposal for the existing Java architecture discussion is prepared
+but not sent automatically. It asks maintainers to confirm module boundaries,
+IO separation, Parquet as the first backend, and deferred query AST.

--- a/maven-projects/info/src/main/java/org/apache/graphar/info/EdgeInfo.java
+++ b/maven-projects/info/src/main/java/org/apache/graphar/info/EdgeInfo.java
@@ -462,38 +462,62 @@ public class EdgeInfo {
         return propertyGroups.getPropertyGroup(property);
     }
 
-    public URI getPropertyGroupUri(PropertyGroup propertyGroup) {
+    public URI getPropertyGroupUri(PropertyGroup propertyGroup, AdjListType adjListType) {
         checkPropertyGroupExist(propertyGroup);
-        return getBaseUri().resolve(propertyGroup.getBaseUri());
+        return resolvePath(getAdjacentListBaseUri(adjListType), propertyGroup.getPrefix());
     }
 
-    public URI getPropertyGroupChunkUri(PropertyGroup propertyGroup, long chunkIndex) {
-        // PropertyGroup will be checked in getPropertyGroupPrefix
-        return getPropertyGroupUri(propertyGroup).resolve("chunk" + chunkIndex);
+    public URI getPropertyGroupChunkUri(
+            PropertyGroup propertyGroup,
+            AdjListType adjListType,
+            long vertexChunkIndex,
+            long edgeChunkIndex) {
+        return resolvePath(
+                getPropertyGroupUri(propertyGroup, adjListType),
+                "part" + vertexChunkIndex + "/chunk" + edgeChunkIndex);
     }
 
     public URI getAdjacentListUri(AdjListType adjListType) {
-        return getBaseUri().resolve(getAdjacentList(adjListType).getBaseUri()).resolve("adj_list/");
+        return resolvePath(getAdjacentListBaseUri(adjListType), "adj_list/");
     }
 
-    public URI getAdjacentListChunkUri(AdjListType adjListType, long vertexChunkIndex) {
-        return getAdjacentListUri(adjListType).resolve("chunk" + vertexChunkIndex);
+    public URI getAdjacentListChunkUri(
+            AdjListType adjListType, long vertexChunkIndex, long edgeChunkIndex) {
+        return resolvePath(
+                getAdjacentListUri(adjListType),
+                "part" + vertexChunkIndex + "/chunk" + edgeChunkIndex);
     }
 
     public URI getOffsetUri(AdjListType adjListType) {
-        return getAdjacentListUri(adjListType).resolve("offset/");
+        return resolvePath(getAdjacentListBaseUri(adjListType), "offset/");
     }
 
     public URI getOffsetChunkUri(AdjListType adjListType, long vertexChunkIndex) {
-        return getOffsetUri(adjListType).resolve("chunk" + vertexChunkIndex);
+        return resolvePath(getOffsetUri(adjListType), "chunk" + vertexChunkIndex);
     }
 
     public URI getVerticesNumFileUri(AdjListType adjListType) {
-        return getAdjacentListUri(adjListType).resolve("vertex_count");
+        return resolvePath(getAdjacentListBaseUri(adjListType), "vertex_count");
     }
 
     public URI getEdgesNumFileUri(AdjListType adjListType, long vertexChunkIndex) {
-        return getAdjacentListUri(adjListType).resolve("edge_count" + vertexChunkIndex);
+        return resolvePath(getAdjacentListBaseUri(adjListType), "edge_count" + vertexChunkIndex);
+    }
+
+    private URI getAdjacentListBaseUri(AdjListType adjListType) {
+        return resolvePath(getBaseUri(), getAdjacentList(adjListType).getPrefix());
+    }
+
+    private static URI resolvePath(URI baseUri, String childPath) {
+        String base = baseUri.toString();
+        String child = childPath;
+        if (!base.endsWith("/")) {
+            base += "/";
+        }
+        while (child.startsWith("/")) {
+            child = child.substring(1);
+        }
+        return URI.create(base + child);
     }
 
     public void dump(Writer output) {

--- a/maven-projects/info/src/test/java/org/apache/graphar/info/GraphInfoTest.java
+++ b/maven-projects/info/src/test/java/org/apache/graphar/info/GraphInfoTest.java
@@ -21,6 +21,8 @@ package org.apache.graphar.info;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -306,31 +308,31 @@ public class GraphInfoTest {
         Assert.assertEquals("ordered_by_source/", adjOrderBySource.getPrefix());
         Assert.assertEquals(URI.create("ordered_by_source/"), adjOrderBySource.getBaseUri());
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_source/adj_list/vertex_count"),
+                URI.create("edge/person_knows_person/ordered_by_source/vertex_count"),
                 knowsEdgeInfo.getVerticesNumFileUri(AdjListType.ordered_by_source));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_source/adj_list/edge_count0"),
+                URI.create("edge/person_knows_person/ordered_by_source/edge_count0"),
                 knowsEdgeInfo.getEdgesNumFileUri(AdjListType.ordered_by_source, 0));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_source/adj_list/edge_count4"),
+                URI.create("edge/person_knows_person/ordered_by_source/edge_count4"),
                 knowsEdgeInfo.getEdgesNumFileUri(AdjListType.ordered_by_source, 4));
         Assert.assertEquals(
                 URI.create("edge/person_knows_person/ordered_by_source/adj_list/"),
                 knowsEdgeInfo.getAdjacentListUri(AdjListType.ordered_by_source));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_source/adj_list/chunk0"),
-                knowsEdgeInfo.getAdjacentListChunkUri(AdjListType.ordered_by_source, 0));
+                URI.create("edge/person_knows_person/ordered_by_source/adj_list/part0/chunk0"),
+                knowsEdgeInfo.getAdjacentListChunkUri(AdjListType.ordered_by_source, 0, 0));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_source/adj_list/chunk4"),
-                knowsEdgeInfo.getAdjacentListChunkUri(AdjListType.ordered_by_source, 4));
+                URI.create("edge/person_knows_person/ordered_by_source/adj_list/part4/chunk2"),
+                knowsEdgeInfo.getAdjacentListChunkUri(AdjListType.ordered_by_source, 4, 2));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_source/adj_list/offset/"),
+                URI.create("edge/person_knows_person/ordered_by_source/offset/"),
                 knowsEdgeInfo.getOffsetUri(AdjListType.ordered_by_source));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_source/adj_list/offset/chunk0"),
+                URI.create("edge/person_knows_person/ordered_by_source/offset/chunk0"),
                 knowsEdgeInfo.getOffsetChunkUri(AdjListType.ordered_by_source, 0));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_source/adj_list/offset/chunk4"),
+                URI.create("edge/person_knows_person/ordered_by_source/offset/chunk4"),
                 knowsEdgeInfo.getOffsetChunkUri(AdjListType.ordered_by_source, 4));
 
         // test ordered by destination adjacency list
@@ -341,31 +343,31 @@ public class GraphInfoTest {
         Assert.assertEquals("ordered_by_dest/", adjOrderByDestination.getPrefix());
         Assert.assertEquals(URI.create("ordered_by_dest/"), adjOrderByDestination.getBaseUri());
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_dest/adj_list/vertex_count"),
+                URI.create("edge/person_knows_person/ordered_by_dest/vertex_count"),
                 knowsEdgeInfo.getVerticesNumFileUri(AdjListType.ordered_by_dest));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_dest/adj_list/edge_count0"),
+                URI.create("edge/person_knows_person/ordered_by_dest/edge_count0"),
                 knowsEdgeInfo.getEdgesNumFileUri(AdjListType.ordered_by_dest, 0));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_dest/adj_list/edge_count4"),
+                URI.create("edge/person_knows_person/ordered_by_dest/edge_count4"),
                 knowsEdgeInfo.getEdgesNumFileUri(AdjListType.ordered_by_dest, 4));
         Assert.assertEquals(
                 URI.create("edge/person_knows_person/ordered_by_dest/adj_list/"),
                 knowsEdgeInfo.getAdjacentListUri(AdjListType.ordered_by_dest));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_dest/adj_list/chunk0"),
-                knowsEdgeInfo.getAdjacentListChunkUri(AdjListType.ordered_by_dest, 0));
+                URI.create("edge/person_knows_person/ordered_by_dest/adj_list/part0/chunk0"),
+                knowsEdgeInfo.getAdjacentListChunkUri(AdjListType.ordered_by_dest, 0, 0));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_dest/adj_list/chunk4"),
-                knowsEdgeInfo.getAdjacentListChunkUri(AdjListType.ordered_by_dest, 4));
+                URI.create("edge/person_knows_person/ordered_by_dest/adj_list/part4/chunk2"),
+                knowsEdgeInfo.getAdjacentListChunkUri(AdjListType.ordered_by_dest, 4, 2));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_dest/adj_list/offset/"),
+                URI.create("edge/person_knows_person/ordered_by_dest/offset/"),
                 knowsEdgeInfo.getOffsetUri(AdjListType.ordered_by_dest));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_dest/adj_list/offset/chunk0"),
+                URI.create("edge/person_knows_person/ordered_by_dest/offset/chunk0"),
                 knowsEdgeInfo.getOffsetChunkUri(AdjListType.ordered_by_dest, 0));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_dest/adj_list/offset/chunk4"),
+                URI.create("edge/person_knows_person/ordered_by_dest/offset/chunk4"),
                 knowsEdgeInfo.getOffsetChunkUri(AdjListType.ordered_by_dest, 4));
     }
 
@@ -377,7 +379,9 @@ public class GraphInfoTest {
         IllegalArgumentException illegalArgumentException =
                 Assert.assertThrows(
                         IllegalArgumentException.class,
-                        () -> knowsEdgeInfo.getPropertyGroupUri(notExistPg));
+                        () ->
+                                knowsEdgeInfo.getPropertyGroupUri(
+                                        notExistPg, AdjListType.ordered_by_source));
         Assert.assertEquals(
                 "Property group "
                         + notExistPg
@@ -399,14 +403,16 @@ public class GraphInfoTest {
         Assert.assertEquals(URI.create("creationDate/"), propertyGroup.getBaseUri());
         Assert.assertEquals(FileType.CSV, propertyGroup.getFileType());
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/creationDate/"),
-                knowsEdgeInfo.getPropertyGroupUri(propertyGroup));
+                URI.create("edge/person_knows_person/ordered_by_source/creationDate/"),
+                knowsEdgeInfo.getPropertyGroupUri(propertyGroup, AdjListType.ordered_by_source));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/creationDate/chunk0"),
-                knowsEdgeInfo.getPropertyGroupChunkUri(propertyGroup, 0));
+                URI.create("edge/person_knows_person/ordered_by_source/creationDate/part0/chunk0"),
+                knowsEdgeInfo.getPropertyGroupChunkUri(
+                        propertyGroup, AdjListType.ordered_by_source, 0, 0));
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/creationDate/chunk4"),
-                knowsEdgeInfo.getPropertyGroupChunkUri(propertyGroup, 4));
+                URI.create("edge/person_knows_person/ordered_by_dest/creationDate/part4/chunk2"),
+                knowsEdgeInfo.getPropertyGroupChunkUri(
+                        propertyGroup, AdjListType.ordered_by_dest, 4, 2));
         // edge properties in group 1
         Assert.assertNotNull(propertyGroup.getPropertyList());
         Assert.assertEquals(1, propertyGroup.getPropertyList().size());
@@ -546,7 +552,32 @@ public class GraphInfoTest {
         Assert.assertEquals(AdjListType.ordered_by_source, adjOrderBySource.getType());
         Assert.assertEquals("ordered_by_source/", adjOrderBySource.getPrefix());
         Assert.assertEquals(
-                URI.create("edge/person_knows_person/ordered_by_source/adj_list/offset/"),
+                URI.create("edge/person_knows_person/ordered_by_source/offset/"),
                 knowsEdgeInfo.getOffsetUri(AdjListType.ordered_by_source));
+
+        URI adjacencyChunkUri =
+                knowsEdgeInfo.getAdjacentListChunkUri(AdjListType.ordered_by_source, 2, 1);
+        URI propertyChunkUri =
+                knowsEdgeInfo.getPropertyGroupChunkUri(
+                        creationDate, AdjListType.ordered_by_source, 2, 1);
+        URI edgeCountUri = knowsEdgeInfo.getEdgesNumFileUri(AdjListType.ordered_by_source, 2);
+
+        Assert.assertEquals(
+                URI.create("edge/person_knows_person/ordered_by_source/adj_list/part2/chunk1"),
+                adjacencyChunkUri);
+        Assert.assertEquals(
+                URI.create("edge/person_knows_person/ordered_by_source/creationDate/part2/chunk1"),
+                propertyChunkUri);
+        Assert.assertEquals(
+                URI.create("edge/person_knows_person/ordered_by_source/edge_count2"), edgeCountUri);
+        Assert.assertTrue(
+                Files.isRegularFile(
+                        Paths.get(graphInfo.getBaseUri().resolve(adjacencyChunkUri).getPath())));
+        Assert.assertTrue(
+                Files.isRegularFile(
+                        Paths.get(graphInfo.getBaseUri().resolve(propertyChunkUri).getPath())));
+        Assert.assertTrue(
+                Files.isRegularFile(
+                        Paths.get(graphInfo.getBaseUri().resolve(edgeCountUri).getPath())));
     }
 }

--- a/maven-projects/info/src/test/java/org/apache/graphar/info/GraphInfoUriTest.java
+++ b/maven-projects/info/src/test/java/org/apache/graphar/info/GraphInfoUriTest.java
@@ -20,6 +20,10 @@
 package org.apache.graphar.info;
 
 import java.net.URI;
+import java.util.List;
+import org.apache.graphar.info.type.AdjListType;
+import org.apache.graphar.info.type.DataType;
+import org.apache.graphar.info.type.FileType;
 import org.apache.graphar.info.yaml.VertexYaml;
 import org.junit.Assert;
 import org.junit.Test;
@@ -91,5 +95,42 @@ public class GraphInfoUriTest {
         Assert.assertEquals(
                 URI.create("file:///tmp/vertex/person/firstName_lastName_gender/chunk0"),
                 vertexInfo.getPropertyGroupChunkUri(vertexInfo.getPropertyGroups().get(1), 0));
+    }
+
+    @Test
+    public void testEdgePathsNormalizePrefixesWithoutTrailingSlashes() {
+        PropertyGroup propertyGroup =
+                new PropertyGroup(
+                        List.of(new Property("created", DataType.STRING, false, false)),
+                        FileType.PARQUET,
+                        "created");
+        EdgeInfo edgeInfo =
+                new EdgeInfo(
+                        "person",
+                        "knows",
+                        "person",
+                        1024,
+                        100,
+                        100,
+                        false,
+                        "edge/person_knows_person",
+                        "gar/v1",
+                        List.of(
+                                new AdjacentList(
+                                        AdjListType.ordered_by_source,
+                                        FileType.PARQUET,
+                                        "ordered_by_source")),
+                        List.of(propertyGroup));
+
+        Assert.assertEquals(
+                URI.create("edge/person_knows_person/ordered_by_source/edge_count2"),
+                edgeInfo.getEdgesNumFileUri(AdjListType.ordered_by_source, 2));
+        Assert.assertEquals(
+                URI.create("edge/person_knows_person/ordered_by_source/adj_list/part2/chunk1"),
+                edgeInfo.getAdjacentListChunkUri(AdjListType.ordered_by_source, 2, 1));
+        Assert.assertEquals(
+                URI.create("edge/person_knows_person/ordered_by_source/created/part2/chunk1"),
+                edgeInfo.getPropertyGroupChunkUri(
+                        propertyGroup, AdjListType.ordered_by_source, 2, 1));
     }
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,4 @@
+# Lessons
+
+- Treat newly mentioned workspace files as in-scope task inputs. Do not label an unreviewed untracked file as unrelated work; inspect it before reporting its scope.
+- When the user authorizes plan execution and GitHub access, continue with the highest-priority ready slice and create the needed GitHub issues, pull requests, and comments without announcing a proposed next step or waiting for approval.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,34 @@
+# Java library index
+
+- [x] Confirm the actively developed pure-Java module and exclude the deprecated FFI module.
+- [x] Rebuild the AST index for the repository and verify its Java symbol coverage.
+- [x] Record the resulting module map and verification evidence.
+
+## Review
+
+Indexed `/Users/alex/IdeaProjects/incubator-graphar/maven-projects/info` as a standalone project: 47 files, 870 symbols, 6,216 references, and one Maven module. Verified outline and references for `GraphInfo`, plus implementations of the loader and saver interfaces. The FastFFI module at `maven-projects/java` was not included in this focused index.
+
+# Development environment and verification
+
+- [x] Inspect the devcontainer definition and start its development environment.
+- [x] Build the focused `graphar-info` pure-Java module in the devcontainer.
+- [x] Run the focused module's Maven test suite and record results.
+
+## Review
+
+The published devcontainer image `ghcr.io/apache/graphar-dev:latest` is cached locally and was verified as Linux/arm64 with OpenJDK 11.0.24 and Maven 3.6.3. The required `testing` submodule was initialized. Inside this image, `mvn --no-transfer-progress clean verify -Dspotless.check.skip=true` completed successfully in 3m38s: 123 tests passed with 0 failures, errors, and skips; the binary JAR, Javadoc JAR, and JaCoCo XML were produced. `spotless:check` and `javadoc:javadoc` also passed in a JDK 11 Maven container; Javadoc emitted two missing-tag warnings in `VersionInfo.checkType`.
+
+# Pure-Java SDK bootstrap
+
+- [x] Phase 0: publish the architecture, compatibility contract, format invariants, and delivery roadmap.
+- [x] Phase 1a: restore C++-compatible edge path resolution in `graphar-info` and replace self-referential URI tests with fixture parity checks.
+- [ ] Phase 1b: add cross-language metadata fixtures and close remaining verified `graphar-info` gaps.
+- [ ] Phase 2: introduce dependency-light storage and physical-IO APIs with local storage.
+- [ ] Phase 3: implement the Parquet projection/range backend.
+- [ ] Phase 4: implement the ordered-by-source reader vertical: layout, offsets, adjacency, `neighbors`, and `scanEdges`.
+- [ ] Phase 5: implement the writer, validator, remaining layouts, and integrations in independently releasable slices.
+- [ ] Prepare—but do not externally post—the #756/design-discussion proposal and upstream PR sequence.
+
+## Review
+
+Phase 0 documents live under `docs/libraries/java/` and are linked from the Java library overview. Phase 1a makes `EdgeInfo` C++-compatible: counts and offsets resolve below the adjacency prefix, topology resolves as `adj_list/part{vertexChunk}/chunk{edgeChunk}`, and edge properties resolve below the selected adjacency layout with the same tuple. The test suite proves these suffixes against the real Parquet fixture, including `part2/chunk1`, and covers prefixes without trailing slashes. The resulting `mvn clean verify` in the devcontainer passed 124 tests with zero failures, errors, or skips.


### PR DESCRIPTION
## Summary

- document the staged pure-Java SDK architecture, format invariants, compatibility contract, and roadmap
- make `EdgeInfo` resolve count, offset, topology, and property paths with the GraphAr C++ layout
- require adjacency type, vertex chunk, and edge chunk for topology and edge-property chunks
- verify generated suffixes against the real Parquet LDBC fixture, including `part2/chunk1`

## Verification

- `mvn --no-transfer-progress clean verify -Dspotless.check.skip=true` in `ghcr.io/apache/graphar-dev:latest`
- 124 tests, 0 failures, 0 errors, 0 skipped

Relates to #756.
