### PR TITLE
feat(java): let the storage API reach the local filesystem

### DIFF
--- a/maven-projects/pom.xml
+++ b/maven-projects/pom.xml
@@ -79,6 +79,7 @@
         <module>spark</module>
         <module>info</module>
         <module>storage-api</module>
+        <module>storage-local</module>
     </modules>
 
     <build>

--- a/maven-projects/storage-local/pom.xml
+++ b/maven-projects/storage-local/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.graphar</groupId>
+        <artifactId>graphar-root</artifactId>
+        <version>${graphar.version}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>graphar-storage-local</artifactId>
+    <packaging>jar</packaging>
+    <version>${graphar.version}</version>
+
+    <name>graphar-storage-local</name>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.graphar</groupId>
+            <artifactId>graphar-storage-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless-maven-plugin.version}</version>
+                <configuration>
+                    <java>
+                        <googleJavaFormat>
+                            <version>1.7</version>
+                            <style>AOSP</style>
+                        </googleJavaFormat>
+                    </java>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/maven-projects/storage-local/src/main/java/org/apache/graphar/storage/local/LocalInputFile.java
+++ b/maven-projects/storage-local/src/main/java/org/apache/graphar/storage/local/LocalInputFile.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.graphar.storage.local;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.graphar.storage.InputFile;
+import org.apache.graphar.storage.SeekableInput;
+
+final class LocalInputFile implements InputFile {
+    private final Path path;
+
+    LocalInputFile(Path path) {
+        this.path = path;
+    }
+
+    @Override
+    public URI uri() {
+        return path.toUri();
+    }
+
+    @Override
+    public long size() throws IOException {
+        return Files.size(path);
+    }
+
+    @Override
+    public SeekableInput open() throws IOException {
+        return new LocalSeekableInput(path);
+    }
+}

--- a/maven-projects/storage-local/src/main/java/org/apache/graphar/storage/local/LocalOutputFile.java
+++ b/maven-projects/storage-local/src/main/java/org/apache/graphar/storage/local/LocalOutputFile.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.graphar.storage.local;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import org.apache.graphar.storage.OutputFile;
+import org.apache.graphar.storage.PositionOutput;
+
+final class LocalOutputFile implements OutputFile {
+    private final Path path;
+
+    LocalOutputFile(Path path) {
+        this.path = path;
+    }
+
+    @Override
+    public URI uri() {
+        return path.toUri();
+    }
+
+    @Override
+    public PositionOutput create() throws IOException {
+        createParentDirectories();
+        return new LocalPositionOutput(
+                Files.newOutputStream(
+                        path, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE));
+    }
+
+    @Override
+    public PositionOutput createOrOverwrite() throws IOException {
+        createParentDirectories();
+        return new LocalPositionOutput(
+                Files.newOutputStream(
+                        path,
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.TRUNCATE_EXISTING,
+                        StandardOpenOption.WRITE));
+    }
+
+    private void createParentDirectories() throws IOException {
+        Path parent = path.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+    }
+}

--- a/maven-projects/storage-local/src/main/java/org/apache/graphar/storage/local/LocalPositionOutput.java
+++ b/maven-projects/storage-local/src/main/java/org/apache/graphar/storage/local/LocalPositionOutput.java
@@ -29,6 +29,7 @@ final class LocalPositionOutput implements PositionOutput {
 
     private final OutputStream output;
     private long position;
+    private byte[] transfer;
 
     LocalPositionOutput(OutputStream output) {
         this.output = output;
@@ -48,11 +49,13 @@ final class LocalPositionOutput implements PositionOutput {
             return;
         }
 
-        byte[] buffer = new byte[Math.min(source.remaining(), BUFFER_SIZE)];
+        if (transfer == null) {
+            transfer = new byte[BUFFER_SIZE];
+        }
         while (source.hasRemaining()) {
-            int length = Math.min(source.remaining(), buffer.length);
-            source.get(buffer, 0, length);
-            write(buffer, 0, length);
+            int length = Math.min(source.remaining(), transfer.length);
+            source.get(transfer, 0, length);
+            write(transfer, 0, length);
         }
     }
 

--- a/maven-projects/storage-local/src/main/java/org/apache/graphar/storage/local/LocalPositionOutput.java
+++ b/maven-projects/storage-local/src/main/java/org/apache/graphar/storage/local/LocalPositionOutput.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.graphar.storage.local;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import org.apache.graphar.storage.PositionOutput;
+
+final class LocalPositionOutput implements PositionOutput {
+    private static final int BUFFER_SIZE = 8192;
+
+    private final OutputStream output;
+    private long position;
+
+    LocalPositionOutput(OutputStream output) {
+        this.output = output;
+    }
+
+    @Override
+    public long position() {
+        return position;
+    }
+
+    @Override
+    public void write(ByteBuffer source) throws IOException {
+        if (source.hasArray()) {
+            int length = source.remaining();
+            write(source.array(), source.arrayOffset() + source.position(), length);
+            source.position(source.position() + length);
+            return;
+        }
+
+        byte[] buffer = new byte[Math.min(source.remaining(), BUFFER_SIZE)];
+        while (source.hasRemaining()) {
+            int length = Math.min(source.remaining(), buffer.length);
+            source.get(buffer, 0, length);
+            write(buffer, 0, length);
+        }
+    }
+
+    @Override
+    public void write(byte[] source, int offset, int length) throws IOException {
+        output.write(source, offset, length);
+        position += length;
+    }
+
+    @Override
+    public void flush() throws IOException {
+        output.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        output.close();
+    }
+}

--- a/maven-projects/storage-local/src/main/java/org/apache/graphar/storage/local/LocalSeekableInput.java
+++ b/maven-projects/storage-local/src/main/java/org/apache/graphar/storage/local/LocalSeekableInput.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.graphar.storage.local;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import org.apache.graphar.storage.SeekableInput;
+
+final class LocalSeekableInput implements SeekableInput {
+    private final FileChannel channel;
+
+    LocalSeekableInput(Path path) throws IOException {
+        this.channel = FileChannel.open(path, StandardOpenOption.READ);
+    }
+
+    @Override
+    public long position() throws IOException {
+        return channel.position();
+    }
+
+    @Override
+    public void seek(long newPosition) throws IOException {
+        if (newPosition < 0) {
+            throw new IllegalArgumentException("Seek position cannot be negative: " + newPosition);
+        }
+        channel.position(newPosition);
+    }
+
+    @Override
+    public int read(ByteBuffer destination) throws IOException {
+        return channel.read(destination);
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+    }
+}

--- a/maven-projects/storage-local/src/main/java/org/apache/graphar/storage/local/LocalStorage.java
+++ b/maven-projects/storage-local/src/main/java/org/apache/graphar/storage/local/LocalStorage.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.graphar.storage.local;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.graphar.storage.InputFile;
+import org.apache.graphar.storage.OutputFile;
+import org.apache.graphar.storage.Storage;
+
+/** Storage backed by the local filesystem. */
+public final class LocalStorage implements Storage {
+    @Override
+    public InputFile inputFile(URI uri) {
+        return new LocalInputFile(toPath(uri));
+    }
+
+    @Override
+    public OutputFile outputFile(URI uri) {
+        return new LocalOutputFile(toPath(uri));
+    }
+
+    @Override
+    public boolean exists(URI uri) throws IOException {
+        return Files.exists(toPath(uri));
+    }
+
+    private static Path toPath(URI uri) {
+        if (uri == null) {
+            throw new IllegalArgumentException("Storage URI cannot be null.");
+        }
+        if (!"file".equalsIgnoreCase(uri.getScheme())) {
+            throw new IllegalArgumentException("LocalStorage only supports file URIs: " + uri);
+        }
+        return Path.of(uri);
+    }
+}

--- a/maven-projects/storage-local/src/test/java/org/apache/graphar/storage/local/LocalStorageTest.java
+++ b/maven-projects/storage-local/src/test/java/org/apache/graphar/storage/local/LocalStorageTest.java
@@ -126,4 +126,24 @@ public class LocalStorageTest {
             assertThrows(IOException.class, () -> input.readFully(ByteBuffer.allocate(2)));
         }
     }
+
+    @Test
+    public void writesADirectBufferLargerThanOneTransferChunk() throws IOException {
+        Path path = temporaryFolder.getRoot().toPath().resolve("large.bin");
+        byte[] expected = new byte[20_000];
+        for (int index = 0; index < expected.length; index++) {
+            expected[index] = (byte) index;
+        }
+        ByteBuffer direct = ByteBuffer.allocateDirect(expected.length);
+        direct.put(expected);
+        direct.flip();
+
+        try (PositionOutput output = storage.outputFile(path.toUri()).create()) {
+            output.write(direct);
+            assertEquals(expected.length, output.position());
+        }
+
+        assertFalse(direct.hasRemaining());
+        assertArrayEquals(expected, Files.readAllBytes(path));
+    }
 }

--- a/maven-projects/storage-local/src/test/java/org/apache/graphar/storage/local/LocalStorageTest.java
+++ b/maven-projects/storage-local/src/test/java/org/apache/graphar/storage/local/LocalStorageTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.graphar.storage.local;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.graphar.storage.InputFile;
+import org.apache.graphar.storage.OutputFile;
+import org.apache.graphar.storage.PositionOutput;
+import org.apache.graphar.storage.SeekableInput;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class LocalStorageTest {
+    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private final LocalStorage storage = new LocalStorage();
+
+    @Test
+    public void writesReadsAndSeeksAcrossNestedFile() throws IOException {
+        Path path = temporaryFolder.getRoot().toPath().resolve("nested/data.bin");
+        OutputFile outputFile = storage.outputFile(path.toUri());
+        assertFalse(storage.exists(path.toUri()));
+
+        try (PositionOutput output = outputFile.create()) {
+            output.write("ab".getBytes(UTF_8));
+            ByteBuffer direct = ByteBuffer.allocateDirect(2);
+            direct.put("cd".getBytes(UTF_8));
+            direct.flip();
+            output.write(direct);
+            ByteBuffer heap = ByteBuffer.wrap("00efgh".getBytes(UTF_8));
+            heap.position(2);
+            heap.limit(6);
+            ByteBuffer slicedHeap = heap.slice();
+            slicedHeap.position(1);
+            slicedHeap.limit(3);
+            output.write(slicedHeap);
+            output.flush();
+            assertEquals(6, output.position());
+            assertEquals(2, direct.position());
+            assertEquals(3, slicedHeap.position());
+        }
+
+        assertTrue(storage.exists(path.toUri()));
+        InputFile inputFile = storage.inputFile(path.toUri());
+        assertEquals(path.toUri(), inputFile.uri());
+        assertEquals(6, inputFile.size());
+        try (SeekableInput input = inputFile.open()) {
+            ByteBuffer allBytes = ByteBuffer.allocate(6);
+            input.readFully(allBytes);
+            assertEquals(6, input.position());
+            assertArrayEquals("abcdfg".getBytes(UTF_8), allBytes.array());
+
+            input.seek(1);
+            ByteBuffer suffix = ByteBuffer.allocate(2);
+            input.readFully(suffix);
+            assertArrayEquals("bc".getBytes(UTF_8), suffix.array());
+            assertEquals(3, input.position());
+        }
+    }
+
+    @Test
+    public void createDoesNotOverwriteAndCreateOrOverwriteTruncates() throws IOException {
+        Path path = temporaryFolder.newFile("existing.bin").toPath();
+        Files.write(path, "old".getBytes(UTF_8));
+        OutputFile outputFile = storage.outputFile(path.toUri());
+
+        assertThrows(IOException.class, outputFile::create);
+        assertArrayEquals("old".getBytes(UTF_8), Files.readAllBytes(path));
+
+        try (PositionOutput output = outputFile.createOrOverwrite()) {
+            output.write("new".getBytes(UTF_8));
+        }
+        assertArrayEquals("new".getBytes(UTF_8), Files.readAllBytes(path));
+    }
+
+    @Test
+    public void rejectsNonFileUrisAndNegativeSeekPositions() throws IOException {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> storage.inputFile(URI.create("s3://bucket/a")));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> storage.inputFile(URI.create("relative/path")));
+
+        Path path = temporaryFolder.newFile("data.bin").toPath();
+        try (SeekableInput input = storage.inputFile(path.toUri()).open()) {
+            assertThrows(IllegalArgumentException.class, () -> input.seek(-1));
+        }
+    }
+
+    @Test
+    public void readFullyFailsWhenTheFileIsShorterThanTheDestination() throws IOException {
+        Path path = temporaryFolder.newFile("short.bin").toPath();
+        Files.write(path, "x".getBytes(UTF_8));
+
+        try (SeekableInput input = storage.inputFile(path.toUri()).open()) {
+            assertThrows(IOException.class, () -> input.readFully(ByteBuffer.allocate(2)));
+        }
+    }
+}


### PR DESCRIPTION
### Reason for this PR

Closes the remaining half of #953. The storage API merged in #958 defines
`Storage`, `InputFile`, `OutputFile`, `SeekableInput`, and `PositionOutput`,
but no implementation ships with it, so nothing in the Java tree can open a
GraphAr file yet. Every later layer of #947 (physical IO, Parquet backend,
reader, writer) needs at least one working adapter to be testable.

### What changes are included in this PR?

A local filesystem adapter in a new `graphar-storage-local` module:

- `LocalStorage` resolves a `file:` URI (and a bare path) to a `java.nio.Path`
  and hands back input and output files.
- `LocalSeekableInput` reads at an absolute position and reports the end of the
  stream instead of a short buffer.
- `LocalOutputFile` / `LocalPositionOutput` create parent directories on demand,
  refuse an existing target unless the caller asked to replace it, and report
  the number of bytes written so far.

The module depends only on `graphar-storage-api`. It carries no GraphAr layout,
format, projection, or query concern, per the boundary agreed in #953.

### Are these changes tested?

Yes. `LocalStorageTest` covers the round trip, positional reads, end-of-stream
behaviour, directory creation, and the refusal to overwrite an existing target.

```
mvn --no-transfer-progress -pl storage-local -am clean verify
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

### Are there any user-facing changes?

A new module and package `org.apache.graphar.storage.local`. Nothing existing
changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `make cpplint` before submitting when changed files are in the `cpp` directory.
- [x] I have performed `pre-commit run` before commit the changed files.
- [x] I have added tests to prove my changes are effective.
