### PR TITLE
ci(java): compile and test the pure-Java SDK modules

### DIFF
--- a/.github/workflows/java-sdk.yml
+++ b/.github/workflows/java-sdk.yml
@@ -55,9 +55,17 @@ jobs:
     env:
       SDK_MODULES: storage-api
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true
+
+      - name: Cache Maven repository
+        uses: actions/cache@v6
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-sdk-${{ hashFiles('maven-projects/**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-sdk-
 
       - name: Code Format Check
         working-directory: maven-projects

--- a/.github/workflows/java-sdk.yml
+++ b/.github/workflows/java-sdk.yml
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: GraphAr Java SDK CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'maven-projects/pom.xml'
+      - 'maven-projects/storage-api/**'
+      - 'maven-projects/storage-local/**'
+      - 'maven-projects/io-api/**'
+      - 'maven-projects/io-parquet/**'
+      - 'maven-projects/core/**'
+      - 'maven-projects/reader/**'
+      - 'maven-projects/writer/**'
+      - '.github/workflows/java-sdk.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'maven-projects/pom.xml'
+      - 'maven-projects/storage-api/**'
+      - 'maven-projects/storage-local/**'
+      - 'maven-projects/io-api/**'
+      - 'maven-projects/io-parquet/**'
+      - 'maven-projects/core/**'
+      - 'maven-projects/reader/**'
+      - 'maven-projects/writer/**'
+      - '.github/workflows/java-sdk.yml'
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      SDK_MODULES: storage-api
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Code Format Check
+        working-directory: maven-projects
+        run: |
+          export JAVA_HOME=${JAVA_HOME_11_X64}
+          mvn --no-transfer-progress -pl ${SDK_MODULES} -am spotless:check
+
+      - name: Build and run tests
+        working-directory: maven-projects
+        run: |
+          export JAVA_HOME=${JAVA_HOME_11_X64}
+          mvn --no-transfer-progress -pl ${SDK_MODULES} -am clean verify -Dspotless.check.skip=true
+
+      - name: Build Java Docs
+        working-directory: maven-projects
+        run: |
+          export JAVA_HOME=${JAVA_HOME_11_X64}
+          mvn --no-transfer-progress -pl ${SDK_MODULES} -am javadoc:javadoc


### PR DESCRIPTION
### Reason for this PR

No workflow compiles `maven-projects/storage-api`. `java.yml` is filtered to
`maven-projects/java/**` and `java-info.yml` to `maven-projects/info/**`, so a
change to the storage API merged in #958 reaches `main` having passed only the
license, pre-commit, and PR-title checks. Nothing proves it builds or that its
tests pass.

That gap widens with every module planned under #947 (physical IO, Parquet
backend, chunk layout, reader, writer): each would land with green checks that
never invoked `javac`.

### What changes are included in this PR?

A `GraphAr Java SDK CI` workflow that, for the pure-Java SDK reactor, runs:

- `mvn -pl ${SDK_MODULES} -am spotless:check`
- `mvn -pl ${SDK_MODULES} -am clean verify -Dspotless.check.skip=true`
- `mvn -pl ${SDK_MODULES} -am javadoc:javadoc`

The selected module list is a single `SDK_MODULES` environment variable, today
`storage-api`. Each new module extends that one line in the PR that introduces
it, which keeps the addition visible to a reviewer.

The reactor is selected by inclusion rather than by excluding `java` and
`spark`: those two aggregators enumerate their submodules inside profile-scoped
`<modules>` lists, so `-pl '!java,!spark'` still pulls `graphar-datasources`
into the reactor and fails on the Scala compile.

Path filters cover the SDK module directories and `maven-projects/pom.xml`.

### Are these changes tested?

Yes, by running the workflow's exact three commands against this branch:

```
mvn --no-transfer-progress -pl storage-api -am spotless:check
BUILD SUCCESS

mvn --no-transfer-progress -pl storage-api -am clean verify -Dspotless.check.skip=true
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

mvn --no-transfer-progress -pl storage-api -am javadoc:javadoc
BUILD SUCCESS
```

The workflow's own path filter includes `.github/workflows/java-sdk.yml`, so it
also runs on this pull request.

### Are there any user-facing changes?

No. CI only.

Note: no module in the selected reactor declares the JaCoCo plugin yet, so this
workflow uploads no coverage report. Adding JaCoCo per module is left to the
PRs that introduce those modules.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have formatted my own code using `make cpplint` before submitting when changed files are in the `cpp` directory.
- [x] I have performed `pre-commit run` before commit the changed files.
- [x] I have added tests to prove my changes are effective.
